### PR TITLE
feat(web): branding genérico configurable en lugar de TC2005B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 - El Docusaurus se sirve ahora en `/docs/...` en lugar de `/docs/docs/...`
   (`routeBasePath: '/'`). Las páginas registradas en BD y los enlaces de los
   labs se migraron al nuevo esquema.
+- Branding genérico configurable: el nombre y subtítulo de la app
+  (antes "TC2005B" / "Construcción de Software y Toma de Decisiones") ahora
+  salen de `packages/web/src/config/app.ts` (`APP_NAME`, `APP_TAGLINE`) y se
+  usan en login, navbar, home, sidebar, título del navegador y export XLSX.
 
 ### Deprecated
 - Se elimina el despliegue por **GitHub Pages**. El sitio se despliega en un

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>TC2005B | Construcción de Software y Toma de Decisiones</title>
+    <title>Grupos | Plataforma académica</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Grupos | Plataforma académica</title>
+    <!-- Fallback pre-hidratación; el título autoritativo lo fija App.tsx desde config/app.ts -->
+    <title>Grupos</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router';
 import Layout from './components/layout/Layout';
 import CalendarPage from './components/calendar/CalendarPage';
@@ -25,8 +26,15 @@ import AlumnoCalendarioPage from './components/dashboard/pages/AlumnoCalendarioP
 import AlumnoCompetenciasPage from './components/dashboard/pages/AlumnoCompetenciasPage/AlumnoCompetenciasPage';
 import PaginaPage from './components/paginas/PaginaPage';
 import PaginasPage from './components/dashboard/pages/PaginasPage/PaginasPage';
+import { APP_NAME, APP_TAGLINE } from './config/app';
 
 export default function App() {
+  // Título del navegador como fuente única de verdad (el <title> de index.html
+  // es solo un fallback pre-hidratación).
+  useEffect(() => {
+    document.title = `${APP_NAME} | ${APP_TAGLINE}`;
+  }, []);
+
   return (
     <Routes>
       <Route element={<Layout />}>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -6,6 +6,7 @@ import { getSidebarItems, getGrupoDetailItems } from './sidebarConfig';
 import styles from './Sidebar.module.css';
 import type { DashboardRole } from '../../../../types/dashboard';
 import { useAuth } from '../../../../context/AuthContext';
+import { APP_NAME } from '../../../../config/app';
 
 interface SidebarProps {
   role: DashboardRole;
@@ -84,7 +85,7 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
           <div className={styles.logo}>
             <Link to={role === 'admin' ? '/admin' : '/alumno'} className={styles.logoLink}>
               <Icon name="school" size="lg" />
-              {!collapsed && <span className={styles.logoText}>TC2005B</span>}
+              {!collapsed && <span className={styles.logoText}>{APP_NAME}</span>}
             </Link>
           </div>
         )}

--- a/packages/web/src/components/dashboard/pages/LoginPage/LoginPage.tsx
+++ b/packages/web/src/components/dashboard/pages/LoginPage/LoginPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router';
 import styles from './LoginPage.module.css';
 import Icon from '../../atoms/Icon/Icon';
 import LoginForm from '../../organisms/LoginForm/LoginForm';
+import { APP_NAME, APP_TAGLINE } from '../../../../config/app';
 
 export default function LoginPage() {
   return (
@@ -11,8 +12,8 @@ export default function LoginPage() {
           <div className={styles.logoWrap}>
             <Icon name="school" size="lg" />
           </div>
-          <h1 className={styles.title}>TC2005B</h1>
-          <p className={styles.subtitle}>Construcción de Software y Toma de Decisiones</p>
+          <h1 className={styles.title}>{APP_NAME}</h1>
+          <p className={styles.subtitle}>{APP_TAGLINE}</p>
         </div>
 
         <LoginForm />

--- a/packages/web/src/components/home/HomePage.tsx
+++ b/packages/web/src/components/home/HomePage.tsx
@@ -1,13 +1,14 @@
 import { Link } from 'react-router';
 import styles from './HomePage.module.css';
+import { APP_NAME, APP_TAGLINE } from '../../config/app';
 
 export default function HomePage() {
   return (
     <div className={styles.home}>
       <section className={styles.hero}>
-        <h1 className={styles.heroTitle}>TC2005B</h1>
+        <h1 className={styles.heroTitle}>{APP_NAME}</h1>
         <p className={styles.heroSubtitle}>
-          Construcción de Software y Toma de Decisiones
+          {APP_TAGLINE}
         </p>
         <p className={styles.heroMeta}>
           Tecnológico de Monterrey &mdash; Campus Querétaro

--- a/packages/web/src/components/layout/Navbar.tsx
+++ b/packages/web/src/components/layout/Navbar.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 import styles from './Navbar.module.css';
+import { APP_NAME, APP_TAGLINE } from '../../config/app';
 
 const AGENDA_ENTREVISTAS_URL =
   'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462';
@@ -8,10 +9,10 @@ export default function Navbar() {
   return (
     <nav className={styles.topBar}>
       <Link to="/" className={styles.brand}>
-        TC2005B
+        {APP_NAME}
       </Link>
       <span className={styles.subtitle}>
-        Construcción de Software y Toma de Decisiones
+        {APP_TAGLINE}
       </span>
       <div className={styles.navLinks}>
         <a

--- a/packages/web/src/config/app.ts
+++ b/packages/web/src/config/app.ts
@@ -2,8 +2,9 @@
  * Identidad/branding del sistema.
  *
  * Fuente única de verdad para el nombre y subtítulo mostrados en la UI
- * (login, navbar, home, título del navegador, metadata de exportaciones).
- * Cambiar aquí para rebrandear todo el sistema.
+ * (login, navbar, home, sidebar, título del navegador vía App.tsx, y metadata
+ * de exportaciones). El <title> estático de index.html es solo un fallback
+ * pre-hidratación. Cambiar aquí para rebrandear todo el sistema.
  */
 export const APP_NAME = 'Grupos';
 export const APP_TAGLINE = 'Plataforma académica';

--- a/packages/web/src/config/app.ts
+++ b/packages/web/src/config/app.ts
@@ -1,0 +1,9 @@
+/**
+ * Identidad/branding del sistema.
+ *
+ * Fuente única de verdad para el nombre y subtítulo mostrados en la UI
+ * (login, navbar, home, título del navegador, metadata de exportaciones).
+ * Cambiar aquí para rebrandear todo el sistema.
+ */
+export const APP_NAME = 'Grupos';
+export const APP_TAGLINE = 'Plataforma académica';

--- a/packages/web/src/utils/mallaExport.ts
+++ b/packages/web/src/utils/mallaExport.ts
@@ -7,6 +7,7 @@
  * import dinámico para no engordar el bundle principal.
  */
 import type * as ExcelJS from 'exceljs';
+import { APP_NAME } from '../config/app';
 
 const API_BASE = '/api';
 
@@ -581,7 +582,7 @@ export async function buildMallaWorkbook(input: MallaExportInput): Promise<Array
   const mod: any = await import('exceljs');
   const ExcelJSLib = mod.default ?? mod;
   const wb: ExcelJS.Workbook = new ExcelJSLib.Workbook();
-  wb.creator = 'TC2005B';
+  wb.creator = APP_NAME;
   wb.created = new Date();
 
   buildActividadesSheet(wb, input);


### PR DESCRIPTION
## Descripción

Primera US de la conversión a sistema genérico: reemplaza el branding específico
del curso (**TC2005B** / *Construcción de Software y Toma de Decisiones*) por un
branding genérico y **configurable desde un solo lugar**.

- Nuevo `packages/web/src/config/app.ts` como fuente única de verdad:
  `APP_NAME = 'Grupos'`, `APP_TAGLINE = 'Plataforma académica'`.
- Se consume la constante en: LoginPage, Navbar, HomePage y Sidebar del dashboard.
- `index.html` `<title>` y `creator` del export XLSX actualizados.
- El correo del login se mantiene sin cambios (a petición): "correo institucional"
  y placeholder actual.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `cd packages/web && npx tsc --noEmit` sin errores
- [x] `yarn workspace @tc2005b/web build` OK
- Verificado que no queda branding hardcodeado en `components/`, `index.html` ni `utils/`.

## Checklist

- [x] La rama sigue Conventional Branch (`feature/branding-generico`)
- [x] Los commits siguen Conventional Commits
- [ ] Actualicé `CHANGELOG.md` (pendiente: ver comentario del review)
- [x] No hay commits directos a `main`; entra vía PR

## Notas

- `packages/web/src/data/calendario/calendario-grupo2.ts` aún referencia el curso,
  pero es **data** de un grupo específico, no branding global — fuera de alcance de esta US.
- En HomePage se mantiene "Tecnológico de Monterrey — Campus Querétaro"; si quieren
  full-genérico, lo movemos a config en otra US.