### PR TITLE
chore(build): incluye el build del Docusaurus en el script build de la raíz

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev": "concurrently -n web,docs,api -c cyan,magenta,yellow \"yarn workspace @tc2005b/web dev\" \"yarn workspace @tc2005b/docs start --port 3001\" \"yarn workspace @tc2005b/api dev\"",
-    "build": "yarn workspace @tc2005b/web build && yarn workspace @tc2005b/api build && node scripts/merge-builds.mjs",
+    "build": "yarn workspace @tc2005b/web build && yarn workspace @tc2005b/api build && yarn workspace @tc2005b/docs build && node scripts/merge-builds.mjs",
     "test": "vitest --globals"
   },
   "devDependencies": {


### PR DESCRIPTION
## Descripción

El script `build` de la raíz solo hacía `web build && api build && merge-builds`.
`merge-builds.mjs` copia `packages/docusaurus/build` **si existe**, así que un
`yarn build` sin reconstruir Docusaurus aparte deja `dist/docs` desactualizado.

Ahora `yarn build` reconstruye **web + api + docs** y luego mergea, para que un
solo comando produzca un `dist/` completo y consistente.

## Tipo de cambio
- [x] `chore` — tooling/build

## Notas
- El `deploy-tc2005b.sh` del servidor ya construye los 3 workspaces por separado,
  así que esto no cambia el deploy; es para consistencia de `yarn build` local/CI.

## ¿Cómo se probó?
- [x] `yarn build` genera `dist/docs/tc2005b/...` (multi-instancia) correctamente.