### PR TITLE
fix(api): invalida el cache del gate al cambiar materias/asignaciones/enrollment

### DIFF
--- a/packages/api/src/controllers/alumnos.controller.ts
+++ b/packages/api/src/controllers/alumnos.controller.ts
@@ -10,6 +10,7 @@ import {
   findGrupoAlumnoLink,
   createGrupoAlumnoLink,
 } from '../services/grupo-alumno.service.js';
+import { invalidateAllowedCache } from '../services/materia.service.js';
 
 export async function listAlumnos(req: Request, res: Response): Promise<void> {
   const { grupoId } = req.params;
@@ -72,6 +73,7 @@ export async function createAlumno(req: Request, res: Response): Promise<void> {
       } else {
         await createGrupoAlumnoLink(existing, grupoPointer);
       }
+      invalidateAllowedCache(existing.id);
 
       res.status(201).json({
         status: 'ok',
@@ -94,6 +96,7 @@ export async function createAlumno(req: Request, res: Response): Promise<void> {
 
     await alumno.save(null, { useMasterKey: true });
     await createGrupoAlumnoLink(alumno, grupoPointer);
+    invalidateAllowedCache(alumno.id);
 
     res.status(201).json({
       status: 'ok',
@@ -145,6 +148,7 @@ export async function archiveAlumno(req: Request, res: Response): Promise<void> 
       link.activate();
     }
     await link.save(null, { useMasterKey: true });
+    invalidateAllowedCache(alumnoId);
 
     // Fetch alumno for response
     const alumnoQuery = new Parse.Query<AppUser>('AppUser');
@@ -172,6 +176,7 @@ export async function deleteAlumno(req: Request, res: Response): Promise<void> {
 
     link.softDelete();
     await link.save(null, { useMasterKey: true });
+    invalidateAllowedCache(alumnoId);
 
     res.json({ status: 'ok', message: 'Alumno eliminado del grupo' });
   } catch (error: any) {
@@ -272,6 +277,9 @@ export async function importAlumnosCSV(req: Request, res: Response): Promise<voi
       imported.push(i);
       credentials.push({ email, name: alumnoName, password });
     }
+
+    // Enrollment masivo: invalidar todo el cache de permisos una vez.
+    if (imported.length > 0) invalidateAllowedCache();
 
     res.json({
       status: 'ok',

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { Grupo } from '../models/Grupo.js';
+import { invalidateAllowedCache } from '../services/materia.service.js';
 
 export async function listGrupos(_req: Request, res: Response): Promise<void> {
   try {
@@ -83,6 +84,8 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
     }
 
     await grupo.save(null, { useMasterKey: true });
+    // Si cambió la materia del grupo, el acceso de sus alumnos cambió.
+    if (materiaId !== undefined) invalidateAllowedCache();
 
     res.json({ status: 'ok', grupo: grupo.toSafeJSON() });
   } catch (error: any) {

--- a/packages/api/src/controllers/materias.controller.ts
+++ b/packages/api/src/controllers/materias.controller.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { Materia } from '../models/Materia.js';
+import { invalidateMateriaSlugsCache, invalidateAllowedCache } from '../services/materia.service.js';
 
 const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -58,6 +59,9 @@ export async function createMateria(req: Request, res: Response): Promise<void> 
     if (codigoCanonico) materia.setCodigo(codigoCanonico);
 
     await materia.save(null, { useMasterKey: true });
+    // El conjunto de slugs cambió → invalidar cache del gate.
+    invalidateMateriaSlugsCache();
+    invalidateAllowedCache();
 
     res.status(201).json({ status: 'ok', materia: materia.toSafeJSON() });
   } catch (error) {
@@ -116,6 +120,9 @@ export async function updateMateria(req: Request, res: Response): Promise<void> 
     }
 
     await materia.save(null, { useMasterKey: true });
+    // slug/nombre pudieron cambiar → invalidar cache del gate.
+    invalidateMateriaSlugsCache();
+    invalidateAllowedCache();
 
     res.json({ status: 'ok', materia: materia.toSafeJSON() });
   } catch (error: any) {
@@ -137,6 +144,9 @@ export async function deleteMateria(req: Request, res: Response): Promise<void> 
 
     materia.softDelete();
     await materia.save(null, { useMasterKey: true });
+    // La materia dejó de existir → invalidar cache del gate.
+    invalidateMateriaSlugsCache();
+    invalidateAllowedCache();
 
     res.json({ status: 'ok', message: 'Materia eliminada' });
   } catch (error: any) {


### PR DESCRIPTION
## Descripción

El gate de `/docs/*` cachea la lista de slugs de materia (`getMateriaSlugs`, 5 min)
y los slugs permitidos por usuario (`getAllowedMateriaSlugs`, 60 s). Esas funciones ya
tenían helpers de invalidación (`invalidateMateriaSlugsCache` / `invalidateAllowedCache`)
pero **no estaban conectados**, así que un cambio de acceso tardaba hasta 5 min en aplicarse
(lo vimos al crear la materia `tc2007b`, que tardó ~5 min en protegerse).

Este PR conecta la invalidación en cada mutación relevante:
- **`materias.controller`** (create/update/delete) → invalida slugs + permisos.
- **`grupos.controller`** (`updateGrupo` con `materiaId`) → invalida permisos (cambia el acceso de los alumnos del grupo).
- **`alumnos.controller`** (alta/baja individual y bulk import) → invalida el cache del alumno afectado (global en el import masivo).

Resultado: **altas/bajas de acceso a los Docusaurus son inmediatas** (sin esperar el TTL).

## Tipo de cambio
- [x] `fix` — corrección (frescura de acceso / seguridad)

## ¿Cómo se probó?
- [x] `tsc --noEmit` y `yarn workspace @tc2005b/api build` sin errores.