### PR TITLE
feat: asignar varios Docusaurus a un grupo (independiente de la materia)

### DIFF
--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -21,8 +21,13 @@ export async function listGrupos(_req: Request, res: Response): Promise<void> {
   }
 }
 
+function normalizeSlugs(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  return value.filter((s): s is string => typeof s === 'string' && s.trim() !== '');
+}
+
 export async function createGrupo(req: Request, res: Response): Promise<void> {
-  const { name, fechaInicio, fechaFin, materiaId } = req.body;
+  const { name, fechaInicio, fechaFin, materiaId, docusaurus } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim() === '') {
     res.status(400).json({ status: 'error', message: 'El nombre es requerido' });
@@ -44,6 +49,8 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
       }
       grupo.setMateria(materia);
     }
+    const docusSlugs = normalizeSlugs(docusaurus);
+    if (docusSlugs) grupo.setDocusaurus(docusSlugs);
 
     await grupo.save(null, { useMasterKey: true });
 
@@ -55,7 +62,7 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
 
 export async function updateGrupo(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { name, fechaInicio, fechaFin, materiaId } = req.body;
+  const { name, fechaInicio, fechaFin, materiaId, docusaurus } = req.body;
 
   try {
     const query = BaseModel.queryActive<Grupo>('Grupo');
@@ -82,10 +89,13 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
         grupo.setMateria(Parse.Object.extend('Materia').createWithoutData(materiaId));
       }
     }
+    if (docusaurus !== undefined) {
+      grupo.setDocusaurus(normalizeSlugs(docusaurus) ?? []);
+    }
 
     await grupo.save(null, { useMasterKey: true });
-    // Si cambió la materia del grupo, el acceso de sus alumnos cambió.
-    if (materiaId !== undefined) invalidateAllowedCache();
+    // Si cambió la materia o los docusaurus del grupo, cambió el acceso de sus alumnos.
+    if (materiaId !== undefined || docusaurus !== undefined) invalidateAllowedCache();
 
     res.json({ status: 'ok', grupo: grupo.toSafeJSON() });
   } catch (error: any) {

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -23,7 +23,10 @@ export async function listGrupos(_req: Request, res: Response): Promise<void> {
 
 function normalizeSlugs(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
-  return value.filter((s): s is string => typeof s === 'string' && s.trim() !== '');
+  const slugs = value
+    .filter((s): s is string => typeof s === 'string' && s.trim() !== '')
+    .map((s) => s.trim());
+  return [...new Set(slugs)];
 }
 
 export async function createGrupo(req: Request, res: Response): Promise<void> {
@@ -89,13 +92,14 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
         grupo.setMateria(Parse.Object.extend('Materia').createWithoutData(materiaId));
       }
     }
-    if (docusaurus !== undefined) {
-      grupo.setDocusaurus(normalizeSlugs(docusaurus) ?? []);
-    }
+    // Solo se aplica si es un array válido (incl. [] para limpiar); un valor
+    // no-array se ignora para no borrar las asignaciones existentes por error.
+    const docusSlugs = docusaurus !== undefined ? normalizeSlugs(docusaurus) : null;
+    if (docusSlugs) grupo.setDocusaurus(docusSlugs);
 
     await grupo.save(null, { useMasterKey: true });
     // Si cambió la materia o los docusaurus del grupo, cambió el acceso de sus alumnos.
-    if (materiaId !== undefined || docusaurus !== undefined) invalidateAllowedCache();
+    if (materiaId !== undefined || docusSlugs) invalidateAllowedCache();
 
     res.json({ status: 'ok', grupo: grupo.toSafeJSON() });
   } catch (error: any) {

--- a/packages/api/src/models/Grupo.ts
+++ b/packages/api/src/models/Grupo.ts
@@ -63,6 +63,18 @@ export class Grupo extends BaseModel {
     this.set('materia', materia);
   }
 
+  /**
+   * Slugs de Docusaurus asignados directamente al grupo (acceso multi-instancia,
+   * independiente de la materia). El acceso a docs del alumno = unión de la
+   * materia del grupo + estos slugs.
+   */
+  getDocusaurus(): string[] {
+    return this.get('docusaurus') ?? [];
+  }
+  setDocusaurus(slugs: string[]): void {
+    this.set('docusaurus', slugs);
+  }
+
   toSafeJSON(): Record<string, unknown> {
     const materia = this.getMateria();
     // Si la materia (incluida) fue soft-deleted, no la exponemos.
@@ -81,6 +93,7 @@ export class Grupo extends BaseModel {
       materia: materiaActiva
         ? { id: materiaActiva.id, nombre: materiaActiva.get('nombre') ?? null, slug: materiaActiva.get('slug') ?? null }
         : null,
+      docusaurus: this.getDocusaurus(),
       active: this.get('active'),
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/packages/api/src/services/materia.service.ts
+++ b/packages/api/src/services/materia.service.ts
@@ -34,6 +34,13 @@ export async function getMateriaSlugs(): Promise<Set<string>> {
   return set;
 }
 
+/** Convierte objetos Materia en {slug, nombre} (descarta los sin slug). */
+function toMateriaInfoList(materias: Parse.Object[]): MateriaInfo[] {
+  return materias
+    .map((m) => ({ slug: m.get('slug') as string, nombre: (m.get('nombre') as string) ?? m.get('slug') }))
+    .filter((m) => !!m.slug);
+}
+
 /* ── Materias permitidas por usuario: admin ⇒ todas; alumno ⇒ las de sus grupos ── */
 export async function getAllowedMaterias(user: AppUser): Promise<MateriaInfo[]> {
   if (user.get('userType') === 'admin') {
@@ -41,10 +48,7 @@ export async function getAllowedMaterias(user: AppUser): Promise<MateriaInfo[]> 
     q.equalTo('exists' as any, true as any);
     q.ascending('nombre');
     q.limit(10000);
-    const materias = await q.find({ useMasterKey: true });
-    return materias
-      .map((m) => ({ slug: m.get('slug') as string, nombre: (m.get('nombre') as string) ?? m.get('slug') }))
-      .filter((m) => !!m.slug);
+    return toMateriaInfoList(await q.find({ useMasterKey: true }));
   }
 
   // Alumno: acceso = unión de (materia del grupo) + (docusaurus[] del grupo),
@@ -58,33 +62,35 @@ export async function getAllowedMaterias(user: AppUser): Promise<MateriaInfo[]> 
   q.limit(1000);
   const links = await q.find({ useMasterKey: true });
 
-  const slugSet = new Set<string>();
+  // La materia se resuelve desde el include (ya confirmada existente, con nombre).
+  // Los slugs de docusaurus quedan pendientes: hay que confirmar que son Materias.
+  const resolved = new Map<string, string>(); // slug → nombre
+  const pending = new Set<string>();
   for (const link of links) {
     const grupo = link.get('grupo');
     if (!grupo || grupo.get('exists') === false) continue;
-    // Materia asignada (compatibilidad).
     const materia = grupo.get('materia');
     if (materia && materia.get('exists') !== false && materia.get('slug')) {
-      slugSet.add(materia.get('slug'));
+      resolved.set(materia.get('slug'), materia.get('nombre') ?? materia.get('slug'));
     }
-    // Docusaurus asignados directamente al grupo.
     const docs = grupo.get('docusaurus');
     if (Array.isArray(docs)) {
-      for (const s of docs) if (typeof s === 'string' && s) slugSet.add(s);
+      for (const s of docs) if (typeof s === 'string' && s && !resolved.has(s)) pending.add(s);
     }
   }
-  if (slugSet.size === 0) return [];
 
-  // Resolver nombres desde Materia; solo los slugs con Materia existente cuentan
-  // (son los que el gate reconoce como protegidos).
-  const mq = new Parse.Query('Materia');
-  mq.containedIn('slug' as any, [...slugSet] as any);
-  mq.equalTo('exists' as any, true as any);
-  mq.limit(10000);
-  const materias = await mq.find({ useMasterKey: true });
-  return materias
-    .map((m) => ({ slug: m.get('slug') as string, nombre: (m.get('nombre') as string) ?? m.get('slug') }))
-    .filter((m) => !!m.slug);
+  // Solo consultamos por los slugs de docusaurus no cubiertos ya por una materia.
+  if (pending.size > 0) {
+    const mq = new Parse.Query('Materia');
+    mq.containedIn('slug' as any, [...pending] as any);
+    mq.equalTo('exists' as any, true as any);
+    mq.limit(10000);
+    for (const info of toMateriaInfoList(await mq.find({ useMasterKey: true }))) {
+      resolved.set(info.slug, info.nombre);
+    }
+  }
+
+  return [...resolved.entries()].map(([slug, nombre]) => ({ slug, nombre }));
 }
 
 /* ── Cache corto por-usuario de slugs permitidos (evita re-query por cada asset) ── */

--- a/packages/api/src/services/materia.service.ts
+++ b/packages/api/src/services/materia.service.ts
@@ -47,7 +47,8 @@ export async function getAllowedMaterias(user: AppUser): Promise<MateriaInfo[]> 
       .filter((m) => !!m.slug);
   }
 
-  // Alumno: GrupoAlumno activos → grupo.materia (include anidado).
+  // Alumno: acceso = unión de (materia del grupo) + (docusaurus[] del grupo),
+  // sobre todos sus GrupoAlumno activos.
   const alumnoPointer = Parse.Object.extend('AppUser').createWithoutData(user.id);
   const q = new Parse.Query<GrupoAlumno>('GrupoAlumno');
   q.equalTo('exists' as any, true as any);
@@ -57,16 +58,33 @@ export async function getAllowedMaterias(user: AppUser): Promise<MateriaInfo[]> 
   q.limit(1000);
   const links = await q.find({ useMasterKey: true });
 
-  const bySlug = new Map<string, string>();
+  const slugSet = new Set<string>();
   for (const link of links) {
     const grupo = link.get('grupo');
     if (!grupo || grupo.get('exists') === false) continue;
+    // Materia asignada (compatibilidad).
     const materia = grupo.get('materia');
-    if (!materia || materia.get('exists') === false) continue;
-    const slug = materia.get('slug');
-    if (slug) bySlug.set(slug, materia.get('nombre') ?? slug);
+    if (materia && materia.get('exists') !== false && materia.get('slug')) {
+      slugSet.add(materia.get('slug'));
+    }
+    // Docusaurus asignados directamente al grupo.
+    const docs = grupo.get('docusaurus');
+    if (Array.isArray(docs)) {
+      for (const s of docs) if (typeof s === 'string' && s) slugSet.add(s);
+    }
   }
-  return [...bySlug.entries()].map(([slug, nombre]) => ({ slug, nombre }));
+  if (slugSet.size === 0) return [];
+
+  // Resolver nombres desde Materia; solo los slugs con Materia existente cuentan
+  // (son los que el gate reconoce como protegidos).
+  const mq = new Parse.Query('Materia');
+  mq.containedIn('slug' as any, [...slugSet] as any);
+  mq.equalTo('exists' as any, true as any);
+  mq.limit(10000);
+  const materias = await mq.find({ useMasterKey: true });
+  return materias
+    .map((m) => ({ slug: m.get('slug') as string, nombre: (m.get('nombre') as string) ?? m.get('slug') }))
+    .filter((m) => !!m.slug);
 }
 
 /* ── Cache corto por-usuario de slugs permitidos (evita re-query por cada asset) ── */

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.module.css
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.module.css
@@ -55,6 +55,16 @@
 
 .checkboxItem input {
   cursor: pointer;
+  flex-shrink: 0;
+}
+
+/* Trunca el nombre a una sola línea con … (min-width:0 para que el flex encoja) */
+.checkboxLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hint {

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.module.css
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.module.css
@@ -32,6 +32,36 @@
   border-color: var(--dash-primary);
 }
 
+.checkboxList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--sidebar-bg);
+  max-height: 160px;
+  overflow-y: auto;
+}
+
+.checkboxItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.checkboxItem input {
+  cursor: pointer;
+}
+
+.hint {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
@@ -101,17 +101,21 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
           {materias.length === 0 && (
             <span className={styles.hint}>No hay Docusaurus disponibles.</span>
           )}
-          {materias.map((m) => (
-            <label key={m.slug} className={styles.checkboxItem}>
-              <input
-                type="checkbox"
-                checked={docusaurus.includes(m.slug)}
-                onChange={() => toggleDocusaurus(m.slug)}
-                disabled={loading}
-              />
-              <span>{m.nombre}</span>
-            </label>
-          ))}
+          {materias.map((m) => {
+            const clave = m.codigo || m.slug.toUpperCase();
+            const label = `${clave} — ${m.nombre}`;
+            return (
+              <label key={m.slug} className={styles.checkboxItem}>
+                <input
+                  type="checkbox"
+                  checked={docusaurus.includes(m.slug)}
+                  onChange={() => toggleDocusaurus(m.slug)}
+                  disabled={loading}
+                />
+                <span className={styles.checkboxLabel} title={label}>{label}</span>
+              </label>
+            );
+          })}
         </div>
       </div>
       <div className={styles.field}>

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import TextInput from '../../atoms/TextInput/TextInput';
 import DashButton from '../../atoms/DashButton/DashButton';
 import styles from './GrupoForm.module.css';
-import type { MateriaOption, MateriaRef } from '../../../../types/materia';
+import type { MateriaRef } from '../../../../types/materia';
 
 interface GrupoData {
   id?: string;
@@ -10,6 +10,7 @@ interface GrupoData {
   fechaInicio?: string;
   fechaFin?: string;
   materia?: MateriaRef | null;
+  docusaurus?: string[];
 }
 
 interface GrupoSavePayload {
@@ -17,11 +18,12 @@ interface GrupoSavePayload {
   fechaInicio?: string;
   fechaFin?: string;
   materiaId?: string | null;
+  docusaurus?: string[];
 }
 
 interface GrupoFormProps {
   grupo?: GrupoData;
-  materias?: MateriaOption[];
+  materias?: MateriaRef[];
   onSave: (data: GrupoSavePayload) => void;
   onCancel: () => void;
   loading?: boolean;
@@ -39,7 +41,14 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
   const [fechaInicio, setFechaInicio] = useState(toDateString(grupo?.fechaInicio));
   const [fechaFin, setFechaFin] = useState(toDateString(grupo?.fechaFin));
   const [materiaId, setMateriaId] = useState(grupo?.materia?.id ?? '');
+  const [docusaurus, setDocusaurus] = useState<string[]>(grupo?.docusaurus ?? []);
   const [error, setError] = useState('');
+
+  function toggleDocusaurus(slug: string) {
+    setDocusaurus((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    );
+  }
 
   function doSave() {
     if (!name.trim()) {
@@ -52,6 +61,7 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
       fechaInicio: fechaInicio || undefined,
       fechaFin: fechaFin || undefined,
       materiaId: materiaId || null,
+      docusaurus,
     });
   }
 
@@ -84,6 +94,25 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
             <option key={m.id} value={m.id}>{m.nombre}</option>
           ))}
         </select>
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label}>Docusaurus con acceso</label>
+        <div className={styles.checkboxList}>
+          {materias.length === 0 && (
+            <span className={styles.hint}>No hay Docusaurus disponibles.</span>
+          )}
+          {materias.map((m) => (
+            <label key={m.slug} className={styles.checkboxItem}>
+              <input
+                type="checkbox"
+                checked={docusaurus.includes(m.slug)}
+                onChange={() => toggleDocusaurus(m.slug)}
+                disabled={loading}
+              />
+              <span>{m.nombre}</span>
+            </label>
+          ))}
+        </div>
       </div>
       <div className={styles.field}>
         <label className={styles.label}>Fecha de inicio</label>

--- a/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
@@ -6,7 +6,7 @@ import AdminTable from '../../organisms/AdminTable/AdminTable';
 import Modal from '../../atoms/Modal/Modal';
 import GrupoForm from '../../organisms/GrupoForm/GrupoForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
-import type { MateriaOption, MateriaRef } from '../../../../types/materia';
+import type { MateriaRef } from '../../../../types/materia';
 import styles from './GruposPage.module.css';
 
 interface GrupoData {
@@ -16,6 +16,7 @@ interface GrupoData {
   fechaFin?: string;
   active: boolean;
   materia?: MateriaRef | null;
+  docusaurus?: string[];
 }
 
 const API_BASE = '/api';
@@ -24,7 +25,7 @@ export default function GruposPage() {
   const { sessionToken } = useAuth();
   const navigate = useNavigate();
   const [grupos, setGrupos] = useState<GrupoData[]>([]);
-  const [materias, setMaterias] = useState<MateriaOption[]>([]);
+  const [materias, setMaterias] = useState<MateriaRef[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -81,7 +82,7 @@ export default function GruposPage() {
     setEditGrupo(undefined);
   }
 
-  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; materiaId?: string | null }) {
+  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; materiaId?: string | null; docusaurus?: string[] }) {
     setSaving(true);
     setError('');
     try {

--- a/packages/web/src/types/materia.ts
+++ b/packages/web/src/types/materia.ts
@@ -9,4 +9,5 @@ export interface MateriaRef {
   id: string;
   nombre: string;
   slug: string;
+  codigo?: string | null;
 }


### PR DESCRIPTION
## Descripción

Permite asignar **múltiples Docusaurus** a un grupo directamente, sin depender de la
materia única. El acceso a docs de un alumno pasa a ser la **unión** de:
- la `materia` del grupo (compatibilidad, sigue funcionando), y
- el nuevo array `Grupo.docusaurus` (slugs asignados directamente).

### Backend
- `Grupo.docusaurus: string[]` (+ en `toSafeJSON`).
- `grupos.controller` create/update aceptan `docusaurus` (array de slugs), lo normalizan
  e invalidan el cache de permisos al cambiarlo.
- `materia.service.getAllowedMaterias(alumno)` → unión `materia.slug ∪ docusaurus[]` de sus
  grupos, resuelta contra las Materias existentes (solo slugs con Materia cuentan).

### Admin
- Multi-select **"Docusaurus con acceso"** (checkboxes) en `GrupoForm`, poblado desde las materias.

## Tipo de cambio
- [x] `feat` (SemVer: MINOR)

## ¿Cómo se probó?
- [x] `tsc --noEmit` api + web, `yarn workspace @tc2005b/web build` sin errores.

## Notas
- **Aditivo/compatible**: los grupos con `materia` conservan su acceso; no requiere migración.