### PR TITLE
feat(admin): submenú de Docusaurus del grupo en el sidebar de detalle

### DIFF
--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
@@ -1,0 +1,69 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Cabecera "Docusaurus": mismo look que un NavItem, pero es un botón toggle. */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s, color 0.2s;
+}
+.header:hover {
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+.header.collapsed {
+  justify-content: center;
+  padding: 10px;
+}
+
+/* La etiqueta empuja el chevron al extremo derecho. */
+.headerLabel {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 2px 0 2px 20px;
+}
+
+/* Cada Docusaurus: enlace truncado a una sola línea con … */
+.link {
+  display: block;
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background 0.2s, color 0.2s;
+}
+.link:hover {
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.hint {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}

--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import Icon from '../../atoms/Icon/Icon';
+import styles from './DocusMenu.module.css';
+
+/** Un Docusaurus habilitado para el grupo: slug + etiqueta "CLAVE — Nombre". */
+export interface DocusLink {
+  slug: string;
+  label: string;
+}
+
+interface DocusMenuProps {
+  items: DocusLink[];
+  collapsed?: boolean;
+  /** Si el submenú arranca abierto. Por defecto colapsado. */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Ítem "Docusaurus" del sidebar con submenú colapsable (colapsado por
+ * defecto) que lista los Docusaurus habilitados del grupo. Cada enlace abre
+ * `/docs/<slug>/` en una pestaña nueva; la etiqueta se trunca a una sola línea.
+ */
+export default function DocusMenu({ items, collapsed, defaultOpen = false }: DocusMenuProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  // Rail colapsado: solo el icono como afordancia (sin submenú expandible).
+  if (collapsed) {
+    return (
+      <div className={`${styles.header} ${styles.collapsed}`} title="Docusaurus">
+        <Icon name="menu_book" size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.wrapper}>
+      <button
+        type="button"
+        className={styles.header}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Icon name="menu_book" size="sm" />
+        <span className={styles.headerLabel}>Docusaurus</span>
+        <Icon name={open ? 'expand_less' : 'expand_more'} size="sm" />
+      </button>
+      {open && (
+        <div className={styles.list}>
+          {items.length === 0 ? (
+            <span className={styles.hint}>Sin Docusaurus asignados</span>
+          ) : (
+            items.map((it) => (
+              <a
+                key={it.slug}
+                href={`/docs/${it.slug}/`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.link}
+                title={it.label}
+              >
+                {it.label}
+              </a>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link, useMatch } from 'react-router';
 import NavItem from '../../molecules/NavItem/NavItem';
+import DocusMenu, { type DocusLink } from '../../molecules/DocusMenu/DocusMenu';
 import Icon from '../../atoms/Icon/Icon';
 import { getSidebarItems, getGrupoDetailItems } from './sidebarConfig';
 import styles from './Sidebar.module.css';
@@ -25,6 +26,7 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
   const [grupoName, setGrupoName] = useState('');
   const [selectedGrupoId, setSelectedGrupoId] = useState<string>('');
   const [docsHref, setDocsHref] = useState('/docs/');
+  const [docusLinks, setDocusLinks] = useState<DocusLink[]>([]);
 
   useEffect(() => {
     if (role === 'alumno' && user?.grupos?.length) {
@@ -61,14 +63,36 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
 
   useEffect(() => {
     if (!grupoId || !sessionToken) return;
-    fetch('/api/admin/grupos', {
-      headers: { 'x-session-token': sessionToken },
-    })
-      .then((r) => r.ok ? r.json() : null)
-      .then((json) => {
-        const grupos = json?.grupos ?? [];
-        const found = grupos.find((g: { id: string }) => g.id === grupoId);
+    const headers = { 'x-session-token': sessionToken };
+    Promise.all([
+      fetch('/api/admin/grupos', { headers }).then((r) => (r.ok ? r.json() : null)),
+      fetch('/api/admin/materias', { headers }).then((r) => (r.ok ? r.json() : null)),
+    ])
+      .then(([gruposJson, materiasJson]) => {
+        const grupos = gruposJson?.grupos ?? [];
+        const found = grupos.find(
+          (g: { id: string; name?: string; materia?: { slug?: string | null } | null; docusaurus?: string[] }) =>
+            g.id === grupoId,
+        );
         if (found?.name) setGrupoName(found.name);
+
+        // Etiquetas "CLAVE — Nombre" resueltas desde la lista de materias
+        // (la del grupo trae slug pero no código).
+        const materias: { slug: string; nombre: string; codigo?: string | null }[] = materiasJson?.materias ?? [];
+        const bySlug = new Map(materias.map((m) => [m.slug, m]));
+
+        // Docusaurus del grupo = unión de (materia del grupo) + (docusaurus[]),
+        // deduplicada, en el orden materia → asignados.
+        const slugs = [found?.materia?.slug, ...(found?.docusaurus ?? [])].filter(
+          (s): s is string => typeof s === 'string' && s.length > 0,
+        );
+        const links: DocusLink[] = [...new Set(slugs)].map((slug) => {
+          const m = bySlug.get(slug);
+          const clave = m?.codigo || slug.toUpperCase();
+          const nombre = m?.nombre || slug;
+          return { slug, label: `${clave} — ${nombre}` };
+        });
+        setDocusLinks(links);
       })
       .catch(() => {});
   }, [grupoId, sessionToken]);
@@ -131,6 +155,7 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
               onClick={onCloseMobile}
             />
           ))}
+          {isGrupoDetail && <DocusMenu items={docusLinks} collapsed={collapsed} />}
         </nav>
         <div className={styles.footer}>
           {!collapsed && (


### PR DESCRIPTION
## Descripción

En el detalle de grupo (`/admin/grupos/:id`) el profesor a veces necesita entrar directo al Docusaurus del grupo. Este PR añade al sidebar un ítem **"Docusaurus"** con submenú **colapsable (colapsado por defecto)** que lista los Docusaurus habilitados del grupo, cada uno como enlace directo.

## Cambios

- Nuevo `molecules/DocusMenu/` (componente + CSS): cabecera "Docusaurus" con chevron que expande/colapsa la lista; enlaces `/docs/<slug>/` en pestaña nueva; etiquetas truncadas a una sola línea con `…` y `title` para el nombre completo.
- `Sidebar.tsx`: en contexto de detalle de grupo resuelve los Docusaurus del grupo = **unión de la materia + los `docusaurus[]` asignados**, deduplicada. Las etiquetas usan la misma nomenclatura del editor de grupo (`CLAVE — Nombre`, con `clave = codigo || slug.toUpperCase()`), resolviendo el código desde `/api/admin/materias` (el grupo trae slug pero no código).
- El submenú solo aparece en `/admin/grupos/:id`; en rail colapsado se muestra solo el icono como afordancia.

## Notas

- Si el grupo no tiene Docusaurus, el submenú muestra "Sin Docusaurus asignados".
- Interpreté "los docusaurus habilitados del grupo" como la unión materia + asignados (todo lo que el grupo puede ver). Si se prefiere solo los `docusaurus[]`, es un cambio de una línea.

## Checklist

- [x] `tsc --noEmit` en web sin errores
- [x] `yarn build` de web pasa
- [ ] Verificación visual en el grupo de prueba