### PR TITLE
feat(cms): editor CodeMirror con preview, publicar e historial (US-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" (US-2)**: editor CodeMirror 6 con preview en vivo
+  (`/admin/contenidos/:id/editar/:docId`), autosave a borrador único,
+  publicar con versionado (`cuerpoHtml` renderizado en servidor), historial
+  con restaurar, y el pipeline compartido `@tc2005b/contenido-pipeline`
+  (GFM, admonitions estilo Docusaurus, sanitización allowlist, highlight).
+- **CMS "Contenidos" (US-1)**: modelos Parse `Coleccion`, `Documento`,
+  `DocumentoVersion` y `Recurso`; CRUD admin y sección `/admin/contenidos`
+  con árbol de páginas (según `design/cms-contenidos.html`).
 - Redirects de las URLs viejas `/docs/docs/...` hacia las nuevas
   (`@docusaurus/plugin-client-redirects`).
 - `CONTRIBUTING.md`, plantilla de PR y este `CHANGELOG.md`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "workspaces": [
     "packages/web",
     "packages/docusaurus",
-    "packages/api"
+    "packages/api",
+    "packages/contenido-pipeline"
   ],
   "scripts": {
     "dev": "concurrently -n web,docs,api -c cyan,magenta,yellow \"yarn workspace @tc2005b/web dev\" \"yarn workspace @tc2005b/docs start --port 3001\" \"yarn workspace @tc2005b/api dev\"",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest --globals"
   },
   "dependencies": {
+    "@tc2005b/contenido-pipeline": "0.1.0",
     "bcryptjs": "^3.0.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/packages/api/src/controllers/cms-documentos.controller.ts
+++ b/packages/api/src/controllers/cms-documentos.controller.ts
@@ -52,7 +52,7 @@ async function getColeccionActiva(id: string): Promise<Coleccion | null> {
  * `exists` (no `active`): el admin gestiona también documentos desactivados
  * — el flag `active` gobierna visibilidad en el visor (US-3), no la edición.
  */
-async function buscarDocumento(docId: string): Promise<{ documento: Documento; coleccion: Coleccion } | null> {
+export async function buscarDocumento(docId: string): Promise<{ documento: Documento; coleccion: Coleccion } | null> {
   try {
     const q = new Parse.Query<Documento>('Documento');
     q.equalTo('exists' as any, true as any);

--- a/packages/api/src/controllers/cms-documentos.controller.ts
+++ b/packages/api/src/controllers/cms-documentos.controller.ts
@@ -66,6 +66,48 @@ export async function buscarDocumento(docId: string): Promise<{ documento: Docum
   }
 }
 
+/**
+ * Devuelve el borrador único del documento, creándolo si no existe.
+ * Único punto donde se crean borradores (numeración, autor y enlace a
+ * Documento.borrador viven aquí) — lo usan saveBorrador y restaurarVersion.
+ *
+ * Mitigación de carreras (dos autosaves simultáneos, o autosave vs publicar):
+ * tras crear la versión se RE-LEE el documento; si otro request enlazó un
+ * borrador entre tanto, descartamos el nuestro y usamos el suyo. La ventana
+ * restante es de milisegundos y el peor caso es un autosave perdido (el
+ * siguiente lo corrige), nunca una versión publicada mutada.
+ */
+export async function asegurarBorrador(
+  docId: string,
+  autor?: AppUser,
+): Promise<{ documento: Documento; borrador: DocumentoVersion } | null> {
+  const encontrado = await buscarDocumento(docId);
+  if (!encontrado) return null;
+  let { documento } = encontrado;
+
+  const existente = documento.getBorrador();
+  if (existente) return { documento, borrador: existente };
+
+  const nuevo = new DocumentoVersion().initDefaults();
+  nuevo.setDocumento(documento);
+  nuevo.setNumero((documento.getVersion()?.getNumero() ?? 0) + 1);
+  if (autor) nuevo.setAutor(autor);
+  await nuevo.save(null, { useMasterKey: true });
+
+  // Re-check: ¿alguien más creó y enlazó un borrador mientras guardábamos?
+  const recheck = await buscarDocumento(docId);
+  const ajeno = recheck?.documento.getBorrador();
+  if (recheck && ajeno && ajeno.id !== nuevo.id) {
+    await nuevo.destroy({ useMasterKey: true });
+    return { documento: recheck.documento, borrador: ajeno };
+  }
+
+  documento = recheck?.documento ?? documento;
+  documento.setBorrador(nuevo);
+  await documento.save(null, { useMasterKey: true });
+  return { documento, borrador: nuevo };
+}
+
 /** Query base de documentos existentes de una colección. */
 function queryDocumentos(coleccion: Coleccion): Parse.Query<Documento> {
   const q = new Parse.Query<Documento>('Documento');
@@ -405,33 +447,21 @@ export async function saveBorrador(req: Request, res: Response): Promise<void> {
   }
 
   try {
-    const encontrado = await buscarDocumento(docId);
-    if (!encontrado) {
+    const autor = req.appUser as AppUser | undefined;
+    const resultado = await asegurarBorrador(docId, autor);
+    if (!resultado) {
       res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
       return;
     }
-    const { documento } = encontrado;
+    const { documento, borrador } = resultado;
     if (documento.getTipo() === 'categoria') {
       res.status(400).json({ status: 'error', message: 'Las categorías no tienen cuerpo' });
       return;
     }
 
-    let borrador = documento.getBorrador();
-    const esNuevo = !borrador;
-    if (!borrador) {
-      borrador = new DocumentoVersion().initDefaults();
-      borrador.setDocumento(documento);
-      borrador.setNumero((documento.getVersion()?.getNumero() ?? 0) + 1);
-    }
     borrador.setCuerpo(cuerpo);
-    const autor = req.appUser as AppUser | undefined;
     if (autor) borrador.setAutor(autor);
     await borrador.save(null, { useMasterKey: true });
-
-    if (esNuevo) {
-      documento.setBorrador(borrador);
-      await documento.save(null, { useMasterKey: true });
-    }
 
     res.json({ status: 'ok', esBorrador: true });
   } catch (error) {

--- a/packages/api/src/controllers/cms-versiones.controller.ts
+++ b/packages/api/src/controllers/cms-versiones.controller.ts
@@ -1,0 +1,198 @@
+import type { Request, Response } from 'express';
+import Parse from 'parse/node';
+import { renderMarkdown } from '@tc2005b/contenido-pipeline';
+import { DocumentoVersion } from '../models/DocumentoVersion.js';
+import type { Documento } from '../models/Documento.js';
+import type { AppUser } from '../models/AppUser.js';
+import { buscarDocumento } from './cms-documentos.controller.js';
+
+/**
+ * Versionado del CMS "Contenidos" (design §1/§3): publicar congela el
+ * borrador como versión nueva (con cuerpoHtml renderizado por el pipeline
+ * compartido); restaurar copia una versión vieja AL BORRADOR (el pasado
+ * nunca se muta) para revisarla y publicarla.
+ */
+
+/** Versión de un documento, verificando la pertenencia. */
+async function buscarVersion(documento: Documento, versionId: string): Promise<DocumentoVersion | null> {
+  try {
+    const q = new Parse.Query<DocumentoVersion>('DocumentoVersion');
+    q.equalTo('exists' as any, true as any);
+    q.equalTo('documento' as any, documento as any);
+    q.include('autor' as any);
+    return await q.get(versionId, { useMasterKey: true });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST /admin/documentos/:docId/publicar — { mensaje? }
+ * El borrador se convierte en la versión publicada: se renderiza cuerpoHtml
+ * (solo Markdown; el HTML crudo se sirve sandboxeado en US-5), se numera y
+ * se apunta Documento.version. El siguiente edit creará un borrador nuevo.
+ */
+export async function publicarDocumento(req: Request, res: Response): Promise<void> {
+  const { docId } = req.params;
+  const { mensaje } = req.body ?? {};
+
+  try {
+    const encontrado = await buscarDocumento(docId);
+    if (!encontrado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
+    }
+    const { documento } = encontrado;
+    if (documento.getTipo() === 'categoria') {
+      res.status(400).json({ status: 'error', message: 'Las categorías no se publican' });
+      return;
+    }
+
+    const borrador = documento.getBorrador();
+    if (!borrador) {
+      res.status(400).json({ status: 'error', message: 'No hay cambios de borrador que publicar' });
+      return;
+    }
+
+    const numeroNuevo = (documento.getVersion()?.getNumero() ?? 0) + 1;
+    borrador.setNumero(numeroNuevo);
+    if (documento.getTipo() === 'md') {
+      borrador.setCuerpoHtml(await renderMarkdown(borrador.getCuerpo()));
+    } else {
+      // Páginas html: el cuerpo crudo se sirve por su endpoint sandboxeado (US-5).
+      borrador.setCuerpoHtml('');
+    }
+    if (typeof mensaje === 'string' && mensaje.trim()) borrador.setMensaje(mensaje.trim());
+    const autor = req.appUser as AppUser | undefined;
+    if (autor) borrador.setAutor(autor);
+    await borrador.save(null, { useMasterKey: true });
+
+    documento.setVersion(borrador);
+    documento.setBorrador(null);
+    documento.setPublicado(true);
+    await documento.save(null, { useMasterKey: true });
+
+    res.json({ status: 'ok', documento: documento.toSafeJSON(), version: numeroNuevo });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al publicar documento' });
+  }
+}
+
+/** GET /admin/documentos/:docId/versiones — historial (sin cuerpos, que pesan). */
+export async function listVersiones(req: Request, res: Response): Promise<void> {
+  const { docId } = req.params;
+
+  try {
+    const encontrado = await buscarDocumento(docId);
+    if (!encontrado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
+    }
+    const { documento } = encontrado;
+
+    const q = new Parse.Query<DocumentoVersion>('DocumentoVersion');
+    q.equalTo('exists' as any, true as any);
+    q.equalTo('documento' as any, documento as any);
+    q.include('autor' as any);
+    q.descending('createdAt');
+    q.limit(500);
+    const versiones = await q.find({ useMasterKey: true });
+
+    const borradorId = documento.getBorrador()?.id ?? null;
+    const publicadaId = documento.getVersion()?.id ?? null;
+
+    res.json({
+      status: 'ok',
+      versiones: versiones.map((v) => {
+        const autor = v.getAutor();
+        return {
+          id: v.id,
+          numero: v.getNumero(),
+          mensaje: v.getMensaje() ?? null,
+          autor: autor ? { id: autor.id, name: autor.get('name') ?? null } : null,
+          esBorrador: v.id === borradorId,
+          esPublicada: v.id === publicadaId,
+          createdAt: v.createdAt,
+          updatedAt: v.updatedAt,
+        };
+      }),
+    });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al obtener versiones' });
+  }
+}
+
+/** GET /admin/documentos/:docId/versiones/:versionId — una versión con su cuerpo. */
+export async function getVersion(req: Request, res: Response): Promise<void> {
+  const { docId, versionId } = req.params;
+
+  try {
+    const encontrado = await buscarDocumento(docId);
+    if (!encontrado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
+    }
+    const version = await buscarVersion(encontrado.documento, versionId);
+    if (!version) {
+      res.status(404).json({ status: 'error', message: 'Versión no encontrada' });
+      return;
+    }
+
+    res.json({ status: 'ok', version: version.toSafeJSON() });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al obtener versión' });
+  }
+}
+
+/**
+ * POST /admin/documentos/:docId/versiones/:versionId/restaurar
+ * Copia el cuerpo de la versión indicada AL BORRADOR (creándolo si no hay).
+ * Nunca muta versiones pasadas; el admin revisa el borrador y publica.
+ */
+export async function restaurarVersion(req: Request, res: Response): Promise<void> {
+  const { docId, versionId } = req.params;
+
+  try {
+    const encontrado = await buscarDocumento(docId);
+    if (!encontrado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
+    }
+    const { documento } = encontrado;
+    if (documento.getTipo() === 'categoria') {
+      res.status(400).json({ status: 'error', message: 'Las categorías no tienen versiones' });
+      return;
+    }
+    const version = await buscarVersion(documento, versionId);
+    if (!version) {
+      res.status(404).json({ status: 'error', message: 'Versión no encontrada' });
+      return;
+    }
+    if (version.id === documento.getBorrador()?.id) {
+      res.status(400).json({ status: 'error', message: 'Esa versión ya es el borrador actual' });
+      return;
+    }
+
+    let borrador = documento.getBorrador();
+    const esNuevo = !borrador;
+    if (!borrador) {
+      borrador = new DocumentoVersion().initDefaults();
+      borrador.setDocumento(documento);
+      borrador.setNumero((documento.getVersion()?.getNumero() ?? 0) + 1);
+    }
+    borrador.setCuerpo(version.getCuerpo());
+    borrador.setMensaje(`restaurado de v${version.getNumero()}`);
+    const autor = req.appUser as AppUser | undefined;
+    if (autor) borrador.setAutor(autor);
+    await borrador.save(null, { useMasterKey: true });
+
+    if (esNuevo) {
+      documento.setBorrador(borrador);
+      await documento.save(null, { useMasterKey: true });
+    }
+
+    res.json({ status: 'ok', cuerpo: borrador.getCuerpo(), esBorrador: true });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al restaurar versión' });
+  }
+}

--- a/packages/api/src/controllers/cms-versiones.controller.ts
+++ b/packages/api/src/controllers/cms-versiones.controller.ts
@@ -4,7 +4,7 @@ import { renderMarkdown } from '@tc2005b/contenido-pipeline';
 import { DocumentoVersion } from '../models/DocumentoVersion.js';
 import type { Documento } from '../models/Documento.js';
 import type { AppUser } from '../models/AppUser.js';
-import { buscarDocumento } from './cms-documentos.controller.js';
+import { buscarDocumento, asegurarBorrador } from './cms-documentos.controller.js';
 
 /**
  * Versionado del CMS "Contenidos" (design §1/§3): publicar congela el
@@ -94,6 +94,10 @@ export async function listVersiones(req: Request, res: Response): Promise<void> 
     q.equalTo('exists' as any, true as any);
     q.equalTo('documento' as any, documento as any);
     q.include('autor' as any);
+    // Solo metadatos: sin select, cada versión arrastraría cuerpo y
+    // cuerpoHtml completos (documentos con mucho historial = MBs por abrir
+    // el modal). createdAt/updatedAt siempre vienen.
+    q.select(['numero', 'mensaje', 'autor'] as any);
     q.descending('createdAt');
     q.limit(500);
     const versiones = await q.find({ useMasterKey: true });
@@ -173,23 +177,17 @@ export async function restaurarVersion(req: Request, res: Response): Promise<voi
       return;
     }
 
-    let borrador = documento.getBorrador();
-    const esNuevo = !borrador;
-    if (!borrador) {
-      borrador = new DocumentoVersion().initDefaults();
-      borrador.setDocumento(documento);
-      borrador.setNumero((documento.getVersion()?.getNumero() ?? 0) + 1);
+    const autor = req.appUser as AppUser | undefined;
+    const resultado = await asegurarBorrador(docId, autor);
+    if (!resultado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
     }
+    const { borrador } = resultado;
     borrador.setCuerpo(version.getCuerpo());
     borrador.setMensaje(`restaurado de v${version.getNumero()}`);
-    const autor = req.appUser as AppUser | undefined;
     if (autor) borrador.setAutor(autor);
     await borrador.save(null, { useMasterKey: true });
-
-    if (esNuevo) {
-      documento.setBorrador(borrador);
-      await documento.save(null, { useMasterKey: true });
-    }
 
     res.json({ status: 'ok', cuerpo: borrador.getCuerpo(), esBorrador: true });
   } catch (error) {

--- a/packages/api/src/routes/contenidos.routes.ts
+++ b/packages/api/src/routes/contenidos.routes.ts
@@ -16,6 +16,12 @@ import {
   getBorrador,
   saveBorrador,
 } from '../controllers/cms-documentos.controller.js';
+import {
+  publicarDocumento,
+  listVersiones,
+  getVersion,
+  restaurarVersion,
+} from '../controllers/cms-versiones.controller.js';
 
 // Rutas admin del CMS "Contenidos" (design/cms-contenidos.html §7).
 // Los endpoints de lectura del visor (US-3) irán en un router aparte.
@@ -37,8 +43,14 @@ router.put('/admin/documentos/:docId', updateDocumento);
 router.put('/admin/documentos/:docId/mover', moveDocumento);
 router.delete('/admin/documentos/:docId', deleteDocumento);
 
-// Borrador provisional (editor rico en US-2)
+// Borrador (autosave del editor)
 router.get('/admin/documentos/:docId/borrador', getBorrador);
 router.put('/admin/documentos/:docId/borrador', saveBorrador);
+
+// Publicar + historial de versiones (US-2)
+router.post('/admin/documentos/:docId/publicar', publicarDocumento);
+router.get('/admin/documentos/:docId/versiones', listVersiones);
+router.get('/admin/documentos/:docId/versiones/:versionId', getVersion);
+router.post('/admin/documentos/:docId/versiones/:versionId/restaurar', restaurarVersion);
 
 export default router;

--- a/packages/contenido-pipeline/index.d.ts
+++ b/packages/contenido-pipeline/index.d.ts
@@ -1,0 +1,8 @@
+/** Tipos de admonition soportados (paridad Docusaurus). */
+export declare const ADMONITION_TIPOS: string[];
+
+/**
+ * Renderiza Markdown (GFM + admonitions) a HTML sanitizado con highlight.
+ * Mismo pipeline en el API (publicar) y en el editor web (preview).
+ */
+export declare function renderMarkdown(cuerpo: string): Promise<string>;

--- a/packages/contenido-pipeline/index.js
+++ b/packages/contenido-pipeline/index.js
@@ -1,0 +1,112 @@
+// Pipeline unified compartido del CMS "Contenidos" (design/cms-contenidos.html §3).
+// El MISMO pipeline renderiza el preview del editor (web) y el cuerpoHtml
+// publicado (api) — cero divergencia entre lo que se edita y lo que se sirve.
+//
+// Orden del pipeline (importa):
+//   remark-parse → remark-gfm → remark-directive → admonitions → remark-rehype
+//   → rehype-sanitize (allowlist) → rehype-highlight → rehype-stringify
+// Sanitizamos ANTES de highlight: así el HTML inline peligroso del autor se
+// elimina, y las clases que agrega highlight (código confiable) sobreviven.
+
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkDirective from 'remark-directive';
+import remarkRehype from 'remark-rehype';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+
+/** Tipos de admonition con paridad Docusaurus. */
+export const ADMONITION_TIPOS = ['note', 'tip', 'info', 'warning', 'danger', 'caution'];
+
+/**
+ * Plugin remark: convierte las directivas de contenedor `:::note Título`
+ * en la estructura de admonition (equivalente a las de Docusaurus):
+ *   <div class="admonition admonition-note">
+ *     <p class="admonition-titulo">Título</p>
+ *     …contenido…
+ *   </div>
+ */
+function remarkAdmonitions() {
+  return (tree) => {
+    visit(tree, 'containerDirective', (node) => {
+      if (!ADMONITION_TIPOS.includes(node.name)) return;
+
+      // El "label" de la directiva (:::note Título) llega como primer hijo
+      // marcado con directiveLabel; se convierte en el título del bloque.
+      let titulo = node.name;
+      const hijos = node.children ?? [];
+      if (hijos[0]?.data?.directiveLabel) {
+        const label = hijos.shift();
+        titulo = (label.children ?? [])
+          .map((c) => ('value' in c ? c.value : ''))
+          .join('')
+          .trim() || node.name;
+      }
+
+      node.children = [
+        {
+          type: 'paragraph',
+          data: { hName: 'p', hProperties: { className: ['admonition-titulo'] } },
+          children: [{ type: 'text', value: titulo }],
+        },
+        ...hijos,
+      ];
+      node.data = {
+        ...node.data,
+        hName: 'div',
+        hProperties: { className: ['admonition', `admonition-${node.name}`] },
+      };
+    });
+  };
+}
+
+// Allowlist: la default de rehype-sanitize + las clases que usa el pipeline
+// (admonitions y highlight). Todo lo demás (scripts, estilos, iframes,
+// handlers) se elimina — el HTML crudo de páginas tipo `html` NO pasa por
+// aquí: se sirve aparte, sandboxeado (US-5).
+const ESQUEMA_SANITIZE = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    div: [...(defaultSchema.attributes?.div ?? []), ['className', 'admonition', /^admonition-/]],
+    p: [...(defaultSchema.attributes?.p ?? []), ['className', 'admonition-titulo']],
+    code: [...(defaultSchema.attributes?.code ?? []), ['className', /^language-/]],
+  },
+};
+
+const procesador = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkDirective)
+  .use(remarkAdmonitions)
+  .use(remarkRehype)
+  .use(rehypeSanitize, ESQUEMA_SANITIZE)
+  .use(rehypeHighlight, { detect: false })
+  .use(rehypeStringify);
+
+// remark-directive exige el título entre corchetes (`:::note[Título]`), pero
+// Docusaurus usa `:::note Título` — y la paridad con esa sintaxis es requisito
+// de la migración (US-6). Normalizamos el estilo Docusaurus antes de parsear.
+const RE_ADMONITION_DOCUSAURUS = new RegExp(
+  `^([ \\t]*):::(${ADMONITION_TIPOS.join('|')})[ \\t]+([^\\[\\n{][^\\n]*)$`,
+  'gm',
+);
+
+function normalizarAdmonitions(cuerpo) {
+  return cuerpo.replace(RE_ADMONITION_DOCUSAURUS, (_m, sangria, tipo, titulo) => {
+    return `${sangria}:::${tipo}[${titulo.trim()}]`;
+  });
+}
+
+/**
+ * Renderiza Markdown (GFM + admonitions) a HTML sanitizado con highlight.
+ * @param {string} cuerpo - fuente Markdown
+ * @returns {Promise<string>} HTML listo para servir/mostrar
+ */
+export async function renderMarkdown(cuerpo) {
+  const archivo = await procesador.process(normalizarAdmonitions(cuerpo ?? ''));
+  return String(archivo);
+}

--- a/packages/contenido-pipeline/index.js
+++ b/packages/contenido-pipeline/index.js
@@ -35,22 +35,20 @@ function remarkAdmonitions() {
       if (!ADMONITION_TIPOS.includes(node.name)) return;
 
       // El "label" de la directiva (:::note Título) llega como primer hijo
-      // marcado con directiveLabel; se convierte en el título del bloque.
-      let titulo = node.name;
+      // marcado con directiveLabel; sus children se conservan tal cual como
+      // título — así el formato inline (**negritas**, `código`) sobrevive.
       const hijos = node.children ?? [];
+      let tituloChildren = [{ type: 'text', value: node.name }];
       if (hijos[0]?.data?.directiveLabel) {
         const label = hijos.shift();
-        titulo = (label.children ?? [])
-          .map((c) => ('value' in c ? c.value : ''))
-          .join('')
-          .trim() || node.name;
+        if (label.children?.length) tituloChildren = label.children;
       }
 
       node.children = [
         {
           type: 'paragraph',
           data: { hName: 'p', hProperties: { className: ['admonition-titulo'] } },
-          children: [{ type: 'text', value: titulo }],
+          children: tituloChildren,
         },
         ...hijos,
       ];
@@ -90,15 +88,39 @@ const procesador = unified()
 // remark-directive exige el título entre corchetes (`:::note[Título]`), pero
 // Docusaurus usa `:::note Título` — y la paridad con esa sintaxis es requisito
 // de la migración (US-6). Normalizamos el estilo Docusaurus antes de parsear.
+// Sangría máx. 3 espacios: con 4+ es bloque de código indentado (CommonMark).
 const RE_ADMONITION_DOCUSAURUS = new RegExp(
-  `^([ \\t]*):::(${ADMONITION_TIPOS.join('|')})[ \\t]+([^\\[\\n{][^\\n]*)$`,
-  'gm',
+  `^( {0,3}):::(${ADMONITION_TIPOS.join('|')})[ \\t]+([^\\[\\n{][^\\n]*)$`,
 );
+const RE_FENCE = /^ {0,3}(`{3,}|~{3,})/;
 
+/**
+ * Normaliza línea por línea, SALTANDO los bloques de código cercados: un
+ * tutorial que documenta la sintaxis `:::note Título` dentro de un fence
+ * debe mostrarse tal cual, no reescribirse.
+ */
 function normalizarAdmonitions(cuerpo) {
-  return cuerpo.replace(RE_ADMONITION_DOCUSAURUS, (_m, sangria, tipo, titulo) => {
-    return `${sangria}:::${tipo}[${titulo.trim()}]`;
-  });
+  let fence = null; // { char, len } del fence abierto
+  return cuerpo
+    .split('\n')
+    .map((linea) => {
+      const marca = linea.match(RE_FENCE);
+      if (marca) {
+        const char = marca[1][0];
+        const len = marca[1].length;
+        if (!fence) {
+          fence = { char, len };
+        } else if (char === fence.char && len >= fence.len && /^ {0,3}(`{3,}|~{3,})\s*$/.test(linea)) {
+          fence = null; // cierre del fence
+        }
+        return linea;
+      }
+      if (fence) return linea;
+      return linea.replace(RE_ADMONITION_DOCUSAURUS, (_m, sangria, tipo, titulo) => {
+        return `${sangria}:::${tipo}[${titulo.trim()}]`;
+      });
+    })
+    .join('\n');
 }
 
 /**

--- a/packages/contenido-pipeline/package.json
+++ b/packages/contenido-pipeline/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tc2005b/contenido-pipeline",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "description": "Pipeline unified compartido del CMS Contenidos: renderiza Markdown a HTML sanitizado (GFM, admonitions, highlight). Lo usan el API (al publicar) y el editor web (preview) para que lo editado y lo servido sean idénticos.",
+  "dependencies": {
+    "rehype-highlight": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.0",
+    "remark-directive": "^3.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.0.0",
+    "unified": "^11.0.0",
+    "unist-util-visit": "^5.0.0"
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,10 +9,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@codemirror/lang-html": "^6.4.0",
+    "@codemirror/lang-markdown": "^6.3.0",
+    "@codemirror/theme-one-dark": "^6.1.0",
+    "@codemirror/view": "^6.34.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-table": "^8.21.3",
+    "@tc2005b/contenido-pipeline": "0.1.0",
+    "@uiw/react-codemirror": "^4.23.0",
     "apexcharts": "^5.10.4",
     "exceljs": "^4.4.0",
     "jszip": "^3.10.1",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router';
 import Layout from './components/layout/Layout';
 import CalendarPage from './components/calendar/CalendarPage';
@@ -29,6 +29,12 @@ import PaginasPage from './components/dashboard/pages/PaginasPage/PaginasPage';
 import ContenidosPage from './components/dashboard/pages/ContenidosPage/ContenidosPage';
 import ColeccionDetailPage from './components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage';
 import { APP_NAME, APP_TAGLINE } from './config/app';
+
+// El editor carga CodeMirror + el pipeline de render: se divide del bundle
+// principal y solo se descarga al entrar a editar.
+const EditorContenidoPage = lazy(
+  () => import('./components/dashboard/pages/EditorContenidoPage/EditorContenidoPage'),
+);
 
 export default function App() {
   // Título del navegador como fuente única de verdad (el <title> de index.html
@@ -71,6 +77,14 @@ export default function App() {
         <Route path="admin/paginas" element={<PaginasPage />} />
         <Route path="admin/contenidos" element={<ContenidosPage />} />
         <Route path="admin/contenidos/:id" element={<ColeccionDetailPage />} />
+        <Route
+          path="admin/contenidos/:id/editar/:docId"
+          element={
+            <Suspense fallback={<p style={{ padding: 24 }}>Cargando editor…</p>}>
+              <EditorContenidoPage />
+            </Suspense>
+          }
+        />
       </Route>
 
       {/* Student dashboard */}

--- a/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.module.css
+++ b/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.module.css
@@ -237,3 +237,19 @@
   outline: none;
   border-color: var(--dash-primary);
 }
+
+.abrirEditor {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  background: var(--dash-primary);
+  color: #fff;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 600;
+}
+.abrirEditor:hover {
+  opacity: 0.92;
+}

--- a/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.tsx
@@ -39,15 +39,6 @@ export default function ColeccionDetailPage() {
   const [metaPlantilla, setMetaPlantilla] = useState<'' | DocumentoPlantilla>('');
   const [moverA, setMoverA] = useState('');
 
-  // Cuerpo (editor provisional; el editor rico llega en la US-2)
-  const [cuerpo, setCuerpo] = useState('');
-  const [cuerpoDirty, setCuerpoDirty] = useState(false);
-  const [cuerpoCargando, setCuerpoCargando] = useState(false);
-  // Si la carga del borrador falla, se BLOQUEA la edición: guardar sobre un
-  // editor vacío por error de red sobreescribiría el borrador real.
-  const [cuerpoError, setCuerpoError] = useState('');
-  const [guardandoCuerpo, setGuardandoCuerpo] = useState(false);
-
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'x-session-token': sessionToken ?? '',
@@ -111,36 +102,14 @@ export default function ColeccionDetailPage() {
     return out;
   }, [documentos, seleccionadoId]);
 
-  const cargarCuerpo = useCallback(async (docId: string): Promise<void> => {
-    setCuerpoCargando(true);
-    setCuerpoError('');
-    try {
-      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
-        headers: { 'x-session-token': sessionToken ?? '' },
-      });
-      if (!res.ok) throw new Error('No se pudo cargar el contenido');
-      const json = await res.json();
-      setCuerpo(json.cuerpo ?? '');
-    } catch {
-      // Bloquear la edición: guardar sobre un cuerpo no cargado perdería el borrador real.
-      setCuerpoError('No se pudo cargar el contenido. Reintenta antes de editar.');
-    } finally {
-      setCuerpoCargando(false);
-    }
-  }, [sessionToken]);
-
-  // Sincronizar panel + cargar cuerpo al seleccionar.
+  // Sincronizar el panel de metadatos al seleccionar (el cuerpo se edita en
+  // la página del editor: /admin/contenidos/:id/editar/:docId).
   useEffect(() => {
     if (!seleccionado) return;
     setMetaTitulo(seleccionado.titulo);
     setMetaSlug(seleccionado.slug);
     setMetaPlantilla(seleccionado.plantilla ?? '');
     setMoverA(seleccionado.padreId ?? '');
-    setCuerpo('');
-    setCuerpoDirty(false);
-    setCuerpoError('');
-    if (seleccionado.tipo === 'categoria') return;
-    cargarCuerpo(seleccionado.id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [seleccionadoId]);
 
@@ -244,20 +213,6 @@ export default function ColeccionDetailPage() {
     }
     setSeleccionadoId(null);
     await fetchDatos();
-  }
-
-  async function handleGuardarCuerpo() {
-    if (!seleccionado) return;
-    setGuardandoCuerpo(true);
-    setError('');
-    const err = await llamada(`${API_BASE}/admin/documentos/${seleccionado.id}/borrador`, 'PUT', { cuerpo });
-    setGuardandoCuerpo(false);
-    if (err) {
-      setError(err);
-      return;
-    }
-    setCuerpoDirty(false);
-    await fetchDatos(); // refresca el estado borrador del árbol
   }
 
   function renderNodo(nodo: DocumentoNodo, nivel: number) {
@@ -382,32 +337,16 @@ export default function ColeccionDetailPage() {
                       Cuerpo ({seleccionado.tipo === 'md' ? 'Markdown' : 'HTML'})
                     </span>
                     <span className={styles.editorEstado}>
-                      {cuerpoCargando ? 'Cargando…' : cuerpoError ? 'Sin cargar' : cuerpoDirty ? 'Cambios sin guardar' : 'Guardado'}
+                      {seleccionado.borradorId ? 'Borrador en curso' : seleccionado.publicado ? 'Publicada' : 'Sin contenido publicado'}
                     </span>
-                    <DashButton
-                      onClick={handleGuardarCuerpo}
-                      disabled={guardandoCuerpo || cuerpoCargando || !!cuerpoError || !cuerpoDirty}
-                    >
-                      {guardandoCuerpo ? 'Guardando…' : 'Guardar borrador'}
-                    </DashButton>
+                    <Link to={`/admin/contenidos/${id}/editar/${seleccionado.id}`} className={styles.abrirEditor}>
+                      <Icon name="edit_note" size="sm" />
+                      <span>Abrir editor</span>
+                    </Link>
                   </div>
-                  {cuerpoError ? (
-                    <div className={styles.error}>
-                      {cuerpoError}
-                      {' '}
-                      <DashButton variant="outline" onClick={() => cargarCuerpo(seleccionado.id)}>Reintentar</DashButton>
-                    </div>
-                  ) : (
-                    <textarea
-                      className={styles.textarea}
-                      value={cuerpo}
-                      onChange={(e) => { setCuerpo(e.target.value); setCuerpoDirty(true); }}
-                      disabled={cuerpoCargando}
-                      spellCheck={false}
-                      placeholder={seleccionado.tipo === 'md' ? '# Escribe el contenido en Markdown…' : '<!-- HTML crudo de la página -->'}
-                    />
-                  )}
-                  <p className={styles.hint}>Editor provisional — el editor con resaltado y preview llega en la siguiente iteración (US-2).</p>
+                  <p className={styles.hint}>
+                    El contenido se edita en el editor (resaltado, preview en vivo, publicar e historial).
+                  </p>
                 </div>
               )}
             </>

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
@@ -1,0 +1,327 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: calc(100vh - var(--dashboard-header-height) - 48px);
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.volver {
+  display: flex;
+  align-items: center;
+  color: var(--text-secondary);
+  padding: 6px;
+  border-radius: 8px;
+}
+.volver:hover {
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.tituloWrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.titulo {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.subtitulo {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.estado {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+.estadoError { color: var(--dash-danger); }
+
+.dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }
+.dot-guardado { background: var(--dash-success); }
+.dot-dirty { background: var(--dash-warning); }
+.dot-guardando { background: var(--dash-info); }
+.dot-cargando { background: var(--text-muted); }
+.dot-error { background: var(--dash-danger); }
+
+.error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  background: #fdecea;
+  color: var(--dash-danger);
+  border-radius: 8px;
+  font-size: 13.5px;
+}
+
+/* ── Toolbar ── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 6px 8px;
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+}
+.toolbar button {
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.toolbar button:hover {
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+.sep {
+  width: 1px;
+  height: 18px;
+  background: var(--border-color);
+  margin: 0 4px;
+}
+.atajos {
+  margin-left: auto;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* ── Split fuente/preview ── */
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+@media (max-width: 900px) {
+  .split { grid-template-columns: 1fr; }
+}
+
+.fuente {
+  min-width: 0;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+}
+.codemirror {
+  flex: 1;
+  overflow: auto;
+  font-size: 13px;
+}
+.fuente :global(.cm-editor) {
+  height: 100%;
+}
+
+.preview {
+  min-width: 0;
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 18px 22px;
+  overflow-y: auto;
+}
+
+.hint {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+/* ── Preview: tipografía del contenido renderizado ── */
+.previewCuerpo {
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+.previewCuerpo h1 { font-size: 24px; margin: 0 0 12px; }
+.previewCuerpo h2 { font-size: 19px; margin: 22px 0 8px; }
+.previewCuerpo h3 { font-size: 16px; margin: 18px 0 6px; }
+.previewCuerpo p { margin: 10px 0; }
+.previewCuerpo a { color: var(--sidebar-active-color); }
+.previewCuerpo img { max-width: 100%; border-radius: 8px; }
+.previewCuerpo table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: 13.5px;
+}
+.previewCuerpo th,
+.previewCuerpo td {
+  border: 1px solid var(--border-color);
+  padding: 6px 12px;
+  text-align: left;
+}
+.previewCuerpo th { background: var(--bg-page); }
+.previewCuerpo code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12.5px;
+  background: var(--bg-page);
+  padding: 1px 6px;
+  border-radius: 5px;
+}
+.previewCuerpo pre {
+  background: #0f172a;
+  color: #dbe4f0;
+  padding: 12px 14px;
+  border-radius: 10px;
+  overflow-x: auto;
+}
+.previewCuerpo pre code {
+  background: none;
+  padding: 0;
+  color: inherit;
+}
+.previewCuerpo blockquote {
+  margin: 12px 0;
+  padding: 4px 14px;
+  border-left: 3px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+/* Admonitions (mismas clases que emite el pipeline) */
+.previewCuerpo :global(.admonition) {
+  border-left: 4px solid var(--dash-info);
+  background: #eff6ff;
+  border-radius: 0 8px 8px 0;
+  padding: 10px 14px;
+  margin: 12px 0;
+}
+.previewCuerpo :global(.admonition-titulo) {
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+.previewCuerpo :global(.admonition-note) { border-color: var(--dash-info); background: #eff6ff; }
+.previewCuerpo :global(.admonition-tip),
+.previewCuerpo :global(.admonition-info) { border-color: var(--dash-success); background: #ecfdf5; }
+.previewCuerpo :global(.admonition-warning),
+.previewCuerpo :global(.admonition-caution) { border-color: var(--dash-warning); background: #fffbeb; }
+.previewCuerpo :global(.admonition-danger) { border-color: var(--dash-danger); background: #fef2f2; }
+
+/* Highlight (clases hljs del pipeline; tema oscuro sobre el pre oscuro) */
+.previewCuerpo :global(.hljs-keyword) { color: #7dd3fc; }
+.previewCuerpo :global(.hljs-string) { color: #86efac; }
+.previewCuerpo :global(.hljs-number) { color: #fbbf24; }
+.previewCuerpo :global(.hljs-comment) { color: #64748b; font-style: italic; }
+.previewCuerpo :global(.hljs-title) { color: #c4b5fd; }
+.previewCuerpo :global(.hljs-attr),
+.previewCuerpo :global(.hljs-attribute) { color: #fda4af; }
+.previewCuerpo :global(.hljs-built_in),
+.previewCuerpo :global(.hljs-literal) { color: #fbbf24; }
+.previewCuerpo :global(.hljs-tag) { color: #94a3b8; }
+.previewCuerpo :global(.hljs-name) { color: #7dd3fc; }
+
+/* ── Modales ── */
+.modalCuerpo {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.campo {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+.input {
+  padding: 9px 11px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--sidebar-bg);
+  font-size: 14px;
+  color: var(--text-primary);
+  font-family: inherit;
+}
+.input:focus {
+  outline: none;
+  border-color: var(--dash-primary);
+}
+.modalAcciones {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.versiones {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 380px;
+  overflow-y: auto;
+}
+.version {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+}
+.versionInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.versionMeta {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+.versionAcciones {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.pill {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.pillPub { background: #e8f5e9; color: #2e7d32; }
+.pillBorr { background: #fff3e0; color: #e65100; }
+
+.verBarra {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.verCuerpo {
+  max-height: 380px;
+  overflow: auto;
+  background: var(--bg-page);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 12.5px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -61,6 +61,18 @@ export default function EditorContenidoPage() {
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const estadoRef = useRef(estado);
   estadoRef.current = estado;
+  const documentoRef = useRef(documento);
+  documentoRef.current = documento;
+  // Single-flight: nunca dos PUT de borrador en paralelo (dos escrituras
+  // concurrentes sobre un documento sin borrador duplicarían versiones).
+  const saveEnVuelo = useRef<Promise<boolean> | null>(null);
+
+  function cancelarAutosave() {
+    if (autosaveTimer.current) {
+      clearTimeout(autosaveTimer.current);
+      autosaveTimer.current = null;
+    }
+  }
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -92,25 +104,41 @@ export default function EditorContenidoPage() {
 
   useEffect(() => {
     cargar();
+    // Al cambiar de documento (o desmontar), un timer pendiente del documento
+    // ANTERIOR escribiría el cuerpo del nuevo en el borrador equivocado.
+    return () => cancelarAutosave();
   }, [cargar]);
 
   /* ── Autosave debounced a borrador único ── */
   const guardar = useCallback(async (): Promise<boolean> => {
-    if (!docId) return false;
-    setEstado('guardando');
+    // Guardas anti-pérdida: sin documento cargado NO se guarda (un PUT con el
+    // editor vacío pisaría el borrador real del servidor).
+    if (!docId || !documentoRef.current) return false;
+    // Single-flight: esperar el PUT en vuelo y luego guardar lo más reciente.
+    if (saveEnVuelo.current) await saveEnVuelo.current.catch(() => {});
+
+    const vuelo = (async () => {
+      setEstado('guardando');
+      try {
+        const res = await fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({ cuerpo: cuerpoRef.current }),
+        });
+        if (!res.ok) throw new Error();
+        setEstado('guardado');
+        return true;
+      } catch {
+        setEstado('error');
+        setError('No se pudo guardar el borrador. Reintenta (⌘S).');
+        return false;
+      }
+    })();
+    saveEnVuelo.current = vuelo;
     try {
-      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
-        method: 'PUT',
-        headers,
-        body: JSON.stringify({ cuerpo: cuerpoRef.current }),
-      });
-      if (!res.ok) throw new Error();
-      setEstado('guardado');
-      return true;
-    } catch {
-      setEstado('error');
-      setError('No se pudo guardar el borrador. Reintenta (⌘S).');
-      return false;
+      return await vuelo;
+    } finally {
+      saveEnVuelo.current = null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [docId, sessionToken]);
@@ -119,7 +147,7 @@ export default function EditorContenidoPage() {
     setCuerpo(valor);
     setEstado('dirty');
     setError('');
-    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    cancelarAutosave();
     autosaveTimer.current = setTimeout(() => { guardar(); }, AUTOSAVE_MS);
   }
 
@@ -142,17 +170,22 @@ export default function EditorContenidoPage() {
     return () => clearTimeout(timer);
   }, [cuerpo, esMd]);
 
-  /* ── Atajos: ⌘S guardar · ⌘⇧P publicar ── */
+  /* ── Atajos: ⌘S guardar · ⌘⇧P publicar ──
+     Mismas guardas que los botones: sin documento cargado (o cargando/error
+     de carga) NO se guarda ni publica — un PUT con el editor vacío pisaría
+     el borrador real. */
   function onKeyDown(e: React.KeyboardEvent) {
     const mod = e.metaKey || e.ctrlKey;
     if (!mod) return;
     if (e.key.toLowerCase() === 's' && !e.shiftKey) {
       e.preventDefault();
-      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+      if (!documento || estado === 'cargando') return;
+      cancelarAutosave();
       guardar();
     }
     if (e.key.toLowerCase() === 'p' && e.shiftKey) {
       e.preventDefault();
+      if (!documento || estado === 'cargando' || estado === 'error') return;
       abrirPublicar();
     }
   }
@@ -183,13 +216,14 @@ export default function EditorContenidoPage() {
   }
 
   async function publicar() {
-    if (!docId) return;
+    if (!docId || !documento) return;
     setPublicando(true);
     setPublicarError('');
     try {
-      // Asegurar que lo visible en pantalla es lo que se publica.
+      // Asegurar que lo visible en pantalla es lo que se publica. `guardar`
+      // es single-flight: si hay un autosave en vuelo, espera y reenvía lo último.
       if (estadoRef.current !== 'guardado') {
-        if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+        cancelarAutosave();
         const ok = await guardar();
         if (!ok) throw new Error('No se pudo guardar el borrador antes de publicar');
       }
@@ -245,6 +279,10 @@ export default function EditorContenidoPage() {
 
   async function restaurarVersion(v: VersionInfo) {
     if (!confirm(`¿Restaurar la v${v.numero} al borrador? El contenido actual del borrador se reemplaza.`)) return;
+    // Un autosave pendiente (timer) o en vuelo (PUT) aterrizaría DESPUÉS del
+    // restore y pisaría el borrador restaurado.
+    cancelarAutosave();
+    if (saveEnVuelo.current) await saveEnVuelo.current.catch(() => {});
     setHistorialError('');
     try {
       const res = await fetch(`${API_BASE}/admin/documentos/${docId}/versiones/${v.id}/restaurar`, {

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, Link } from 'react-router';
+import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
+import { markdown } from '@codemirror/lang-markdown';
+import { html } from '@codemirror/lang-html';
+import { oneDark } from '@codemirror/theme-one-dark';
+import { EditorView } from '@codemirror/view';
+import { renderMarkdown } from '@tc2005b/contenido-pipeline';
+import { useAuth } from '../../../../context/AuthContext';
+import Modal from '../../atoms/Modal/Modal';
+import Icon from '../../atoms/Icon/Icon';
+import DashButton from '../../atoms/DashButton/DashButton';
+import type { DocumentoData } from '../../../../types/contenidos';
+import styles from './EditorContenidoPage.module.css';
+
+const API_BASE = '/api';
+const AUTOSAVE_MS = 1500;
+const PREVIEW_MS = 300;
+
+type EstadoGuardado = 'cargando' | 'guardado' | 'dirty' | 'guardando' | 'error';
+
+interface VersionInfo {
+  id: string;
+  numero: number;
+  mensaje: string | null;
+  autor: { id: string; name: string | null } | null;
+  esBorrador: boolean;
+  esPublicada: boolean;
+  createdAt: string;
+}
+
+/**
+ * Editor del CMS "Contenidos" (design §3): CodeMirror + preview en vivo con
+ * el MISMO pipeline unified que renderiza al publicar — WYSIWYG real.
+ * Autosave a borrador único; publicar congela una versión; historial/restaurar.
+ */
+export default function EditorContenidoPage() {
+  const { id, docId } = useParams<{ id: string; docId: string }>();
+  const { sessionToken } = useAuth();
+  const editorRef = useRef<ReactCodeMirrorRef>(null);
+
+  const [documento, setDocumento] = useState<DocumentoData | null>(null);
+  const [cuerpo, setCuerpo] = useState('');
+  const [estado, setEstado] = useState<EstadoGuardado>('cargando');
+  const [error, setError] = useState('');
+  const [previewHtml, setPreviewHtml] = useState('');
+
+  const [publicarOpen, setPublicarOpen] = useState(false);
+  const [mensajePublicar, setMensajePublicar] = useState('');
+  const [publicando, setPublicando] = useState(false);
+  const [publicarError, setPublicarError] = useState('');
+
+  const [historialOpen, setHistorialOpen] = useState(false);
+  const [versiones, setVersiones] = useState<VersionInfo[]>([]);
+  const [historialError, setHistorialError] = useState('');
+  const [verCuerpo, setVerCuerpo] = useState<{ numero: number; cuerpo: string } | null>(null);
+
+  // El autosave usa refs para leer el estado más reciente sin recrear timers.
+  const cuerpoRef = useRef(cuerpo);
+  cuerpoRef.current = cuerpo;
+  const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const estadoRef = useRef(estado);
+  estadoRef.current = estado;
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-session-token': sessionToken ?? '',
+  };
+
+  /* ── Carga inicial: el editor queda bloqueado hasta tener el cuerpo real ── */
+  const cargar = useCallback(async () => {
+    if (!docId) return;
+    setEstado('cargando');
+    setError('');
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'No se pudo cargar el documento');
+      }
+      const json = await res.json();
+      setDocumento(json.documento);
+      setCuerpo(json.cuerpo ?? '');
+      setEstado('guardado');
+    } catch (err: any) {
+      setError(err.message);
+      setEstado('error');
+    }
+  }, [docId, sessionToken]);
+
+  useEffect(() => {
+    cargar();
+  }, [cargar]);
+
+  /* ── Autosave debounced a borrador único ── */
+  const guardar = useCallback(async (): Promise<boolean> => {
+    if (!docId) return false;
+    setEstado('guardando');
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ cuerpo: cuerpoRef.current }),
+      });
+      if (!res.ok) throw new Error();
+      setEstado('guardado');
+      return true;
+    } catch {
+      setEstado('error');
+      setError('No se pudo guardar el borrador. Reintenta (⌘S).');
+      return false;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [docId, sessionToken]);
+
+  function onCambio(valor: string) {
+    setCuerpo(valor);
+    setEstado('dirty');
+    setError('');
+    if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+    autosaveTimer.current = setTimeout(() => { guardar(); }, AUTOSAVE_MS);
+  }
+
+  // Aviso al salir con cambios sin guardar.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (estadoRef.current === 'dirty' || estadoRef.current === 'guardando') e.preventDefault();
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  /* ── Preview en vivo (solo Markdown; el HTML crudo se sirve sandboxeado en US-5) ── */
+  const esMd = documento?.tipo === 'md';
+  useEffect(() => {
+    if (!esMd) return;
+    const timer = setTimeout(() => {
+      renderMarkdown(cuerpo).then(setPreviewHtml).catch(() => {});
+    }, PREVIEW_MS);
+    return () => clearTimeout(timer);
+  }, [cuerpo, esMd]);
+
+  /* ── Atajos: ⌘S guardar · ⌘⇧P publicar ── */
+  function onKeyDown(e: React.KeyboardEvent) {
+    const mod = e.metaKey || e.ctrlKey;
+    if (!mod) return;
+    if (e.key.toLowerCase() === 's' && !e.shiftKey) {
+      e.preventDefault();
+      if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+      guardar();
+    }
+    if (e.key.toLowerCase() === 'p' && e.shiftKey) {
+      e.preventDefault();
+      abrirPublicar();
+    }
+  }
+
+  /* ── Toolbar: insertar snippets en el cursor ── */
+  function insertar(antes: string, despues = '', relleno = '') {
+    const view = editorRef.current?.view;
+    if (!view) return;
+    const { from, to } = view.state.selection.main;
+    const seleccion = view.state.sliceDoc(from, to) || relleno;
+    const texto = `${antes}${seleccion}${despues}`;
+    view.dispatch({
+      changes: { from, to, insert: texto },
+      selection: { anchor: from + antes.length, head: from + antes.length + seleccion.length },
+    });
+    view.focus();
+  }
+
+  const SNIPPET_TABLA = '\n| Columna | Columna |\n| ------- | ------- |\n|         |         |\n';
+  const SNIPPET_ADMONITION = '\n:::note Título\nContenido.\n:::\n';
+  const SNIPPET_CODIGO = '\n```js\n// código\n```\n';
+
+  /* ── Publicar ── */
+  function abrirPublicar() {
+    setMensajePublicar('');
+    setPublicarError('');
+    setPublicarOpen(true);
+  }
+
+  async function publicar() {
+    if (!docId) return;
+    setPublicando(true);
+    setPublicarError('');
+    try {
+      // Asegurar que lo visible en pantalla es lo que se publica.
+      if (estadoRef.current !== 'guardado') {
+        if (autosaveTimer.current) clearTimeout(autosaveTimer.current);
+        const ok = await guardar();
+        if (!ok) throw new Error('No se pudo guardar el borrador antes de publicar');
+      }
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/publicar`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ mensaje: mensajePublicar.trim() || undefined }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'Error al publicar');
+      }
+      const json = await res.json();
+      setDocumento(json.documento);
+      setPublicarOpen(false);
+    } catch (err: any) {
+      setPublicarError(err.message);
+    } finally {
+      setPublicando(false);
+    }
+  }
+
+  /* ── Historial ── */
+  async function abrirHistorial() {
+    setHistorialError('');
+    setVerCuerpo(null);
+    setHistorialOpen(true);
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/versiones`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) throw new Error('No se pudo cargar el historial');
+      const json = await res.json();
+      setVersiones(json.versiones ?? []);
+    } catch (err: any) {
+      setHistorialError(err.message);
+    }
+  }
+
+  async function verVersion(v: VersionInfo) {
+    setHistorialError('');
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/versiones/${v.id}`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) throw new Error('No se pudo cargar la versión');
+      const json = await res.json();
+      setVerCuerpo({ numero: v.numero, cuerpo: json.version?.cuerpo ?? '' });
+    } catch (err: any) {
+      setHistorialError(err.message);
+    }
+  }
+
+  async function restaurarVersion(v: VersionInfo) {
+    if (!confirm(`¿Restaurar la v${v.numero} al borrador? El contenido actual del borrador se reemplaza.`)) return;
+    setHistorialError('');
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}/versiones/${v.id}/restaurar`, {
+        method: 'POST',
+        headers,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'No se pudo restaurar');
+      }
+      const json = await res.json();
+      setCuerpo(json.cuerpo ?? '');
+      setEstado('guardado'); // el borrador restaurado YA está en el servidor
+      setHistorialOpen(false);
+    } catch (err: any) {
+      setHistorialError(err.message);
+    }
+  }
+
+  const ESTADO_LABEL: Record<EstadoGuardado, string> = {
+    cargando: 'Cargando…',
+    guardado: 'Borrador guardado',
+    dirty: 'Cambios sin guardar',
+    guardando: 'Guardando…',
+    error: 'Error al guardar',
+  };
+
+  function formatFecha(iso: string): string {
+    return new Date(iso).toLocaleString('es-MX', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+  }
+
+  return (
+    <div className={styles.page} onKeyDown={onKeyDown}>
+      <div className={styles.header}>
+        <Link to={`/admin/contenidos/${id}`} className={styles.volver}>
+          <Icon name="arrow_back" size="sm" />
+        </Link>
+        <div className={styles.tituloWrap}>
+          <span className={styles.titulo} title={documento?.titulo}>{documento?.titulo ?? '…'}</span>
+          <span className={styles.subtitulo}>
+            {documento?.tipo === 'html' ? 'HTML crudo' : 'Markdown'}
+            {documento?.publicado ? ' · publicada' : ' · sin publicar'}
+          </span>
+        </div>
+        <span className={`${styles.estado} ${estado === 'error' ? styles.estadoError : ''}`}>
+          <span className={`${styles.dot} ${styles[`dot-${estado}`]}`} />
+          {ESTADO_LABEL[estado]}
+        </span>
+        <DashButton variant="outline" onClick={abrirHistorial}>🕘 Historial</DashButton>
+        <DashButton onClick={abrirPublicar} disabled={estado === 'cargando' || estado === 'error'}>
+          Publicar
+        </DashButton>
+      </div>
+
+      {error && (
+        <div className={styles.error}>
+          {error}
+          {estado === 'error' && !documento && (
+            <DashButton variant="outline" onClick={cargar}>Reintentar</DashButton>
+          )}
+        </div>
+      )}
+
+      {esMd && (
+        <div className={styles.toolbar}>
+          <button type="button" title="Negritas" onClick={() => insertar('**', '**', 'texto')}><b>B</b></button>
+          <button type="button" title="Cursivas" onClick={() => insertar('*', '*', 'texto')}><i>I</i></button>
+          <button type="button" title="Encabezado" onClick={() => insertar('\n## ', '', 'Encabezado')}>H2</button>
+          <span className={styles.sep} />
+          <button type="button" title="Código en línea" onClick={() => insertar('`', '`', 'código')}>{'</>'}</button>
+          <button type="button" title="Bloque de código" onClick={() => insertar(SNIPPET_CODIGO)}>{ '```' }</button>
+          <button type="button" title="Enlace" onClick={() => insertar('[', '](https://)', 'texto')}>🔗</button>
+          <button type="button" title="Tabla" onClick={() => insertar(SNIPPET_TABLA)}>▦ Tabla</button>
+          <button type="button" title="Admonition" onClick={() => insertar(SNIPPET_ADMONITION)}>💡 Nota</button>
+          <span className={styles.atajos}>⌘S guardar · ⌘⇧P publicar</span>
+        </div>
+      )}
+
+      <div className={styles.split}>
+        <div className={styles.fuente}>
+          <CodeMirror
+            ref={editorRef}
+            value={cuerpo}
+            onChange={onCambio}
+            editable={documento !== null && estado !== 'cargando'}
+            theme={oneDark}
+            extensions={[esMd ? markdown() : html(), EditorView.lineWrapping]}
+            basicSetup={{ foldGutter: true, highlightActiveLine: true }}
+            className={styles.codemirror}
+          />
+        </div>
+        {esMd ? (
+          <div className={styles.preview}>
+            {/* Seguro: previewHtml SIEMPRE sale de renderMarkdown(), cuyo pipeline
+                aplica rehype-sanitize (allowlist) — scripts/handlers/iframes se
+                eliminan. Es el mismo HTML que servirá producción (design §3). */}
+            <div className={styles.previewCuerpo} dangerouslySetInnerHTML={{ __html: previewHtml }} />
+          </div>
+        ) : (
+          <div className={styles.preview}>
+            <p className={styles.hint}>
+              Las páginas HTML se muestran sandboxeadas en el visor (iframe aislado, US-5) — sin preview en vivo aquí.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* ── Modal publicar ── */}
+      <Modal isOpen={publicarOpen} onClose={() => setPublicarOpen(false)} title="Publicar versión">
+        <div className={styles.modalCuerpo}>
+          {publicarError && <div className={styles.error}>{publicarError}</div>}
+          <p className={styles.hint}>
+            Se congela el borrador como la nueva versión publicada (los alumnos con acceso la verán en el visor).
+          </p>
+          <label className={styles.campo}>
+            <span>¿Qué cambió? (opcional)</span>
+            <input
+              className={styles.input}
+              value={mensajePublicar}
+              onChange={(e) => setMensajePublicar(e.target.value)}
+              placeholder="p. ej. nuevo ejercicio de flexbox"
+              disabled={publicando}
+            />
+          </label>
+          <div className={styles.modalAcciones}>
+            <DashButton variant="outline" onClick={() => setPublicarOpen(false)} disabled={publicando}>
+              Cancelar
+            </DashButton>
+            <DashButton onClick={publicar} disabled={publicando}>
+              {publicando ? 'Publicando…' : 'Publicar'}
+            </DashButton>
+          </div>
+        </div>
+      </Modal>
+
+      {/* ── Modal historial ── */}
+      <Modal isOpen={historialOpen} onClose={() => setHistorialOpen(false)} title="Historial de versiones">
+        <div className={styles.modalCuerpo}>
+          {historialError && <div className={styles.error}>{historialError}</div>}
+          {verCuerpo ? (
+            <>
+              <div className={styles.verBarra}>
+                <b>v{verCuerpo.numero}</b>
+                <DashButton variant="outline" onClick={() => setVerCuerpo(null)}>← Volver al historial</DashButton>
+              </div>
+              <pre className={styles.verCuerpo}>{verCuerpo.cuerpo}</pre>
+            </>
+          ) : versiones.length === 0 ? (
+            <p className={styles.hint}>Sin versiones todavía.</p>
+          ) : (
+            <div className={styles.versiones}>
+              {versiones.map((v) => (
+                <div key={v.id} className={styles.version}>
+                  <div className={styles.versionInfo}>
+                    <b>v{v.numero}</b>
+                    {v.esBorrador && <span className={`${styles.pill} ${styles.pillBorr}`}>borrador</span>}
+                    {v.esPublicada && <span className={`${styles.pill} ${styles.pillPub}`}>publicada</span>}
+                    <span className={styles.versionMeta}>
+                      {v.autor?.name ?? '—'} · {formatFecha(v.createdAt)}
+                      {v.mensaje ? ` · "${v.mensaje}"` : ''}
+                    </span>
+                  </div>
+                  <div className={styles.versionAcciones}>
+                    <DashButton variant="outline" onClick={() => verVersion(v)}>Ver</DashButton>
+                    {!v.esBorrador && (
+                      <DashButton variant="outline" onClick={() => restaurarVersion(v)}>Restaurar</DashButton>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,6 +1206,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
+"@babel/runtime@^7.18.6":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.28.6.tgz#0e7e56ecedb78aeef66ce7972b082fce76a23e57"
@@ -1235,6 +1240,135 @@
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
+
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.7.1":
+  version "6.20.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz#696b740312c6a962e14567b49a3661b5924bc5ae"
+  integrity sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0", "@codemirror/commands@^6.1.0":
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.4.tgz#64dec1bd043976eb344e3cc9d15af13b6f724bfd"
+  integrity sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.7.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-css@^6.0.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
+  integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-html@^6.0.0", "@codemirror/lang-html@^6.4.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
+
+"@codemirror/lang-javascript@^6.0.0":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz#b9ea6b2f0383ed6895fae7888c0322541538f10a"
+  integrity sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/lang-markdown@^6.3.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz#29df87310a555b007beba8e12893363956a26e8e"
+  integrity sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.7.1"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.3.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.2.1"
+    "@lezer/markdown" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.4.tgz#01e70fd5aa3a8a067ff1dfec75d5b6394cdfa058"
+  integrity sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.7.tgz#841fc733674389d91fe49a1c34027ad3babdf105"
+  integrity sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.42.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.7.1.tgz#2523a762871d18ad982edc2d4b2fa1da483b0392"
+  integrity sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.37.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.1", "@codemirror/state@^6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.7.0.tgz#624c3504dc3d04e727dd49711fb75244e675e8e7"
+  integrity sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/theme-one-dark@^6.0.0", "@codemirror/theme-one-dark@^6.1.0":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz#1dbb73f6e73c53c12ad2aed9f48c263c4e63ea37"
+  integrity sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.34.0", "@codemirror/view@^6.37.0", "@codemirror/view@^6.42.0":
+  version "6.43.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.4.tgz#a903200d489aa0e14406435c08e836680951ed5a"
+  integrity sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==
+  dependencies:
+    "@codemirror/state" "^6.7.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -3050,6 +3184,65 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
 
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
+"@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.4.tgz#ba05a03d5ca114ad523aa3c0e93aff8d1e26ed70"
+  integrity sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.13.tgz#6a1305ae3bd2c9c01f877f8a8dc1e15ec652d01c"
+  integrity sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.4.tgz#11746955f957d33c0933f17d7594db54a8b4beea"
+  integrity sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.6.4.tgz#250d54e1c4e59e89be9329884141f76165d66327"
+  integrity sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==
+  dependencies:
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz#bdbe907e00c17c84e33fc51b1519d9aa211e7e8e"
+  integrity sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==
+
 "@mdx-js/mdx@^3.0.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-3.1.1.tgz#c5ffd991a7536b149e17175eee57a1a2a511c6d1"
@@ -4404,6 +4597,31 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@uiw/codemirror-extensions-basic-setup@4.25.10":
+  version "4.25.10"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.10.tgz#6c26ffed8e06094f3a27efb88977374e5b24c971"
+  integrity sha512-P3vytLlpE62KYSWrMUnwDCv2lvaQDuDZzyj03mHntuHo5bSl34fRZpjTY3kQTPGuXHxkGSYpoPFFj+hMTqaaMQ==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
+"@uiw/react-codemirror@^4.23.0":
+  version "4.25.10"
+  resolved "https://registry.yarnpkg.com/@uiw/react-codemirror/-/react-codemirror-4.25.10.tgz#7a590bda3ee123c9d091b6396283e6fec62f1ed5"
+  integrity sha512-DzgSMwM5qzB7v1FIb4gEeriYt67iiay756/HIOM9mAbeOVK0MO7rqefHf0O5c0269pJKMW7AH9FjclExD23V9w==
+  dependencies:
+    "@babel/runtime" "^7.18.6"
+    "@codemirror/commands" "^6.1.0"
+    "@codemirror/state" "^6.1.1"
+    "@codemirror/theme-one-dark" "^6.0.0"
+    "@uiw/codemirror-extensions-basic-setup" "4.25.10"
+    codemirror "^6.0.0"
+
 "@ungap/structured-clone@^1.0.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
@@ -5608,6 +5826,19 @@ cluster-key-slot@1.1.2:
   resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
+codemirror@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.2.tgz#4d3fea1ad60b6753f97ca835f2f48c6936a8946e"
+  integrity sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 codepage@~1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
@@ -5947,6 +6178,11 @@ crc32-stream@^4.0.2:
   dependencies:
     crc-32 "^1.2.0"
     readable-stream "^3.4.0"
+
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.7.tgz#3b441b2ddfa73161d6a2770aa4cd677f895eaf28"
+  integrity sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==
 
 cross-inspect@1.0.1:
   version "1.0.1"
@@ -7845,6 +8081,13 @@ hast-util-from-parse5@^8.0.0:
     vfile-location "^5.0.0"
     web-namespaces "^2.0.0"
 
+hast-util-is-element@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz#6e31a6532c217e5b533848c7e52c9d9369ca0932"
+  integrity sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
 hast-util-parse-selector@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
@@ -7871,6 +8114,15 @@ hast-util-raw@^9.0.0:
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
 
+hast-util-sanitize@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz#edb260d94e5bba2030eb9375790a8753e5bf391f"
+  integrity sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    unist-util-position "^5.0.0"
+
 hast-util-to-estree@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz#e654c1c9374645135695cc0ab9f70b8fcaf733d7"
@@ -7892,6 +8144,23 @@ hast-util-to-estree@^3.0.0:
     style-to-js "^1.0.0"
     unist-util-position "^5.0.0"
     zwitch "^2.0.0"
+
+hast-util-to-html@^9.0.0:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz#ccc673a55bb8e85775b08ac28380f72d47167005"
+  integrity sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    ccount "^2.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-whitespace "^3.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    stringify-entities "^4.0.0"
+    zwitch "^2.0.4"
 
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
@@ -7927,6 +8196,16 @@ hast-util-to-parse5@^8.0.0:
     web-namespaces "^2.0.0"
     zwitch "^2.0.0"
 
+hast-util-to-text@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz#57b676931e71bf9cb852453678495b3080bfae3e"
+  integrity sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    hast-util-is-element "^3.0.0"
+    unist-util-find-after "^5.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
@@ -7949,6 +8228,11 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+highlight.js@~11.11.0:
+  version "11.11.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
+  integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
 history@^4.9.0:
   version "4.10.1"
@@ -9125,6 +9409,15 @@ lowercase-keys@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
   integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
+
+lowlight@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-3.3.0.tgz#007b8a5bfcfd27cc65b96246d2de3e9dd4e23c6c"
+  integrity sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    devlop "^1.0.0"
+    highlight.js "~11.11.0"
 
 lru-cache@10.4.0:
   version "10.4.0"
@@ -11883,6 +12176,17 @@ regjsparser@^0.13.0:
   dependencies:
     jsesc "~3.1.0"
 
+rehype-highlight@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-highlight/-/rehype-highlight-7.0.2.tgz#997e05e3a336853f6f6b2cfc450c5dad0f960b07"
+  integrity sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-to-text "^4.0.0"
+    lowlight "^3.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+
 rehype-raw@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
@@ -11900,6 +12204,23 @@ rehype-recma@^1.0.0:
     "@types/estree" "^1.0.0"
     "@types/hast" "^3.0.0"
     hast-util-to-estree "^3.0.0"
+
+rehype-sanitize@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz#16e95f4a67a69cbf0f79e113c8e0df48203db73c"
+  integrity sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-sanitize "^5.0.0"
+
+rehype-stringify@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-10.0.1.tgz#2ec1ebc56c6aba07905d3b4470bdf0f684f30b75"
+  integrity sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-to-html "^9.0.0"
+    unified "^11.0.0"
 
 relateurl@^0.2.7:
   version "0.2.7"
@@ -12852,6 +13173,11 @@ stubs@^3.0.0:
   resolved "https://registry.yarnpkg.com/stubs/-/stubs-3.0.0.tgz#e8d2ba1fa9c90570303c030b6900f7d5f89abe5b"
   integrity sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==
 
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
 style-to-js@^1.0.0:
   version "1.1.21"
   resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.21.tgz#2908941187f857e79e28e9cd78008b9a0b3e0e8d"
@@ -13278,6 +13604,14 @@ unique-string@^3.0.0:
   dependencies:
     crypto-random-string "^4.0.0"
 
+unist-util-find-after@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz#3fccc1b086b56f34c8b798e1ff90b5c54468e896"
+  integrity sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
 unist-util-is@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-6.0.1.tgz#d0a3f86f2dd0db7acd7d8c2478080b5c67f9c6a9"
@@ -13594,6 +13928,11 @@ vitest@^3.1.0:
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
     vite-node "3.2.4"
     why-is-node-running "^2.3.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 watchpack@^2.5.1:
   version "2.5.1"
@@ -14063,7 +14402,7 @@ zip-stream@^4.1.0:
     compress-commons "^4.1.2"
     readable-stream "^3.6.0"
 
-zwitch@^2.0.0:
+zwitch@^2.0.0, zwitch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-2.0.4.tgz#c827d4b0acb76fc3e685a4c6ec2902d51070e9d7"
   integrity sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==


### PR DESCRIPTION
## Descripción

**US-2 del roadmap del CMS "Contenidos"** (`design/cms-contenidos.html` §3/§8): el editor que sustituye la flexibilidad de VS Code. Reemplaza el textarea provisional de la US-1 por un editor CodeMirror 6 con preview en vivo, autosave, publicación con versionado e historial con restaurar. Incluye ya los fixes del code review (10 hallazgos, detalle en comentario).

## Cambios

### Pipeline compartido (`packages/contenido-pipeline`, nuevo workspace)
- `renderMarkdown()`: `remark-parse → remark-gfm → remark-directive → admonitions → remark-rehype → rehype-sanitize (allowlist) → rehype-highlight`.
- **Admonitions con paridad Docusaurus**: `:::note Título` se normaliza a remark-directive, **saltando bloques de código cercados** y respetando código indentado; títulos con formato inline (**negritas**, `código`) se conservan.
- Sanitiza ANTES de highlight. Verificado: `<script>`/`onerror` eliminados; GFM, highlight y 3 sintaxis de admonition intactos.
- **El mismo pipeline corre en el API (publicar) y en el editor (preview)** — WYSIWYG real.

### API (`packages/api`)
- `POST /admin/documentos/:docId/publicar` — congela el borrador como versión nueva (numera, renderiza `cuerpoHtml` en `md`; el `html` crudo se servirá sandboxeado en US-5) y limpia el borrador.
- `GET .../versiones` (solo metadatos, con `select`) y `GET .../versiones/:versionId` (con cuerpo).
- `POST .../versiones/:versionId/restaurar` — copia la versión vieja **al borrador** (el pasado nunca se muta).
- `asegurarBorrador()`: único punto de creación de borradores, con re-lectura anti-carrera.

### Web (`packages/web`)
- **`/admin/contenidos/:id/editar/:docId`** (lazy, ~988 KB code-split): CodeMirror 6 (md/html, tema oscuro), split fuente/preview debounced, toolbar de snippets, **autosave single-flight y cancelable** con indicador, atajos ⌘S/⌘⇧P con guardas anti-pérdida, aviso `beforeunload`, modal publicar con mensaje y modal historial con Ver/Restaurar.
- El preview usa `dangerouslySetInnerHTML` **solo** con salida sanitizada del pipeline (decisión §3).
- El detalle de colección enlaza al editor (deja de editar cuerpo).
- Entradas de `CHANGELOG.md` para US-1 y US-2.

## Cómo probarlo
1. `/admin/contenidos` → colección → página → **Abrir editor**.
2. Markdown con `:::note Título`, tabla y código → preview en vivo; autosave marca "Borrador guardado".
3. **Publicar** (con mensaje) → el árbol muestra "publicada"; editar de nuevo crea borrador nuevo.
4. **Historial** → Ver / Restaurar → el borrador toma el cuerpo de la versión.

## Checklist
- [x] `tsc --noEmit` en web y api sin errores
- [x] Builds de web y api pasan (editor code-split)
- [x] Pipeline verificado (admonitions, fences, GFM, highlight, XSS)
- [x] Code review ejecutado y los 10 hallazgos corregidos
- [ ] Validación funcional manual