### PR TITLE
feat(cms): recursos con subida, pegado de imágenes y stream gated (US-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" (US-4)**: recursos adjuntos — subida (límite 50 MB) y
+  pegado de imágenes en el editor con referencia `recurso:`, gestor por
+  documento, y stream vía endpoint gated por colección; los archivos de
+  Parse dejan de ser públicos (gate interno de `/parse/files`).
 - **CMS "Contenidos" (US-3)**: visor de lectura `/contenidos/<slug>/...` con
   autorización por request (árbol, TOC, breadcrumb y prev/next calculados en
   servidor; no permitido = 404), caches de permisos con invalidación y tema

--- a/package.json
+++ b/package.json
@@ -15,5 +15,10 @@
   "devDependencies": {
     "concurrently": "^9.1.0",
     "vitest": "^3.1.0"
+  },
+  "resolutions": {
+    "@types/express": "^4.17.21",
+    "@types/express-serve-static-core": "^4.17.43",
+    "@types/serve-static": "^1.15.5"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,6 +26,7 @@
     "jsonwebtoken": "^9.0.3",
     "jwks-rsa": "^4.0.1",
     "mailersend": "^2.6.0",
+    "multer": "^2.0.2",
     "parse": "5.3.0",
     "parse-server": "8.6.10",
     "xlsx": "^0.18.5"
@@ -36,6 +37,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "4.17.21",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^1.4.12",
     "@types/parse": "3.0.9",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0"

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -15,6 +15,7 @@ import contenidosRoutes from './routes/contenidos.routes.js';
 import contenidosVisorRoutes from './routes/contenidos-visor.routes.js';
 import meRoutes from './routes/me.routes.js';
 import { docsGate } from './middlewares/docs-gate.middleware.js';
+import { filesGate } from './middlewares/files-gate.middleware.js';
 import alumnosRoutes from './routes/alumnos.routes.js';
 import calendarioRoutes from './routes/calendario.routes.js';
 import indicacionesMallaRoutes from './routes/indicaciones-malla.routes.js';
@@ -46,6 +47,12 @@ const app = express();
 app.use(cors({ origin: config.auth.frontendUrl, credentials: true }));
 app.use(express.json());
 app.use(cookieParser());
+
+// Los archivos de Parse (/parse/files/*) NUNCA se sirven directo (design §2):
+// solo el propio API los lee (llave interna) y los entrega vía el endpoint
+// gated de Recursos. Se registra aquí para correr antes del mount de Parse
+// (que index.ts agrega después).
+app.use(`${config.parseMount}/files`, filesGate);
 
 app.use('/api', healthRoutes);
 app.use('/api', testRoutes);

--- a/packages/api/src/controllers/cms-documentos.controller.ts
+++ b/packages/api/src/controllers/cms-documentos.controller.ts
@@ -37,7 +37,8 @@ function parseSlug(valor: unknown): string | null {
   return typeof valor === 'string' && SLUG_REGEX.test(valor) ? valor : null;
 }
 
-async function getColeccionActiva(id: string): Promise<Coleccion | null> {
+/** Colección existente por id (compartido con recursos.controller). */
+export async function getColeccionActiva(id: string): Promise<Coleccion | null> {
   try {
     const q = new Parse.Query<Coleccion>('Coleccion');
     q.equalTo('exists' as any, true as any);

--- a/packages/api/src/controllers/colecciones.controller.ts
+++ b/packages/api/src/controllers/colecciones.controller.ts
@@ -14,6 +14,15 @@ function invalidarCachesVisor(): void {
 
 const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+// Segmentos que el router del visor usa como literales bajo /contenidos/:
+// una colección con este slug quedaría inalcanzable (shadowing de rutas).
+const SLUGS_RESERVADOS = new Set(['recursos']);
+
+function validarSlug(slug: unknown): string | null {
+  if (typeof slug !== 'string' || !SLUG_REGEX.test(slug) || SLUGS_RESERVADOS.has(slug)) return null;
+  return slug;
+}
+
 /** Duplicado de slug/clave entre colecciones existentes (excluyendo excludeId). */
 async function existeDuplicado(campo: 'slug' | 'clave', valor: string, excludeId?: string): Promise<boolean> {
   const q = new Parse.Query<Coleccion>('Coleccion');
@@ -44,13 +53,14 @@ export async function createColeccion(req: Request, res: Response): Promise<void
     res.status(400).json({ status: 'error', message: 'El nombre es requerido' });
     return;
   }
-  if (!slug || typeof slug !== 'string' || !SLUG_REGEX.test(slug)) {
-    res.status(400).json({ status: 'error', message: 'El slug es requerido y debe contener solo letras minúsculas, números y guiones' });
+  const slugValido = validarSlug(slug);
+  if (!slugValido) {
+    res.status(400).json({ status: 'error', message: 'El slug es requerido, debe contener solo letras minúsculas, números y guiones, y no puede ser una palabra reservada' });
     return;
   }
 
   try {
-    if (await existeDuplicado('slug', slug)) {
+    if (await existeDuplicado('slug', slugValido)) {
       res.status(409).json({ status: 'error', message: 'Ya existe una colección con ese slug' });
       return;
     }
@@ -63,7 +73,7 @@ export async function createColeccion(req: Request, res: Response): Promise<void
 
     const coleccion = new Coleccion().initDefaults();
     coleccion.setNombre(nombre.trim());
-    coleccion.setSlug(slug);
+    coleccion.setSlug(slugValido);
     if (claveCanonica) coleccion.setClave(claveCanonica);
     if (typeof descripcion === 'string' && descripcion.trim()) coleccion.setDescripcion(descripcion.trim());
     if (typeof icono === 'string' && icono.trim()) coleccion.setIcono(icono.trim());
@@ -98,15 +108,16 @@ export async function updateColeccion(req: Request, res: Response): Promise<void
     }
 
     if (slug !== undefined) {
-      if (typeof slug !== 'string' || !SLUG_REGEX.test(slug)) {
-        res.status(400).json({ status: 'error', message: 'El slug debe contener solo letras minúsculas, números y guiones' });
+      const slugValido = validarSlug(slug);
+      if (!slugValido) {
+        res.status(400).json({ status: 'error', message: 'El slug debe contener solo letras minúsculas, números y guiones, y no puede ser una palabra reservada' });
         return;
       }
-      if (slug !== coleccion.getSlug() && (await existeDuplicado('slug', slug, id))) {
+      if (slugValido !== coleccion.getSlug() && (await existeDuplicado('slug', slugValido, id))) {
         res.status(409).json({ status: 'error', message: 'Ya existe una colección con ese slug' });
         return;
       }
-      coleccion.setSlug(slug);
+      coleccion.setSlug(slugValido);
     }
 
     if (clave !== undefined) {

--- a/packages/api/src/controllers/recursos.controller.ts
+++ b/packages/api/src/controllers/recursos.controller.ts
@@ -12,6 +12,26 @@ import { FILES_INTERNAL_KEY, FILES_INTERNAL_HEADER } from '../middlewares/files-
 export const RECURSO_MAX_BYTES = 50 * 1024 * 1024;
 
 /**
+ * Mimes que pueden servirse INLINE sin riesgo de ejecutar script en el
+ * origen de la app. El mime lo declara el cliente al subir (no es
+ * confiable): todo lo demás baja como attachment octet-stream.
+ * SVG excluido a propósito: puede contener <script>.
+ */
+const MIME_INLINE_SEGURO = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'application/pdf',
+  'video/mp4',
+  'video/webm',
+  'audio/mpeg',
+  'audio/wav',
+  'text/plain',
+]);
+
+/**
  * Nombre de archivo seguro y "markdown-friendly": minúsculas, sin espacios
  * ni caracteres raros, conservando la extensión. Las referencias
  * `recurso:<id>/<nombre>` viajan dentro de Markdown — sin espacios.
@@ -201,8 +221,17 @@ export async function streamRecurso(req: Request, res: Response): Promise<void> 
       return;
     }
 
-    res.setHeader('Content-Type', recurso.getMime());
-    res.setHeader('Content-Disposition', `inline; filename="${recurso.getNombre()}"`);
+    // El mime almacenado lo declaró el cliente: solo los tipos de la
+    // allowlist se sirven inline con su mime real; el resto baja como
+    // attachment octet-stream (un text/html inline sería XSS en el origen).
+    // El nombre viene sanitizado desde la subida (sin comillas ni saltos).
+    const inlineSeguro = MIME_INLINE_SEGURO.has(recurso.getMime());
+    res.setHeader('Content-Type', inlineSeguro ? recurso.getMime() : 'application/octet-stream');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader(
+      'Content-Disposition',
+      `${inlineSeguro ? 'inline' : 'attachment'}; filename="${recurso.getNombre()}"`,
+    );
     if (recurso.getBytes() > 0) res.setHeader('Content-Length', String(recurso.getBytes()));
     // Privado: puede cachearlo el navegador del usuario, jamás un proxy.
     res.setHeader('Cache-Control', 'private, max-age=3600');

--- a/packages/api/src/controllers/recursos.controller.ts
+++ b/packages/api/src/controllers/recursos.controller.ts
@@ -6,6 +6,7 @@ import { Documento } from '../models/Documento.js';
 import { Recurso } from '../models/Recurso.js';
 import type { AppUser } from '../models/AppUser.js';
 import { getSlugsPermitidos } from '../services/contenidos.service.js';
+import { getColeccionActiva } from './cms-documentos.controller.js';
 import { FILES_INTERNAL_KEY, FILES_INTERNAL_HEADER } from '../middlewares/files-gate.middleware.js';
 
 /** Límite de subida (decisión #7 del diseño: cubre los ZIP/PDF actuales). */
@@ -15,7 +16,10 @@ export const RECURSO_MAX_BYTES = 50 * 1024 * 1024;
  * Mimes que pueden servirse INLINE sin riesgo de ejecutar script en el
  * origen de la app. El mime lo declara el cliente al subir (no es
  * confiable): todo lo demás baja como attachment octet-stream.
- * SVG excluido a propósito: puede contener <script>.
+ * SVG excluido a propósito (puede contener <script>). Video/audio excluidos
+ * también: reproducirlos embebidos exige soporte de Range/206 (Safari no
+ * arranca sin él) — como attachment se descargan íntegros; para video
+ * embebido usar enlaces de streaming (YouTube) como hoy.
  */
 const MIME_INLINE_SEGURO = new Set([
   'image/png',
@@ -24,10 +28,6 @@ const MIME_INLINE_SEGURO = new Set([
   'image/webp',
   'image/avif',
   'application/pdf',
-  'video/mp4',
-  'video/webm',
-  'audio/mpeg',
-  'audio/wav',
   'text/plain',
 ]);
 
@@ -47,16 +47,6 @@ function sanitizarNombre(original: string): string {
     .slice(0, 80) || 'archivo';
   const ext = punto > 0 ? original.slice(punto + 1).toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 10) : '';
   return ext ? `${base}.${ext}` : base;
-}
-
-async function getColeccionActiva(id: string): Promise<Coleccion | null> {
-  try {
-    const q = new Parse.Query<Coleccion>('Coleccion');
-    q.equalTo('exists' as any, true as any);
-    return await q.get(id, { useMasterKey: true });
-  } catch {
-    return null;
-  }
 }
 
 /**

--- a/packages/api/src/controllers/recursos.controller.ts
+++ b/packages/api/src/controllers/recursos.controller.ts
@@ -1,0 +1,217 @@
+import type { Request, Response } from 'express';
+import { Readable } from 'stream';
+import Parse from 'parse/node';
+import { Coleccion } from '../models/Coleccion.js';
+import { Documento } from '../models/Documento.js';
+import { Recurso } from '../models/Recurso.js';
+import type { AppUser } from '../models/AppUser.js';
+import { getSlugsPermitidos } from '../services/contenidos.service.js';
+import { FILES_INTERNAL_KEY, FILES_INTERNAL_HEADER } from '../middlewares/files-gate.middleware.js';
+
+/** Límite de subida (decisión #7 del diseño: cubre los ZIP/PDF actuales). */
+export const RECURSO_MAX_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Nombre de archivo seguro y "markdown-friendly": minúsculas, sin espacios
+ * ni caracteres raros, conservando la extensión. Las referencias
+ * `recurso:<id>/<nombre>` viajan dentro de Markdown — sin espacios.
+ */
+function sanitizarNombre(original: string): string {
+  const punto = original.lastIndexOf('.');
+  const base = (punto > 0 ? original.slice(0, punto) : original)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'archivo';
+  const ext = punto > 0 ? original.slice(punto + 1).toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 10) : '';
+  return ext ? `${base}.${ext}` : base;
+}
+
+async function getColeccionActiva(id: string): Promise<Coleccion | null> {
+  try {
+    const q = new Parse.Query<Coleccion>('Coleccion');
+    q.equalTo('exists' as any, true as any);
+    return await q.get(id, { useMasterKey: true });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST /admin/recursos — multipart { archivo, coleccionId, documentoId? }.
+ * Guarda el binario como Parse.File (adapter actual: GridFS; S3 en US-8) y
+ * registra el Recurso. Devuelve la referencia `recurso:` lista para pegar.
+ */
+export async function uploadRecurso(req: Request, res: Response): Promise<void> {
+  const archivo = req.file;
+  const { coleccionId, documentoId } = req.body ?? {};
+
+  if (!archivo) {
+    res.status(400).json({ status: 'error', message: 'Falta el archivo (campo "archivo")' });
+    return;
+  }
+  if (!coleccionId || typeof coleccionId !== 'string') {
+    res.status(400).json({ status: 'error', message: 'coleccionId es requerido' });
+    return;
+  }
+
+  try {
+    const coleccion = await getColeccionActiva(coleccionId);
+    if (!coleccion) {
+      res.status(404).json({ status: 'error', message: 'Colección no encontrada' });
+      return;
+    }
+
+    let documento: Documento | null = null;
+    if (documentoId) {
+      const dq = new Parse.Query<Documento>('Documento');
+      dq.equalTo('exists' as any, true as any);
+      dq.equalTo('coleccion' as any, coleccion as any);
+      documento = await dq.get(documentoId, { useMasterKey: true }).catch(() => null);
+      if (!documento) {
+        res.status(400).json({ status: 'error', message: 'El documento indicado no existe en esta colección' });
+        return;
+      }
+    }
+
+    const nombre = sanitizarNombre(archivo.originalname);
+    const mime = archivo.mimetype || 'application/octet-stream';
+
+    const parseFile = new Parse.File(nombre, { base64: archivo.buffer.toString('base64') }, mime);
+    await parseFile.save({ useMasterKey: true });
+
+    const recurso = new Recurso().initDefaults();
+    recurso.setColeccion(coleccion);
+    recurso.setDocumento(documento);
+    recurso.setNombre(nombre);
+    recurso.setArchivo(parseFile);
+    recurso.setMime(mime);
+    recurso.setBytes(archivo.size);
+    const autor = req.appUser as AppUser | undefined;
+    if (autor) recurso.setSubidoPor(autor);
+    await recurso.save(null, { useMasterKey: true });
+
+    res.status(201).json({
+      status: 'ok',
+      recurso: recurso.toSafeJSON(),
+      // Referencia lista para el Markdown: el pipeline la reescribe al endpoint gated.
+      referencia: `recurso:${recurso.id}/${nombre}`,
+    });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al subir el recurso' });
+  }
+}
+
+/** GET /admin/colecciones/:id/recursos?documentoId= — recursos existentes. */
+export async function listRecursos(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { documentoId } = req.query;
+
+  try {
+    const coleccion = await getColeccionActiva(id);
+    if (!coleccion) {
+      res.status(404).json({ status: 'error', message: 'Colección no encontrada' });
+      return;
+    }
+
+    const q = new Parse.Query<Recurso>('Recurso');
+    q.equalTo('exists' as any, true as any);
+    q.equalTo('coleccion' as any, coleccion as any);
+    if (typeof documentoId === 'string' && documentoId) {
+      const puntero = Parse.Object.extend('Documento').createWithoutData(documentoId);
+      q.equalTo('documento' as any, puntero as any);
+    }
+    q.descending('createdAt');
+    q.limit(1000);
+    const recursos = await q.find({ useMasterKey: true });
+
+    res.json({
+      status: 'ok',
+      recursos: recursos.map((r) => ({
+        ...r.toSafeJSON(),
+        referencia: `recurso:${r.id}/${r.getNombre()}`,
+      })),
+    });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al obtener recursos' });
+  }
+}
+
+/** DELETE /admin/recursos/:id — soft-delete (el binario queda en el adapter). */
+export async function deleteRecurso(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+
+  try {
+    const q = new Parse.Query<Recurso>('Recurso');
+    q.equalTo('exists' as any, true as any);
+    const recurso = await q.get(id, { useMasterKey: true });
+
+    recurso.softDelete();
+    await recurso.save(null, { useMasterKey: true });
+
+    res.json({ status: 'ok', message: 'Recurso eliminado' });
+  } catch (error: any) {
+    if (error?.code === Parse.Error.OBJECT_NOT_FOUND) {
+      res.status(404).json({ status: 'error', message: 'Recurso no encontrado' });
+      return;
+    }
+    res.status(500).json({ status: 'error', message: 'Error al eliminar recurso' });
+  }
+}
+
+/**
+ * GET /contenidos/recursos/:id/:nombre — stream del asset SI la colección
+ * dueña está permitida para el usuario (design §2: assets gated, sin URL
+ * pública). 404 uniforme para inexistente/no permitido; el binario se lee
+ * de Parse con la llave interna del proceso (files-gate bloquea el resto).
+ */
+export async function streamRecurso(req: Request, res: Response): Promise<void> {
+  const user = req.appUser;
+  const { id } = req.params;
+  if (!user) {
+    res.status(401).json({ status: 'error', message: 'Autenticación requerida' });
+    return;
+  }
+
+  try {
+    const q = new Parse.Query<Recurso>('Recurso');
+    q.equalTo('exists' as any, true as any);
+    q.include('coleccion' as any);
+    const recurso = await q.get(id, { useMasterKey: true }).catch(() => null);
+    const coleccion = recurso?.getColeccion();
+    const archivo = recurso?.getArchivo();
+    if (!recurso || !coleccion || coleccion.get('exists') === false || !archivo) {
+      res.status(404).json({ status: 'error', message: 'No encontrado' });
+      return;
+    }
+
+    const permitidos = await getSlugsPermitidos(user);
+    if (!permitidos.has(coleccion.get('slug'))) {
+      res.status(404).json({ status: 'error', message: 'No encontrado' });
+      return;
+    }
+
+    const interna = await fetch(archivo.url(), {
+      headers: { [FILES_INTERNAL_HEADER]: FILES_INTERNAL_KEY },
+    });
+    if (!interna.ok || !interna.body) {
+      res.status(502).json({ status: 'error', message: 'No se pudo leer el archivo' });
+      return;
+    }
+
+    res.setHeader('Content-Type', recurso.getMime());
+    res.setHeader('Content-Disposition', `inline; filename="${recurso.getNombre()}"`);
+    if (recurso.getBytes() > 0) res.setHeader('Content-Length', String(recurso.getBytes()));
+    // Privado: puede cachearlo el navegador del usuario, jamás un proxy.
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    Readable.fromWeb(interna.body as any).pipe(res);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({ status: 'error', message: 'Error al servir el recurso' });
+    } else {
+      res.end();
+    }
+  }
+}

--- a/packages/api/src/middlewares/files-gate.middleware.ts
+++ b/packages/api/src/middlewares/files-gate.middleware.ts
@@ -2,18 +2,31 @@ import type { Request, Response, NextFunction } from 'express';
 import crypto from 'crypto';
 
 /**
- * Gate de los archivos de Parse Server (design §2: los assets NUNCA son
- * públicos). Parse sirve GridFS en /parse/files/<appId>/<nombre> con URLs
- * adivinables por listado; este middleware responde 404 a todo acceso que
- * no venga del propio API (el stream gated de Recursos, que agrega la
- * llave interna por proceso).
+ * Gate de LECTURA de los archivos de Parse Server (design §2: los assets
+ * NUNCA son públicos). Parse sirve GridFS en /parse/files/<appId>/<nombre>;
+ * este middleware responde 404 a todo GET que no venga del propio API (el
+ * stream gated de Recursos, que agrega la llave interna).
+ *
+ * Solo se gatea GET/HEAD: la SUBIDA del propio SDK (Parse.File.save hace un
+ * POST real a /parse/files/<nombre>) debe pasar — la protege el propio
+ * parse-server (masterKey/usuario autenticado; enableForPublic=false).
  */
 
-/** Llave efímera por proceso: solo este servidor puede leerse a sí mismo. */
-export const FILES_INTERNAL_KEY = crypto.randomBytes(32).toString('hex');
+/**
+ * Llave interna compartida entre el gate y el stream. Configurable por env
+ * (FILES_INTERNAL_KEY) para despliegues multi-proceso (pm2 cluster/replicas):
+ * con llave aleatoria por proceso, el self-fetch podría aterrizar en otro
+ * worker con otra llave. En un solo proceso, la aleatoria basta.
+ */
+export const FILES_INTERNAL_KEY =
+  process.env.FILES_INTERNAL_KEY || crypto.randomBytes(32).toString('hex');
 export const FILES_INTERNAL_HEADER = 'x-files-internal';
 
 export function filesGate(req: Request, res: Response, next: NextFunction): void {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    next();
+    return;
+  }
   if (req.get(FILES_INTERNAL_HEADER) === FILES_INTERNAL_KEY) {
     next();
     return;

--- a/packages/api/src/middlewares/files-gate.middleware.ts
+++ b/packages/api/src/middlewares/files-gate.middleware.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
+
+/**
+ * Gate de los archivos de Parse Server (design §2: los assets NUNCA son
+ * públicos). Parse sirve GridFS en /parse/files/<appId>/<nombre> con URLs
+ * adivinables por listado; este middleware responde 404 a todo acceso que
+ * no venga del propio API (el stream gated de Recursos, que agrega la
+ * llave interna por proceso).
+ */
+
+/** Llave efímera por proceso: solo este servidor puede leerse a sí mismo. */
+export const FILES_INTERNAL_KEY = crypto.randomBytes(32).toString('hex');
+export const FILES_INTERNAL_HEADER = 'x-files-internal';
+
+export function filesGate(req: Request, res: Response, next: NextFunction): void {
+  if (req.get(FILES_INTERNAL_HEADER) === FILES_INTERNAL_KEY) {
+    next();
+    return;
+  }
+  res.status(404).json({ status: 'error', message: 'No encontrado' });
+}

--- a/packages/api/src/routes/contenidos-visor.routes.ts
+++ b/packages/api/src/routes/contenidos-visor.routes.ts
@@ -5,6 +5,7 @@ import {
   getArbolColeccion,
   getPagina,
 } from '../controllers/contenidos-lectura.controller.js';
+import { streamRecurso } from '../controllers/recursos.controller.js';
 
 // Lectura del CMS "Contenidos" (design §2/§4). Solo requiere usuario
 // autenticado: la autorización POR COLECCIÓN vive en cada handler
@@ -12,6 +13,8 @@ import {
 const router = Router();
 
 router.get('/me/colecciones', identifyUser, getMisColecciones);
+// Antes de :slug/... para que "recursos" nunca se interprete como slug.
+router.get('/contenidos/recursos/:id/:nombre', identifyUser, streamRecurso);
 router.get('/contenidos/:slug/arbol', identifyUser, getArbolColeccion);
 router.get('/contenidos/:slug/pagina/*', identifyUser, getPagina);
 

--- a/packages/api/src/routes/contenidos.routes.ts
+++ b/packages/api/src/routes/contenidos.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import multer from 'multer';
 import { identifyUser } from '../middlewares/auth.middleware.js';
 import { requireAdmin } from '../middlewares/abac.middleware.js';
 import {
@@ -22,6 +23,15 @@ import {
   getVersion,
   restaurarVersion,
 } from '../controllers/cms-versiones.controller.js';
+import {
+  uploadRecurso,
+  listRecursos,
+  deleteRecurso,
+  RECURSO_MAX_BYTES,
+} from '../controllers/recursos.controller.js';
+
+// Subida en memoria: el binario va directo a Parse.File (sin disco temporal).
+const subida = multer({ storage: multer.memoryStorage(), limits: { fileSize: RECURSO_MAX_BYTES } });
 
 // Rutas admin del CMS "Contenidos" (design/cms-contenidos.html §7).
 // Los endpoints de lectura del visor (US-3) irán en un router aparte.
@@ -29,6 +39,7 @@ const router = Router();
 
 router.use('/admin/colecciones', identifyUser, requireAdmin);
 router.use('/admin/documentos', identifyUser, requireAdmin);
+router.use('/admin/recursos', identifyUser, requireAdmin);
 
 // Colecciones
 router.get('/admin/colecciones', listColecciones);
@@ -52,5 +63,10 @@ router.post('/admin/documentos/:docId/publicar', publicarDocumento);
 router.get('/admin/documentos/:docId/versiones', listVersiones);
 router.get('/admin/documentos/:docId/versiones/:versionId', getVersion);
 router.post('/admin/documentos/:docId/versiones/:versionId/restaurar', restaurarVersion);
+
+// Recursos (US-4): subida multipart (límite 50 MB), listado y borrado
+router.post('/admin/recursos', subida.single('archivo'), uploadRecurso);
+router.get('/admin/colecciones/:id/recursos', listRecursos);
+router.delete('/admin/recursos/:id', deleteRecurso);
 
 export default router;

--- a/packages/api/src/routes/contenidos.routes.ts
+++ b/packages/api/src/routes/contenidos.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response, type NextFunction } from 'express';
 import multer from 'multer';
 import { identifyUser } from '../middlewares/auth.middleware.js';
 import { requireAdmin } from '../middlewares/abac.middleware.js';
@@ -33,6 +33,21 @@ import {
 // Subida en memoria: el binario va directo a Parse.File (sin disco temporal).
 const subida = multer({ storage: multer.memoryStorage(), limits: { fileSize: RECURSO_MAX_BYTES } });
 
+/** Envuelve a multer para responder sus errores como 4xx en español. */
+function subidaArchivo(req: Request, res: Response, next: NextFunction): void {
+  subida.single('archivo')(req, res, (err: unknown) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        res.status(413).json({ status: 'error', message: 'El archivo excede el límite de 50 MB' });
+        return;
+      }
+      res.status(400).json({ status: 'error', message: 'Archivo inválido en la subida' });
+      return;
+    }
+    next(err);
+  });
+}
+
 // Rutas admin del CMS "Contenidos" (design/cms-contenidos.html §7).
 // Los endpoints de lectura del visor (US-3) irán en un router aparte.
 const router = Router();
@@ -65,7 +80,7 @@ router.get('/admin/documentos/:docId/versiones/:versionId', getVersion);
 router.post('/admin/documentos/:docId/versiones/:versionId/restaurar', restaurarVersion);
 
 // Recursos (US-4): subida multipart (límite 50 MB), listado y borrado
-router.post('/admin/recursos', subida.single('archivo'), uploadRecurso);
+router.post('/admin/recursos', subidaArchivo, uploadRecurso);
 router.get('/admin/colecciones/:id/recursos', listRecursos);
 router.delete('/admin/recursos/:id', deleteRecurso);
 

--- a/packages/contenido-pipeline/index.d.ts
+++ b/packages/contenido-pipeline/index.d.ts
@@ -16,3 +16,6 @@ export declare function renderMarkdown(cuerpo: string): Promise<string>;
 
 /** Extrae el TOC (h2/h3) del HTML renderizado por este pipeline. */
 export declare function extraerToc(html: string): TocEntry[];
+
+/** Prefijo del endpoint gated que sirve los Recursos (US-4). */
+export declare const RECURSOS_ENDPOINT: string;

--- a/packages/contenido-pipeline/index.js
+++ b/packages/contenido-pipeline/index.js
@@ -22,6 +22,24 @@ import { visit } from 'unist-util-visit';
 /** Tipos de admonition con paridad Docusaurus. */
 export const ADMONITION_TIPOS = ['note', 'tip', 'info', 'warning', 'danger', 'caution'];
 
+/** Prefijo del endpoint gated que sirve los Recursos (US-4). */
+export const RECURSOS_ENDPOINT = '/api/contenidos/recursos/';
+
+/**
+ * Plugin remark: reescribe las referencias `recurso:<id>/<nombre>` de
+ * imágenes y enlaces hacia el endpoint gated. Corre ANTES de sanitize:
+ * el esquema no permite protocolos desconocidos, pero sí URLs relativas.
+ */
+function remarkRecursos() {
+  return (tree) => {
+    visit(tree, ['image', 'link'], (node) => {
+      if (typeof node.url === 'string' && node.url.startsWith('recurso:')) {
+        node.url = RECURSOS_ENDPOINT + node.url.slice('recurso:'.length);
+      }
+    });
+  };
+}
+
 /**
  * Plugin remark: convierte las directivas de contenedor `:::note Título`
  * en la estructura de admonition (equivalente a las de Docusaurus):
@@ -84,6 +102,7 @@ const procesador = unified()
   .use(remarkGfm)
   .use(remarkDirective)
   .use(remarkAdmonitions)
+  .use(remarkRecursos)
   .use(remarkRehype)
   .use(rehypeSanitize, ESQUEMA_SANITIZE)
   .use(rehypeSlug)

--- a/packages/contenido-pipeline/index.test.js
+++ b/packages/contenido-pipeline/index.test.js
@@ -46,6 +46,20 @@ describe('admonitions (paridad Docusaurus)', () => {
   });
 });
 
+describe('recursos (referencias recurso:)', () => {
+  it('reescribe imágenes y enlaces recurso: al endpoint gated', async () => {
+    const img = await renderMarkdown('![diagrama](recurso:abc123/diagrama.png)');
+    expect(img).toContain('src="/api/contenidos/recursos/abc123/diagrama.png"');
+    const link = await renderMarkdown('[starter](recurso:xyz/starter.zip)');
+    expect(link).toContain('href="/api/contenidos/recursos/xyz/starter.zip"');
+  });
+
+  it('sigue bloqueando protocolos peligrosos', async () => {
+    const html = await renderMarkdown('![x](javascript:alert(1))');
+    expect(html).not.toContain('javascript:');
+  });
+});
+
 describe('TOC', () => {
   it('extrae h2/h3 con sus ids (anclas)', async () => {
     const html = await renderMarkdown('# T\n\n## Objetivo\n\n### Detalle\n\n## Entrega');

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
@@ -243,3 +243,11 @@
   line-height: 1.6;
   white-space: pre-wrap;
 }
+
+.recursoNombre {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
+}

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -72,8 +72,12 @@ export default function EditorContenidoPage() {
 
   const [recursosOpen, setRecursosOpen] = useState(false);
   const [recursos, setRecursos] = useState<RecursoInfo[]>([]);
+  const [recursosCargando, setRecursosCargando] = useState(false);
   const [recursosError, setRecursosError] = useState('');
-  const [subiendo, setSubiendo] = useState(false);
+  // Contador (no booleano): varios pegados concurrentes no deben apagar el
+  // indicador cuando termina solo el primero.
+  const [subidasActivas, setSubidasActivas] = useState(0);
+  const subiendo = subidasActivas > 0;
   const archivoInputRef = useRef<HTMLInputElement>(null);
 
   // El autosave usa refs para leer el estado más reciente sin recrear timers.
@@ -232,7 +236,7 @@ export default function EditorContenidoPage() {
   /* ── Recursos: subir e insertar referencia `recurso:` (US-4) ── */
   async function subirArchivo(file: File): Promise<void> {
     if (!documento?.coleccionId || !docId) return;
-    setSubiendo(true);
+    setSubidasActivas((n) => n + 1);
     setError('');
     try {
       const form = new FormData();
@@ -255,20 +259,27 @@ export default function EditorContenidoPage() {
     } catch (err: any) {
       setError(err.message);
     } finally {
-      setSubiendo(false);
+      setSubidasActivas((n) => n - 1);
     }
   }
 
-  function onPaste(e: React.ClipboardEvent) {
+  /**
+   * Solo pegados DENTRO del panel de fuente: a nivel de página secuestraría
+   * el paste de los inputs de los modales (publicar/historial/recursos).
+   * Secuencial: el orden de inserción respeta el orden de los archivos.
+   */
+  async function onPasteFuente(e: React.ClipboardEvent) {
     const archivos = [...(e.clipboardData?.files ?? [])];
     if (!archivos.length || !documento) return;
     e.preventDefault();
-    for (const f of archivos) subirArchivo(f);
+    for (const f of archivos) await subirArchivo(f);
   }
 
   async function abrirRecursos() {
     if (!documento?.coleccionId) return;
     setRecursosError('');
+    setRecursos([]); // sin lista vieja: otro admin pudo borrar/subir entre aperturas
+    setRecursosCargando(true);
     setRecursosOpen(true);
     try {
       const res = await fetch(
@@ -280,6 +291,8 @@ export default function EditorContenidoPage() {
       setRecursos(json.recursos ?? []);
     } catch (err: any) {
       setRecursosError(err.message);
+    } finally {
+      setRecursosCargando(false);
     }
   }
 
@@ -402,7 +415,7 @@ export default function EditorContenidoPage() {
   }
 
   return (
-    <div className={styles.page} onKeyDown={onKeyDown} onPaste={onPaste}>
+    <div className={styles.page} onKeyDown={onKeyDown}>
       <div className={styles.header}>
         <Link to={`/admin/contenidos/${id}`} className={styles.volver}>
           <Icon name="arrow_back" size="sm" />
@@ -464,7 +477,7 @@ export default function EditorContenidoPage() {
       />
 
       <div className={styles.split}>
-        <div className={styles.fuente}>
+        <div className={styles.fuente} onPaste={onPasteFuente}>
           <CodeMirror
             ref={editorRef}
             value={cuerpo}
@@ -524,7 +537,9 @@ export default function EditorContenidoPage() {
       <Modal isOpen={recursosOpen} onClose={() => setRecursosOpen(false)} title="Recursos del documento">
         <div className={styles.modalCuerpo}>
           {recursosError && <div className={styles.error}>{recursosError}</div>}
-          {recursos.length === 0 ? (
+          {recursosCargando ? (
+            <p className={styles.hint}>Cargando…</p>
+          ) : recursos.length === 0 ? (
             <p className={styles.hint}>Sin recursos. Sube uno con 🖼️ o pega una imagen en el editor.</p>
           ) : (
             <div className={styles.versiones}>

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -30,6 +30,20 @@ interface VersionInfo {
   createdAt: string;
 }
 
+interface RecursoInfo {
+  id: string;
+  nombre: string;
+  mime: string;
+  bytes: number;
+  referencia: string;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${bytes} B`;
+}
+
 /**
  * Editor del CMS "Contenidos" (design §3): CodeMirror + preview en vivo con
  * el MISMO pipeline unified que renderiza al publicar — WYSIWYG real.
@@ -55,6 +69,12 @@ export default function EditorContenidoPage() {
   const [versiones, setVersiones] = useState<VersionInfo[]>([]);
   const [historialError, setHistorialError] = useState('');
   const [verCuerpo, setVerCuerpo] = useState<{ numero: number; cuerpo: string } | null>(null);
+
+  const [recursosOpen, setRecursosOpen] = useState(false);
+  const [recursos, setRecursos] = useState<RecursoInfo[]>([]);
+  const [recursosError, setRecursosError] = useState('');
+  const [subiendo, setSubiendo] = useState(false);
+  const archivoInputRef = useRef<HTMLInputElement>(null);
 
   // El autosave usa refs para leer el estado más reciente sin recrear timers.
   const cuerpoRef = useRef(cuerpo);
@@ -209,6 +229,72 @@ export default function EditorContenidoPage() {
   const SNIPPET_ADMONITION = '\n:::note Título\nContenido.\n:::\n';
   const SNIPPET_CODIGO = '\n```js\n// código\n```\n';
 
+  /* ── Recursos: subir e insertar referencia `recurso:` (US-4) ── */
+  async function subirArchivo(file: File): Promise<void> {
+    if (!documento?.coleccionId || !docId) return;
+    setSubiendo(true);
+    setError('');
+    try {
+      const form = new FormData();
+      form.append('archivo', file);
+      form.append('coleccionId', documento.coleccionId);
+      form.append('documentoId', docId);
+      const res = await fetch(`${API_BASE}/admin/recursos`, {
+        method: 'POST',
+        headers: { 'x-session-token': sessionToken ?? '' }, // sin Content-Type: FormData pone el boundary
+        body: form,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'Error al subir el archivo (límite: 50 MB)');
+      }
+      const json = await res.json();
+      const esImagen = (json.recurso?.mime ?? '').startsWith('image/');
+      const nombre = json.recurso?.nombre ?? file.name;
+      insertar(`\n${esImagen ? '!' : ''}[${nombre}](${json.referencia})\n`);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSubiendo(false);
+    }
+  }
+
+  function onPaste(e: React.ClipboardEvent) {
+    const archivos = [...(e.clipboardData?.files ?? [])];
+    if (!archivos.length || !documento) return;
+    e.preventDefault();
+    for (const f of archivos) subirArchivo(f);
+  }
+
+  async function abrirRecursos() {
+    if (!documento?.coleccionId) return;
+    setRecursosError('');
+    setRecursosOpen(true);
+    try {
+      const res = await fetch(
+        `${API_BASE}/admin/colecciones/${documento.coleccionId}/recursos?documentoId=${docId}`,
+        { headers: { 'x-session-token': sessionToken ?? '' } },
+      );
+      if (!res.ok) throw new Error('No se pudieron cargar los recursos');
+      const json = await res.json();
+      setRecursos(json.recursos ?? []);
+    } catch (err: any) {
+      setRecursosError(err.message);
+    }
+  }
+
+  async function eliminarRecurso(r: RecursoInfo) {
+    if (!confirm(`¿Eliminar "${r.nombre}"? Las páginas que lo referencien mostrarán un enlace roto.`)) return;
+    setRecursosError('');
+    try {
+      const res = await fetch(`${API_BASE}/admin/recursos/${r.id}`, { method: 'DELETE', headers });
+      if (!res.ok) throw new Error('No se pudo eliminar');
+      setRecursos((prev) => prev.filter((x) => x.id !== r.id));
+    } catch (err: any) {
+      setRecursosError(err.message);
+    }
+  }
+
   /* ── Publicar ── */
   function abrirPublicar() {
     setMensajePublicar('');
@@ -316,7 +402,7 @@ export default function EditorContenidoPage() {
   }
 
   return (
-    <div className={styles.page} onKeyDown={onKeyDown}>
+    <div className={styles.page} onKeyDown={onKeyDown} onPaste={onPaste}>
       <div className={styles.header}>
         <Link to={`/admin/contenidos/${id}`} className={styles.volver}>
           <Icon name="arrow_back" size="sm" />
@@ -358,9 +444,24 @@ export default function EditorContenidoPage() {
           <button type="button" title="Enlace" onClick={() => insertar('[', '](https://)', 'texto')}>🔗</button>
           <button type="button" title="Tabla" onClick={() => insertar(SNIPPET_TABLA)}>▦ Tabla</button>
           <button type="button" title="Admonition" onClick={() => insertar(SNIPPET_ADMONITION)}>💡 Nota</button>
+          <span className={styles.sep} />
+          <button type="button" title="Subir imagen o archivo (o pega una imagen)" onClick={() => archivoInputRef.current?.click()} disabled={subiendo}>
+            {subiendo ? '⏳ Subiendo…' : '🖼️ Subir'}
+          </button>
+          <button type="button" title="Recursos del documento" onClick={abrirRecursos}>📎 Recursos</button>
           <span className={styles.atajos}>⌘S guardar · ⌘⇧P publicar</span>
         </div>
       )}
+      <input
+        ref={archivoInputRef}
+        type="file"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const f = e.target.files?.[0];
+          if (f) subirArchivo(f);
+          e.target.value = '';
+        }}
+      />
 
       <div className={styles.split}>
         <div className={styles.fuente}>
@@ -416,6 +517,40 @@ export default function EditorContenidoPage() {
               {publicando ? 'Publicando…' : 'Publicar'}
             </DashButton>
           </div>
+        </div>
+      </Modal>
+
+      {/* ── Modal recursos ── */}
+      <Modal isOpen={recursosOpen} onClose={() => setRecursosOpen(false)} title="Recursos del documento">
+        <div className={styles.modalCuerpo}>
+          {recursosError && <div className={styles.error}>{recursosError}</div>}
+          {recursos.length === 0 ? (
+            <p className={styles.hint}>Sin recursos. Sube uno con 🖼️ o pega una imagen en el editor.</p>
+          ) : (
+            <div className={styles.versiones}>
+              {recursos.map((r) => (
+                <div key={r.id} className={styles.version}>
+                  <div className={styles.versionInfo}>
+                    <span>{r.mime.startsWith('image/') ? '🖼️' : '📦'}</span>
+                    <b className={styles.recursoNombre} title={r.nombre}>{r.nombre}</b>
+                    <span className={styles.versionMeta}>{formatBytes(r.bytes)}</span>
+                  </div>
+                  <div className={styles.versionAcciones}>
+                    <DashButton
+                      variant="outline"
+                      onClick={() => {
+                        insertar(`\n${r.mime.startsWith('image/') ? '!' : ''}[${r.nombre}](${r.referencia})\n`);
+                        setRecursosOpen(false);
+                      }}
+                    >
+                      Insertar
+                    </DashButton>
+                    <DashButton variant="outline" onClick={() => eliminarRecurso(r)}>Eliminar</DashButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </Modal>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,17 +4229,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/express-serve-static-core@*", "@types/express-serve-static-core@^5.0.0":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz#1a77faffee9572d39124933259be2523837d7eaa"
-  integrity sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-    "@types/send" "*"
-
-"@types/express-serve-static-core@^4.17.21", "@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.21", "@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33", "@types/express-serve-static-core@^4.17.43":
   version "4.19.8"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz#99b960322a4d576b239a640ab52ef191989b036f"
   integrity sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==
@@ -4249,26 +4239,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*":
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-5.0.6.tgz#2d724b2c990dcb8c8444063f3580a903f6d500cc"
-  integrity sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^5.0.0"
-    "@types/serve-static" "^2"
-
-"@types/express@4.17.21":
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
-  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.33"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
-
-"@types/express@^4.17.13", "@types/express@^4.17.20", "@types/express@^4.17.25":
+"@types/express@*", "@types/express@4.17.21", "@types/express@^4.17.13", "@types/express@^4.17.20", "@types/express@^4.17.21", "@types/express@^4.17.25":
   version "4.17.25"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
   integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
@@ -4375,6 +4346,13 @@
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
+
+"@types/multer@^1.4.12":
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.13.tgz#be483f909a77f13e0624cac3d001859eb12ae68b"
+  integrity sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==
+  dependencies:
+    "@types/express" "*"
 
 "@types/node-fetch@^2.6.1":
   version "2.6.13"
@@ -4516,14 +4494,6 @@
   integrity sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==
   dependencies:
     "@types/express" "*"
-
-"@types/serve-static@*", "@types/serve-static@^2":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
-  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
-  dependencies:
-    "@types/http-errors" "*"
-    "@types/node" "*"
 
 "@types/serve-static@^1", "@types/serve-static@^1.15.5":
   version "1.15.10"
@@ -5037,6 +5007,11 @@ apexcharts@^5.10.4:
   version "5.10.4"
   resolved "https://registry.yarnpkg.com/apexcharts/-/apexcharts-5.10.4.tgz#79c9a05ab40b069f33873a1859de6cb0882ccf0e"
   integrity sha512-gt0VUqZ2+mr25ScbUcKZgJr96jKYm4vjOcxEWCEh/E5F4dWqhyo3dBhPRvNNnkKiWxkMd2cBwj3ZYH3rK39fkA==
+
+append-field@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-field/-/append-field-1.0.0.tgz#1e3440e915f0b1203d23748e78edd7b9b5b43e56"
+  integrity sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==
 
 "aproba@^1.0.3 || ^2.0.0":
   version "2.1.0"
@@ -5989,6 +5964,16 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+concat-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
+  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.0.2"
+    typedarray "^0.0.6"
 
 concurrently@^9.1.0:
   version "9.2.1"
@@ -10375,6 +10360,16 @@ ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+multer@^2.0.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-2.2.0.tgz#f005268ca816324ba7335e3b48166896a3fa5d79"
+  integrity sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==
+  dependencies:
+    append-field "^1.0.0"
+    busboy "^1.6.0"
+    concat-stream "^2.0.0"
+    type-is "^1.6.18"
+
 multicast-dns@^7.2.5:
   version "7.2.5"
   resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-7.2.5.tgz#77eb46057f4d7adbd16d9290fa7299f6fa64cced"
@@ -12033,7 +12028,7 @@ readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0, readable-stream@^3.6.2:
+readable-stream@^3.0.2, readable-stream@^3.0.6, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0, readable-stream@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -13533,6 +13528,14 @@ type-fest@^2.13.0, type-fest@^2.5.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
+type-is@^1.6.18, type-is@~1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
+
 type-is@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-2.0.1.tgz#64f6cf03f92fce4015c2b224793f6bdd4b068c97"
@@ -13541,14 +13544,6 @@ type-is@^2.0.1:
     content-type "^1.0.5"
     media-typer "^1.1.0"
     mime-types "^3.0.0"
-
-type-is@~1.6.18:
-  version "1.6.18"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
-  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.24"
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -13565,6 +13560,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
 typescript@^5.8.0:
   version "5.9.3"


### PR DESCRIPTION
## Descripción

**US-4 del roadmap del CMS "Contenidos"** (`design/cms-contenidos.html` §1/§2): assets adjuntos de principio a fin — subir, referenciar desde Markdown y servir **solo a quien tiene acceso a la colección**. Incluye los fixes del code review (10 hallazgos, uno bloqueador) y del review de seguridad (XSS por Content-Type); detalle en comentario.

> **PR apilado sobre `feature/cms-visor` (US-3, PR #25).** Orden de merge: #25 → este → US-5 → US-6.

## Cambios

### API
- **`POST /api/admin/recursos`** — multipart (multer en memoria, **límite 50 MB** = decisión #7, errores 4xx en español): guarda el binario como `Parse.File` (GridFS hoy; S3 en US-8), registra el `Recurso` y devuelve la referencia `recurso:<id>/<nombre>`. Nombres sanitizados markdown-friendly.
- **`GET /api/contenidos/recursos/:id/:nombre`** — stream **solo si la colección dueña está permitida** (404 uniforme); **allowlist de mimes inline** (SVG excluido por XSS; video/audio excluidos por Range/Safari), resto attachment octet-stream + `nosniff`.
- **`files-gate`** — los GET de `/parse/files/*` responden 404 salvo llave interna (env `FILES_INTERNAL_KEY` para pm2 cluster); la subida del SDK (POST) pasa y la protege parse-server. **Los archivos de Parse dejan de tener URL pública.**
- Slug `recursos` reservado en colecciones (shadowing de rutas del visor).

### Pipeline
- **`remarkRecursos`**: reescribe `recurso:<id>/<n>` (imágenes y enlaces) al endpoint gated antes de sanitize; `javascript:` sigue bloqueado. Con tests.

### Editor
- **Pegar imagen** en el panel de fuente la sube e inserta la referencia (solo ahí: no secuestra el paste de los modales); botón **🖼️ Subir**; modal **📎 Recursos** del documento (insertar/eliminar, estado de carga); subidas concurrentes con contador.
- Las imágenes del preview/visor se autorizan con la cookie httpOnly de sesión.

## Seguridad probada
- 18/18 tests al momento (rewrite gated, `javascript:` bloqueado); stream con colección permitida por request; anónimo 401; no permitido/inexistente 404 idéntico; mimes inline allowlist + nosniff.

## Checklist
- [x] `tsc --noEmit` web y api; builds pasan
- [x] Code review (10 hallazgos, 1 bloqueador) + review de seguridad (XSS) atendidos
- [ ] Validación funcional manual (subir/pegar imagen, publicar, verla en el visor)