### PR TITLE
feat(cms): búsqueda con scope por permisos y páginas HTML sandboxeadas (US-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" (US-5)**: búsqueda full-text con scope por permisos
+  (imposible sugerir contenido ajeno; índice de texto Mongo con degradación
+  a regex) con buscador en el visor; y páginas HTML crudas servidas con CSP
+  propia dentro de iframe sandbox (origen opaco, sin cookies).
 - **CMS "Contenidos" (US-4)**: recursos adjuntos — subida (límite 50 MB) y
   pegado de imágenes en el editor con referencia `recurso:`, gestor por
   documento, y stream vía endpoint gated por colección; los archivos de

--- a/packages/api/scripts/crear-indices-busqueda.ts
+++ b/packages/api/scripts/crear-indices-busqueda.ts
@@ -1,0 +1,31 @@
+/**
+ * Crea los índices de texto de Mongo que usa la búsqueda del CMS (US-5):
+ *   - Documento.titulo (text)
+ *   - DocumentoVersion.cuerpo (text)
+ *
+ * Idempotente: createIndex no hace nada si el índice ya existe.
+ * Correr una vez por entorno (el endpoint degrada a regex si faltan):
+ *   ./node_modules/.bin/tsx scripts/crear-indices-busqueda.ts
+ */
+import { MongoClient } from 'mongodb';
+import { config } from '../src/config/index.js';
+
+async function main() {
+  const client = new MongoClient(config.databaseURI);
+  await client.connect();
+  const db = client.db();
+
+  console.log('[indices] creando índice de texto Documento.titulo…');
+  await db.collection('Documento').createIndex({ titulo: 'text' }, { name: 'busqueda_titulo_text' });
+
+  console.log('[indices] creando índice de texto DocumentoVersion.cuerpo…');
+  await db.collection('DocumentoVersion').createIndex({ cuerpo: 'text' }, { name: 'busqueda_cuerpo_text' });
+
+  console.log('[indices] listo.');
+  await client.close();
+}
+
+main().catch((error) => {
+  console.error('[indices] error:', error);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/colecciones.controller.ts
+++ b/packages/api/src/controllers/colecciones.controller.ts
@@ -108,7 +108,13 @@ export async function updateColeccion(req: Request, res: Response): Promise<void
     }
 
     if (slug !== undefined) {
-      const slugValido = validarSlug(slug);
+      // Conservar el slug ACTUAL siempre es válido, aunque después se haya
+      // reservado: si no, una colección preexistente con ese slug quedaría
+      // ineditable (los clientes reenvían el objeto completo).
+      const slugValido =
+        slug === coleccion.getSlug() && typeof slug === 'string' && SLUG_REGEX.test(slug)
+          ? slug
+          : validarSlug(slug);
       if (!slugValido) {
         res.status(400).json({ status: 'error', message: 'El slug debe contener solo letras minúsculas, números y guiones, y no puede ser una palabra reservada' });
         return;

--- a/packages/api/src/controllers/colecciones.controller.ts
+++ b/packages/api/src/controllers/colecciones.controller.ts
@@ -16,7 +16,7 @@ const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 // Segmentos que el router del visor usa como literales bajo /contenidos/:
 // una colección con este slug quedaría inalcanzable (shadowing de rutas).
-const SLUGS_RESERVADOS = new Set(['recursos']);
+const SLUGS_RESERVADOS = new Set(['recursos', 'busqueda']);
 
 function validarSlug(slug: unknown): string | null {
   if (typeof slug !== 'string' || !SLUG_REGEX.test(slug) || SLUGS_RESERVADOS.has(slug)) return null;

--- a/packages/api/src/controllers/contenidos-lectura.controller.ts
+++ b/packages/api/src/controllers/contenidos-lectura.controller.ts
@@ -100,6 +100,42 @@ export async function getArbolColeccion(req: Request, res: Response): Promise<vo
 }
 
 /**
+ * Resolución compartida de una página publicada: path → árbol visible →
+ * documento con su versión publicada. null = 404 (no visible/no publicada).
+ * La usan getPagina y getHtmlCrudo (misma semántica de visibilidad).
+ */
+async function resolverPaginaPublicada(
+  coleccionId: string,
+  rawPath: string,
+): Promise<{
+  arbol: ReturnType<typeof construirArbolVisible>;
+  nodo: NonNullable<ReturnType<typeof resolverPath>>['nodo'];
+  breadcrumb: { titulo: string; slug: string }[];
+  documento: Documento;
+  version: DocumentoVersion;
+} | null> {
+  const path = String(rawPath ?? '')
+    .split('/')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const arbol = construirArbolVisible(await getDocumentosPlanos(coleccionId));
+
+  // Resolver SOBRE el árbol visible: lo no publicado no existe para el visor.
+  const resuelto = resolverPath(arbol, path);
+  if (!resuelto) return null;
+
+  const q = new Parse.Query<Documento>('Documento');
+  q.equalTo('exists' as any, true as any);
+  q.include('version' as any);
+  const documento = await q.get(resuelto.nodo.id, { useMasterKey: true }).catch(() => null);
+  const version = documento?.getVersion();
+  if (!documento || !version) return null;
+
+  return { arbol, nodo: resuelto.nodo, breadcrumb: resuelto.breadcrumb, documento, version };
+}
+
+/**
  * GET /api/contenidos/:slug/pagina/*path — la página publicada con todo lo
  * que el visor necesita: cuerpoHtml, toc, breadcrumb, prev/next.
  */
@@ -108,31 +144,12 @@ export async function getPagina(req: Request, res: Response): Promise<void> {
     const info = await autorizarColeccion(req, res);
     if (!info) return;
 
-    const path = String((req.params as Record<string, string>)[0] ?? '')
-      .split('/')
-      .map((s) => s.trim())
-      .filter(Boolean);
-
-    const arbol = construirArbolVisible(await getDocumentosPlanos(info.id));
-
-    // Resolver SOBRE el árbol visible: lo no publicado no existe para el visor.
-    const resuelto = resolverPath(arbol, path);
+    const resuelto = await resolverPaginaPublicada(info.id, (req.params as Record<string, string>)[0]);
     if (!resuelto) {
       res.status(404).json({ status: 'error', message: 'No encontrado' });
       return;
     }
-    const { nodo, breadcrumb } = resuelto;
-
-    // Versión publicada (incluida) del documento resuelto.
-    const q = new Parse.Query<Documento>('Documento');
-    q.equalTo('exists' as any, true as any);
-    q.include('version' as any);
-    const documento = await q.get(nodo.id, { useMasterKey: true }).catch(() => null);
-    const version = documento?.getVersion();
-    if (!documento || !version) {
-      res.status(404).json({ status: 'error', message: 'No encontrado' });
-      return;
-    }
+    const { arbol, nodo, breadcrumb, documento, version } = resuelto;
 
     // Curación perezosa: versiones publicadas ANTES de que el pipeline
     // generara ids/TOC (toc === undefined) se re-renderizan una vez con el
@@ -182,43 +199,64 @@ export async function getHtmlCrudo(req: Request, res: Response): Promise<void> {
     const info = await autorizarColeccion(req, res);
     if (!info) return;
 
-    const path = String((req.params as Record<string, string>)[0] ?? '')
-      .split('/')
-      .map((s) => s.trim())
-      .filter(Boolean);
-
-    const arbol = construirArbolVisible(await getDocumentosPlanos(info.id));
-    const resuelto = resolverPath(arbol, path);
+    const resuelto = await resolverPaginaPublicada(info.id, (req.params as Record<string, string>)[0]);
     if (!resuelto || resuelto.nodo.tipo !== 'html') {
       res.status(404).json({ status: 'error', message: 'No encontrado' });
       return;
     }
 
-    const q = new Parse.Query<Documento>('Documento');
-    q.equalTo('exists' as any, true as any);
-    q.include('version' as any);
-    const documento = await q.get(resuelto.nodo.id, { useMasterKey: true }).catch(() => null);
-    const version = documento?.getVersion();
-    if (!documento || !version) {
-      res.status(404).json({ status: 'error', message: 'No encontrado' });
-      return;
-    }
-
-    // CSP del documento embebido: inline sí (es una demo autocontenida),
-    // recursos externos no; solo embebible desde este mismo sitio.
+    // CSP del documento: inline sí (demo autocontenida), recursos externos
+    // no. La directiva `sandbox` fuerza el origen opaco EN EL SERVIDOR:
+    // incluso abierto top-level (link directo, fuera del iframe) el
+    // documento corre sandboxeado — sin cookies, sin same-origin, sin forms.
     res.setHeader(
       'Content-Security-Policy',
-      "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; media-src data: blob:; frame-ancestors 'self'",
+      "sandbox allow-scripts; default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; media-src data: blob:; form-action 'none'; frame-ancestors 'self'",
     );
     res.setHeader('X-Content-Type-Options', 'nosniff');
-    res.setHeader('Cache-Control', 'private, max-age=300');
-    res.type('text/html; charset=utf-8').send(version.getCuerpo());
+    // Sin cache: el cuerpo depende de la autorización de ESTE request
+    // (despublicar o revocar acceso debe surtir efecto de inmediato).
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.type('text/html; charset=utf-8').send(resuelto.version.getCuerpo());
   } catch {
     res.status(500).json({ status: 'error', message: 'Error al servir la página' });
   }
 }
 
 const BUSQUEDA_MAX = 20;
+
+// Disponibilidad del índice de texto, memoizada por campo: sin esto, un
+// entorno sin índices pagaría DOS $text fallidos por cada tecleo, siempre.
+const indiceTexto = new Map<string, boolean>();
+
+function escaparRegex(q: string): string {
+  return q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** fullText si el índice existe (memoizado); si no, regex contains. */
+async function buscarConIndice<T extends Parse.Object>(
+  crearQuery: () => Parse.Query<T>,
+  campo: string,
+  q: string,
+  configurar: (query: Parse.Query<T>) => void,
+): Promise<T[]> {
+  if (indiceTexto.get(campo) !== false) {
+    try {
+      const query = crearQuery();
+      (query as any).fullText(campo, q);
+      configurar(query);
+      const out = await query.find({ useMasterKey: true });
+      indiceTexto.set(campo, true);
+      return out;
+    } catch {
+      indiceTexto.set(campo, false); // sin índice: regex de aquí en adelante
+    }
+  }
+  const query = crearQuery();
+  query.matches(campo as any, new RegExp(escaparRegex(q), 'i') as any);
+  configurar(query);
+  return query.find({ useMasterKey: true });
+}
 
 /**
  * GET /api/contenidos/busqueda?q=… — búsqueda full-text con SCOPE por
@@ -248,10 +286,13 @@ export async function buscarContenidos(req: Request, res: Response): Promise<voi
       return;
     }
 
-    // Mapa documentoId → {path, coleccion} de TODO lo visible del usuario.
-    const paginaPorId = new Map<string, { path: string; coleccion: string; clave: string | null; titulo: string }>();
-    for (const info of infos) {
-      const arbol = construirArbolVisible(await getDocumentosPlanos(info.id));
+    // Mapa documentoId → {path, coleccion} de TODO lo visible del usuario
+    // (árboles en paralelo: una espera por colección secuencial sumaría).
+    const paginaPorId = new Map<string, { path: string; coleccion: string; clave: string | null; titulo: string; tipo?: string }>();
+    const arboles = await Promise.all(
+      infos.map(async (info) => ({ info, arbol: construirArbolVisible(await getDocumentosPlanos(info.id)) })),
+    );
+    for (const { info, arbol } of arboles) {
       for (const p of paginasEnOrden(arbol)) {
         paginaPorId.set(p.id, { path: p.path, coleccion: info.slug, clave: info.clave, titulo: p.titulo });
       }
@@ -269,42 +310,30 @@ export async function buscarContenidos(req: Request, res: Response): Promise<voi
       return dq;
     };
 
-    // 1) Títulos que matchean (fullText → fallback regex sin índice).
-    let docsTitulo: Documento[] = [];
-    try {
-      const dq = baseDocs();
-      (dq as any).fullText('titulo', q);
-      dq.include('version' as any);
-      dq.limit(BUSQUEDA_MAX);
-      docsTitulo = await dq.find({ useMasterKey: true });
-    } catch {
-      const dq = baseDocs();
-      dq.matches('titulo' as any, new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') as any);
-      dq.include('version' as any);
-      dq.limit(BUSQUEDA_MAX);
-      docsTitulo = await dq.find({ useMasterKey: true });
-    }
-
-    // 2) Cuerpos publicados que matchean: DocumentoVersion + verificación de
-    //    que ES la versión publicada de un documento visible del scope.
-    let versionesCuerpo: DocumentoVersion[] = [];
-    const baseVersiones = () => {
-      const vq = new Parse.Query<DocumentoVersion>('DocumentoVersion');
-      vq.equalTo('exists' as any, true as any);
-      vq.matchesQuery('documento' as any, baseDocs() as any);
-      vq.include('documento' as any);
-      vq.limit(BUSQUEDA_MAX * 3); // margen: se filtran borradores/versiones viejas
-      return vq;
-    };
-    try {
-      const vq = baseVersiones();
-      (vq as any).fullText('cuerpo', q);
-      versionesCuerpo = await vq.find({ useMasterKey: true });
-    } catch {
-      const vq = baseVersiones();
-      vq.matches('cuerpo' as any, new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') as any);
-      versionesCuerpo = await vq.find({ useMasterKey: true });
-    }
+    // 1) Títulos que matchean y 2) cuerpos cuya versión ES la publicada de
+    // un documento del scope (matchesKeyInQuery contra Documento.version:
+    // sin ventanas post-filtradas que dejarían fuera publicadas cuando el
+    // historial/borradores dominan los matches). En paralelo.
+    const [docsTitulo, versionesCuerpo] = await Promise.all([
+      buscarConIndice<Documento>(baseDocs, 'titulo', q, (query) => {
+        query.include('version' as any);
+        query.limit(BUSQUEDA_MAX);
+      }),
+      buscarConIndice<DocumentoVersion>(
+        () => {
+          const vq = new Parse.Query<DocumentoVersion>('DocumentoVersion');
+          vq.equalTo('exists' as any, true as any);
+          (vq as any).matchesKeyInQuery('objectId', 'version.objectId', baseDocs());
+          return vq;
+        },
+        'cuerpo',
+        q,
+        (query) => {
+          query.include('documento' as any);
+          query.limit(BUSQUEDA_MAX);
+        },
+      ),
+    ]);
 
     const resultados: { titulo: string; coleccion: string; clave: string | null; path: string; snippet: string }[] = [];
     const vistos = new Set<string>();

--- a/packages/api/src/controllers/contenidos-lectura.controller.ts
+++ b/packages/api/src/controllers/contenidos-lectura.controller.ts
@@ -14,6 +14,8 @@ import {
   resolverPath,
   type DocPlano,
 } from '../services/contenidos-arbol.js';
+import { extraerSnippet } from '../services/contenidos-busqueda.js';
+import { DocumentoVersion } from '../models/DocumentoVersion.js';
 
 /**
  * Lectura del CMS "Contenidos" (design §2/§4): NINGÚN byte de contenido sale
@@ -165,5 +167,180 @@ export async function getPagina(req: Request, res: Response): Promise<void> {
     });
   } catch {
     res.status(500).json({ status: 'error', message: 'Error al obtener la página' });
+  }
+}
+
+/**
+ * GET /api/contenidos/:slug/html/*path — el cuerpo CRUDO de una página tipo
+ * `html`, con CSP propia, pensado para consumirse SOLO dentro de un
+ * <iframe sandbox="allow-scripts"> (sin allow-same-origin: origen opaco —
+ * sus scripts no ven cookies ni pueden llamar al API con credenciales).
+ * Nunca se inyecta en el DOM de la app (design §3).
+ */
+export async function getHtmlCrudo(req: Request, res: Response): Promise<void> {
+  try {
+    const info = await autorizarColeccion(req, res);
+    if (!info) return;
+
+    const path = String((req.params as Record<string, string>)[0] ?? '')
+      .split('/')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const arbol = construirArbolVisible(await getDocumentosPlanos(info.id));
+    const resuelto = resolverPath(arbol, path);
+    if (!resuelto || resuelto.nodo.tipo !== 'html') {
+      res.status(404).json({ status: 'error', message: 'No encontrado' });
+      return;
+    }
+
+    const q = new Parse.Query<Documento>('Documento');
+    q.equalTo('exists' as any, true as any);
+    q.include('version' as any);
+    const documento = await q.get(resuelto.nodo.id, { useMasterKey: true }).catch(() => null);
+    const version = documento?.getVersion();
+    if (!documento || !version) {
+      res.status(404).json({ status: 'error', message: 'No encontrado' });
+      return;
+    }
+
+    // CSP del documento embebido: inline sí (es una demo autocontenida),
+    // recursos externos no; solo embebible desde este mismo sitio.
+    res.setHeader(
+      'Content-Security-Policy',
+      "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:; media-src data: blob:; frame-ancestors 'self'",
+    );
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Cache-Control', 'private, max-age=300');
+    res.type('text/html; charset=utf-8').send(version.getCuerpo());
+  } catch {
+    res.status(500).json({ status: 'error', message: 'Error al servir la página' });
+  }
+}
+
+const BUSQUEDA_MAX = 20;
+
+/**
+ * GET /api/contenidos/busqueda?q=… — búsqueda full-text con SCOPE por
+ * permisos (design §2): solo consulta las colecciones permitidas del
+ * usuario; es imposible que sugiera títulos o contenido ajenos.
+ * Usa el índice de texto de Mongo (scripts/crear-indices-busqueda.ts);
+ * si aún no existe, degrada a regex (colecciones chicas: aceptable).
+ */
+export async function buscarContenidos(req: Request, res: Response): Promise<void> {
+  const user = req.appUser;
+  const q = String(req.query.q ?? '').trim();
+  if (!user) {
+    res.status(401).json({ status: 'error', message: 'Autenticación requerida' });
+    return;
+  }
+  if (q.length < 2) {
+    res.json({ status: 'ok', resultados: [] });
+    return;
+  }
+
+  try {
+    const permitidos = await getSlugsPermitidos(user);
+    const porSlug = await getColeccionesPorSlug();
+    const infos = [...porSlug.values()].filter((c) => permitidos.has(c.slug));
+    if (infos.length === 0) {
+      res.json({ status: 'ok', resultados: [] });
+      return;
+    }
+
+    // Mapa documentoId → {path, coleccion} de TODO lo visible del usuario.
+    const paginaPorId = new Map<string, { path: string; coleccion: string; clave: string | null; titulo: string }>();
+    for (const info of infos) {
+      const arbol = construirArbolVisible(await getDocumentosPlanos(info.id));
+      for (const p of paginasEnOrden(arbol)) {
+        paginaPorId.set(p.id, { path: p.path, coleccion: info.slug, clave: info.clave, titulo: p.titulo });
+      }
+    }
+
+    const punteros = infos.map((i) => Parse.Object.extend('Coleccion').createWithoutData(i.id));
+
+    // Query base de documentos publicados dentro del scope.
+    const baseDocs = () => {
+      const dq = new Parse.Query<Documento>('Documento');
+      dq.equalTo('exists' as any, true as any);
+      dq.equalTo('active' as any, true as any);
+      dq.equalTo('publicado' as any, true as any);
+      dq.containedIn('coleccion' as any, punteros as any);
+      return dq;
+    };
+
+    // 1) Títulos que matchean (fullText → fallback regex sin índice).
+    let docsTitulo: Documento[] = [];
+    try {
+      const dq = baseDocs();
+      (dq as any).fullText('titulo', q);
+      dq.include('version' as any);
+      dq.limit(BUSQUEDA_MAX);
+      docsTitulo = await dq.find({ useMasterKey: true });
+    } catch {
+      const dq = baseDocs();
+      dq.matches('titulo' as any, new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') as any);
+      dq.include('version' as any);
+      dq.limit(BUSQUEDA_MAX);
+      docsTitulo = await dq.find({ useMasterKey: true });
+    }
+
+    // 2) Cuerpos publicados que matchean: DocumentoVersion + verificación de
+    //    que ES la versión publicada de un documento visible del scope.
+    let versionesCuerpo: DocumentoVersion[] = [];
+    const baseVersiones = () => {
+      const vq = new Parse.Query<DocumentoVersion>('DocumentoVersion');
+      vq.equalTo('exists' as any, true as any);
+      vq.matchesQuery('documento' as any, baseDocs() as any);
+      vq.include('documento' as any);
+      vq.limit(BUSQUEDA_MAX * 3); // margen: se filtran borradores/versiones viejas
+      return vq;
+    };
+    try {
+      const vq = baseVersiones();
+      (vq as any).fullText('cuerpo', q);
+      versionesCuerpo = await vq.find({ useMasterKey: true });
+    } catch {
+      const vq = baseVersiones();
+      vq.matches('cuerpo' as any, new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i') as any);
+      versionesCuerpo = await vq.find({ useMasterKey: true });
+    }
+
+    const resultados: { titulo: string; coleccion: string; clave: string | null; path: string; snippet: string }[] = [];
+    const vistos = new Set<string>();
+
+    for (const d of docsTitulo) {
+      const pagina = paginaPorId.get(d.id);
+      if (!pagina || vistos.has(d.id)) continue;
+      vistos.add(d.id);
+      resultados.push({
+        titulo: pagina.titulo,
+        coleccion: pagina.coleccion,
+        clave: pagina.clave,
+        path: pagina.path,
+        snippet: extraerSnippet(d.getVersion()?.getCuerpo() ?? '', q),
+      });
+    }
+    for (const v of versionesCuerpo) {
+      const documento = v.getDocumento();
+      if (!documento) continue;
+      // Solo la versión PUBLICADA cuenta (no borradores ni historial).
+      if ((documento.get('version') as Parse.Object | undefined)?.id !== v.id) continue;
+      const pagina = paginaPorId.get(documento.id);
+      if (!pagina || vistos.has(documento.id)) continue;
+      vistos.add(documento.id);
+      resultados.push({
+        titulo: pagina.titulo,
+        coleccion: pagina.coleccion,
+        clave: pagina.clave,
+        path: pagina.path,
+        snippet: extraerSnippet(v.getCuerpo(), q),
+      });
+      if (resultados.length >= BUSQUEDA_MAX) break;
+    }
+
+    res.json({ status: 'ok', resultados: resultados.slice(0, BUSQUEDA_MAX) });
+  } catch {
+    res.status(500).json({ status: 'error', message: 'Error en la búsqueda' });
   }
 }

--- a/packages/api/src/routes/contenidos-visor.routes.ts
+++ b/packages/api/src/routes/contenidos-visor.routes.ts
@@ -4,6 +4,8 @@ import {
   getMisColecciones,
   getArbolColeccion,
   getPagina,
+  getHtmlCrudo,
+  buscarContenidos,
 } from '../controllers/contenidos-lectura.controller.js';
 import { streamRecurso } from '../controllers/recursos.controller.js';
 
@@ -13,9 +15,11 @@ import { streamRecurso } from '../controllers/recursos.controller.js';
 const router = Router();
 
 router.get('/me/colecciones', identifyUser, getMisColecciones);
-// Antes de :slug/... para que "recursos" nunca se interprete como slug.
+// Literales antes de :slug/... ("recursos"/"busqueda" son slugs reservados).
 router.get('/contenidos/recursos/:id/:nombre', identifyUser, streamRecurso);
+router.get('/contenidos/busqueda', identifyUser, buscarContenidos);
 router.get('/contenidos/:slug/arbol', identifyUser, getArbolColeccion);
 router.get('/contenidos/:slug/pagina/*', identifyUser, getPagina);
+router.get('/contenidos/:slug/html/*', identifyUser, getHtmlCrudo);
 
 export default router;

--- a/packages/api/src/services/contenidos-busqueda.ts
+++ b/packages/api/src/services/contenidos-busqueda.ts
@@ -4,7 +4,10 @@
  */
 
 const RE_HTML_TAGS = /<[^>]*>/g;
-const RE_MD_RUIDO = /[#*_`>|[\]()!:-]+/g;
+// Solo puntuación ESTRUCTURAL de Markdown. Sin `-`/`:`: son comunes dentro
+// de palabras (flexbox-magico, http:, 10:30) y comérselos rompía el
+// centrado del snippet sobre el término buscado.
+const RE_MD_RUIDO = /[#*_`>|[\]()!]+/g;
 const RE_ESPACIOS = /\s+/g;
 
 /**
@@ -18,15 +21,20 @@ export function aTextoPlano(cuerpo: string): string {
 
 /**
  * Snippet alrededor de la primera aparición del término (case-insensitive),
- * con elipsis en los cortes. Si el término no aparece (p. ej. matcheó por
- * stemming del índice), devuelve el inicio del texto.
+ * con elipsis en los cortes. El término se busca sobre el cuerpo CRUDO (no el
+ * texto ya limpiado) para no fallar el centrado cuando el término lleva
+ * puntuación; la ventana resultante sí se pasa a texto plano. Si el término no
+ * aparece (p. ej. matcheó por stemming del índice), devuelve el inicio.
  */
 export function extraerSnippet(cuerpo: string, termino: string, radio = 80): string {
-  const texto = aTextoPlano(cuerpo);
-  if (!texto) return '';
-  const idx = texto.toLowerCase().indexOf(termino.toLowerCase());
-  if (idx < 0) return texto.slice(0, radio * 2) + (texto.length > radio * 2 ? '…' : '');
+  if (!cuerpo) return '';
+  const idx = cuerpo.toLowerCase().indexOf(termino.toLowerCase());
+  if (idx < 0) {
+    const texto = aTextoPlano(cuerpo);
+    return texto.slice(0, radio * 2) + (texto.length > radio * 2 ? '…' : '');
+  }
   const inicio = Math.max(0, idx - radio);
-  const fin = Math.min(texto.length, idx + termino.length + radio);
-  return `${inicio > 0 ? '…' : ''}${texto.slice(inicio, fin)}${fin < texto.length ? '…' : ''}`;
+  const fin = Math.min(cuerpo.length, idx + termino.length + radio);
+  const ventana = aTextoPlano(cuerpo.slice(inicio, fin));
+  return `${inicio > 0 ? '…' : ''}${ventana}${fin < cuerpo.length ? '…' : ''}`;
 }

--- a/packages/api/src/services/contenidos-busqueda.ts
+++ b/packages/api/src/services/contenidos-busqueda.ts
@@ -3,12 +3,17 @@
  * El scope por permisos vive en el controller; aquí solo el snippet.
  */
 
+const RE_HTML_TAGS = /<[^>]*>/g;
 const RE_MD_RUIDO = /[#*_`>|[\]()!:-]+/g;
 const RE_ESPACIOS = /\s+/g;
 
-/** Markdown → texto plano aproximado para snippets. */
-export function aTextoPlano(markdown: string): string {
-  return markdown.replace(RE_MD_RUIDO, ' ').replace(RE_ESPACIOS, ' ').trim();
+/**
+ * Markdown u HTML crudo → texto plano aproximado para snippets. Los tags se
+ * quitan primero: los cuerpos de páginas tipo `html` mostrarían sopa de
+ * etiquetas en los resultados.
+ */
+export function aTextoPlano(cuerpo: string): string {
+  return cuerpo.replace(RE_HTML_TAGS, ' ').replace(RE_MD_RUIDO, ' ').replace(RE_ESPACIOS, ' ').trim();
 }
 
 /**

--- a/packages/api/src/services/contenidos-busqueda.ts
+++ b/packages/api/src/services/contenidos-busqueda.ts
@@ -1,0 +1,27 @@
+/**
+ * Utilidades PURAS de la búsqueda del CMS (US-5) — testeables sin Parse.
+ * El scope por permisos vive en el controller; aquí solo el snippet.
+ */
+
+const RE_MD_RUIDO = /[#*_`>|[\]()!:-]+/g;
+const RE_ESPACIOS = /\s+/g;
+
+/** Markdown → texto plano aproximado para snippets. */
+export function aTextoPlano(markdown: string): string {
+  return markdown.replace(RE_MD_RUIDO, ' ').replace(RE_ESPACIOS, ' ').trim();
+}
+
+/**
+ * Snippet alrededor de la primera aparición del término (case-insensitive),
+ * con elipsis en los cortes. Si el término no aparece (p. ej. matcheó por
+ * stemming del índice), devuelve el inicio del texto.
+ */
+export function extraerSnippet(cuerpo: string, termino: string, radio = 80): string {
+  const texto = aTextoPlano(cuerpo);
+  if (!texto) return '';
+  const idx = texto.toLowerCase().indexOf(termino.toLowerCase());
+  if (idx < 0) return texto.slice(0, radio * 2) + (texto.length > radio * 2 ? '…' : '');
+  const inicio = Math.max(0, idx - radio);
+  const fin = Math.min(texto.length, idx + termino.length + radio);
+  return `${inicio > 0 ? '…' : ''}${texto.slice(inicio, fin)}${fin < texto.length ? '…' : ''}`;
+}

--- a/packages/api/tests/contenidos-busqueda.test.ts
+++ b/packages/api/tests/contenidos-busqueda.test.ts
@@ -12,6 +12,12 @@ describe('aTextoPlano', () => {
       'Título negritas y código link recurso x/y.png',
     );
   });
+
+  it('quita tags de HTML crudo (las páginas tipo html no muestran sopa de etiquetas)', () => {
+    expect(aTextoPlano('<!doctype html><html><body><h1>Demo Flexbox</h1><p>Un ejemplo</p></body></html>')).toBe(
+      'Demo Flexbox Un ejemplo',
+    );
+  });
 });
 
 describe('extraerSnippet', () => {

--- a/packages/api/tests/contenidos-busqueda.test.ts
+++ b/packages/api/tests/contenidos-busqueda.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests de las utilidades puras de la búsqueda del CMS (US-5).
+ * El SCOPE por permisos se verifica en el controller (usa getSlugsPermitidos,
+ * el mismo gate probado del visor); aquí la extracción de snippets.
+ */
+import { describe, it, expect } from 'vitest';
+import { aTextoPlano, extraerSnippet } from '../src/services/contenidos-busqueda.js';
+
+describe('aTextoPlano', () => {
+  it('quita el ruido de Markdown', () => {
+    expect(aTextoPlano('# Título\n\n**negritas** y `código` [link](recurso:x/y.png)')).toBe(
+      'Título negritas y código link recurso x/y.png',
+    );
+  });
+});
+
+describe('extraerSnippet', () => {
+  const cuerpo = `# Lab 1\n\n${'relleno '.repeat(40)}la palabra flexbox aparece aquí${' relleno'.repeat(40)}`;
+
+  it('centra el snippet en la primera aparición del término (case-insensitive)', () => {
+    const s = extraerSnippet(cuerpo, 'FLEXBOX');
+    expect(s).toContain('flexbox');
+    expect(s.startsWith('…')).toBe(true);
+    expect(s.endsWith('…')).toBe(true);
+    expect(s.length).toBeLessThan(220);
+  });
+
+  it('sin aparición devuelve el inicio del texto', () => {
+    const s = extraerSnippet(cuerpo, 'inexistente-xyz');
+    expect(s.startsWith('Lab 1')).toBe(true);
+  });
+
+  it('cuerpo vacío devuelve vacío', () => {
+    expect(extraerSnippet('', 'algo')).toBe('');
+  });
+});

--- a/packages/api/tests/contenidos-busqueda.test.ts
+++ b/packages/api/tests/contenidos-busqueda.test.ts
@@ -7,9 +7,9 @@ import { describe, it, expect } from 'vitest';
 import { aTextoPlano, extraerSnippet } from '../src/services/contenidos-busqueda.js';
 
 describe('aTextoPlano', () => {
-  it('quita el ruido de Markdown', () => {
+  it('quita el ruido de Markdown (sin comerse guiones/dos-puntos internos)', () => {
     expect(aTextoPlano('# Título\n\n**negritas** y `código` [link](recurso:x/y.png)')).toBe(
-      'Título negritas y código link recurso x/y.png',
+      'Título negritas y código link recurso:x/y.png',
     );
   });
 
@@ -29,6 +29,12 @@ describe('extraerSnippet', () => {
     expect(s.startsWith('…')).toBe(true);
     expect(s.endsWith('…')).toBe(true);
     expect(s.length).toBeLessThan(220);
+  });
+
+  it('centra correctamente términos con guion (no los parte al limpiar)', () => {
+    const conGuion = `# Título\n\n${'x '.repeat(50)}el término flexbox-magico va aquí${' y'.repeat(50)}`;
+    const s = extraerSnippet(conGuion, 'flexbox-magico');
+    expect(s).toContain('flexbox-magico');
   });
 
   it('sin aparición devuelve el inicio del texto', () => {

--- a/packages/web/src/components/contenidos/VisorContenidoPage.module.css
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.module.css
@@ -244,3 +244,82 @@
   font-family: inherit;
   cursor: pointer;
 }
+
+/* ── Búsqueda (US-5) ── */
+.buscador {
+  position: relative;
+  flex-shrink: 1;
+  min-width: 0;
+}
+.buscadorInput {
+  width: 260px;
+  max-width: 34vw;
+  padding: 6px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-family: inherit;
+}
+.buscadorInput:focus {
+  outline: none;
+  border-color: var(--sidebar-active-color);
+}
+.buscadorPanel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  width: 420px;
+  max-width: 80vw;
+  max-height: 380px;
+  overflow-y: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  z-index: 30;
+}
+.buscadorItem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  padding: 10px 14px;
+  cursor: pointer;
+  font-family: inherit;
+}
+.buscadorItem:last-child { border-bottom: none; }
+.buscadorItem:hover { background: var(--bg-page); }
+.buscadorTitulo {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--sidebar-active-color);
+}
+.buscadorSnippet {
+  display: block;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.buscadorVacio {
+  padding: 12px 14px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+/* ── Iframe sandbox de páginas HTML (US-5) ── */
+.htmlFrame {
+  width: 100%;
+  min-height: calc(100vh - 160px);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: #fff;
+}

--- a/packages/web/src/components/contenidos/VisorContenidoPage.tsx
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.tsx
@@ -67,6 +67,13 @@ export default function VisorContenidoPage() {
     { titulo: string; coleccion: string; clave: string | null; path: string; snippet: string }[]
   >([]);
   const [buscando, setBuscando] = useState(false);
+  const [errorBusqueda, setErrorBusqueda] = useState(false);
+
+  // Páginas html: se descargan con el MISMO auth que el resto del visor
+  // (header x-session-token) y se montan como blob en el iframe sandboxeado
+  // — un src directo solo podría autenticarse por cookie.
+  const [htmlBlobUrl, setHtmlBlobUrl] = useState<string | null>(null);
+  const [htmlError, setHtmlError] = useState(false);
 
   const path = (pathParam ?? '').replace(/\/+$/, '');
   const rutaPanel = user?.userType === 'admin' ? '/admin' : '/alumno';
@@ -129,17 +136,54 @@ export default function VisorContenidoPage() {
     }
     let cancelado = false;
     setBuscando(true);
+    setErrorBusqueda(false);
     const timer = setTimeout(() => {
       fetch(`${API_BASE}/contenidos/busqueda?q=${encodeURIComponent(q)}`, {
         headers: { 'x-session-token': sessionToken ?? '' },
       })
-        .then((r) => (r.ok ? r.json() : null))
-        .then((json) => { if (!cancelado) setResultados(json?.resultados ?? []); })
-        .catch(() => {})
+        .then(async (r) => {
+          if (cancelado) return;
+          if (!r.ok) {
+            // 401/500 NO son "sin resultados": el usuario debe distinguirlo.
+            setResultados([]);
+            setErrorBusqueda(true);
+            return;
+          }
+          const json = await r.json();
+          if (!cancelado) setResultados(json?.resultados ?? []);
+        })
+        .catch(() => { if (!cancelado) { setResultados([]); setErrorBusqueda(true); } })
         .finally(() => { if (!cancelado) setBuscando(false); });
     }, 300);
     return () => { cancelado = true; clearTimeout(timer); };
   }, [consulta, sessionToken]);
+
+  /* ── Página html: descargar autenticado y montar como blob sandboxeado ── */
+  useEffect(() => {
+    if (!pagina || pagina.tipo !== 'html' || !slug || !path) {
+      setHtmlBlobUrl(null);
+      setHtmlError(false);
+      return;
+    }
+    let cancelado = false;
+    let blobUrl: string | null = null;
+    setHtmlError(false);
+    fetch(`${API_BASE}/contenidos/${slug}/html/${path}`, {
+      headers: { 'x-session-token': sessionToken ?? '' },
+    })
+      .then(async (r) => {
+        if (cancelado) return;
+        if (!r.ok) throw new Error();
+        const html = await r.text();
+        blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+        if (!cancelado) setHtmlBlobUrl(blobUrl);
+      })
+      .catch(() => { if (!cancelado) setHtmlError(true); });
+    return () => {
+      cancelado = true;
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [pagina, slug, path, sessionToken]);
 
   /* ── Sin path: ir a la primera página del árbol ── */
   useEffect(() => {
@@ -289,6 +333,8 @@ export default function VisorContenidoPage() {
             <div className={styles.buscadorPanel}>
               {buscando ? (
                 <div className={styles.buscadorVacio}>Buscando…</div>
+              ) : errorBusqueda ? (
+                <div className={styles.buscadorVacio}>Error al buscar — reintenta</div>
               ) : resultados.length === 0 ? (
                 <div className={styles.buscadorVacio}>Sin resultados</div>
               ) : (
@@ -351,13 +397,20 @@ export default function VisorContenidoPage() {
               {pagina.tipo === 'html' ? (
                 /* HTML crudo SIEMPRE sandboxeado: sin allow-same-origin el
                    iframe corre en origen opaco — sus scripts no ven cookies
-                   ni pueden llamar al API con credenciales (design §3). */
-                <iframe
-                  src={`${API_BASE}/contenidos/${slug}/html/${path}`}
-                  sandbox="allow-scripts"
-                  className={styles.htmlFrame}
-                  title={pagina.titulo}
-                />
+                   ni pueden llamar al API con credenciales (design §3). El
+                   server además manda CSP con `sandbox` (defensa doble). */
+                htmlError ? (
+                  <div className={styles.notFound}><h1>😵</h1><p>No se pudo cargar la demo.</p></div>
+                ) : !htmlBlobUrl ? (
+                  <p className={styles.hint}>Cargando…</p>
+                ) : (
+                  <iframe
+                    src={htmlBlobUrl}
+                    sandbox="allow-scripts"
+                    className={styles.htmlFrame}
+                    title={pagina.titulo}
+                  />
+                )
               ) : (
                 /* Seguro: cuerpoHtml lo renderizó el SERVIDOR al publicar con el
                    pipeline compartido (rehype-sanitize, allowlist) — scripts,

--- a/packages/web/src/components/contenidos/VisorContenidoPage.tsx
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.tsx
@@ -61,6 +61,13 @@ export default function VisorContenidoPage() {
   const [oscuro, setOscuro] = useState(() => localStorage.getItem(TEMA_KEY) === 'oscuro');
   const [reintento, setReintento] = useState(0);
 
+  // Búsqueda (US-5): server-side, con scope por permisos.
+  const [consulta, setConsulta] = useState('');
+  const [resultados, setResultados] = useState<
+    { titulo: string; coleccion: string; clave: string | null; path: string; snippet: string }[]
+  >([]);
+  const [buscando, setBuscando] = useState(false);
+
   const path = (pathParam ?? '').replace(/\/+$/, '');
   const rutaPanel = user?.userType === 'admin' ? '/admin' : '/alumno';
 
@@ -111,6 +118,28 @@ export default function VisorContenidoPage() {
       .then((json) => { if (json) setMisColecciones(json.colecciones ?? []); })
       .catch(() => {});
   }, [sessionToken]);
+
+  /* ── Búsqueda debounced (el server aplica el scope de permisos) ── */
+  useEffect(() => {
+    const q = consulta.trim();
+    if (q.length < 2) {
+      setResultados([]);
+      setBuscando(false);
+      return;
+    }
+    let cancelado = false;
+    setBuscando(true);
+    const timer = setTimeout(() => {
+      fetch(`${API_BASE}/contenidos/busqueda?q=${encodeURIComponent(q)}`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      })
+        .then((r) => (r.ok ? r.json() : null))
+        .then((json) => { if (!cancelado) setResultados(json?.resultados ?? []); })
+        .catch(() => {})
+        .finally(() => { if (!cancelado) setBuscando(false); });
+    }, 300);
+    return () => { cancelado = true; clearTimeout(timer); };
+  }, [consulta, sessionToken]);
 
   /* ── Sin path: ir a la primera página del árbol ── */
   useEffect(() => {
@@ -248,6 +277,41 @@ export default function VisorContenidoPage() {
             ))}
           </select>
         )}
+        <div className={styles.buscador}>
+          <input
+            className={styles.buscadorInput}
+            type="search"
+            placeholder="🔍 Buscar en tus contenidos…"
+            value={consulta}
+            onChange={(e) => setConsulta(e.target.value)}
+          />
+          {consulta.trim().length >= 2 && (
+            <div className={styles.buscadorPanel}>
+              {buscando ? (
+                <div className={styles.buscadorVacio}>Buscando…</div>
+              ) : resultados.length === 0 ? (
+                <div className={styles.buscadorVacio}>Sin resultados</div>
+              ) : (
+                resultados.map((r, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    className={styles.buscadorItem}
+                    onClick={() => {
+                      setConsulta('');
+                      navigate(`/contenidos/${r.coleccion}/${r.path}`);
+                    }}
+                  >
+                    <span className={styles.buscadorTitulo}>
+                      {r.clave ? `${r.clave} · ` : ''}{r.titulo}
+                    </span>
+                    <span className={styles.buscadorSnippet}>{r.snippet}</span>
+                  </button>
+                ))
+              )}
+            </div>
+          )}
+        </div>
         <span style={{ flex: 1 }} />
         <button type="button" className={styles.temaBtn} onClick={toggleTema} title="Cambiar tema">
           {oscuro ? '☀️' : '🌙'}
@@ -285,10 +349,15 @@ export default function VisorContenidoPage() {
                 ))}
               </div>
               {pagina.tipo === 'html' ? (
-                <div className={styles.htmlAviso}>
-                  <h1>{pagina.titulo}</h1>
-                  <p>Esta página es una demo HTML interactiva — se habilita con el visor sandboxeado (próxima iteración).</p>
-                </div>
+                /* HTML crudo SIEMPRE sandboxeado: sin allow-same-origin el
+                   iframe corre en origen opaco — sus scripts no ven cookies
+                   ni pueden llamar al API con credenciales (design §3). */
+                <iframe
+                  src={`${API_BASE}/contenidos/${slug}/html/${path}`}
+                  sandbox="allow-scripts"
+                  className={styles.htmlFrame}
+                  title={pagina.titulo}
+                />
               ) : (
                 /* Seguro: cuerpoHtml lo renderizó el SERVIDOR al publicar con el
                    pipeline compartido (rehype-sanitize, allowlist) — scripts,


### PR DESCRIPTION
## Descripción

**US-5 del roadmap del CMS "Contenidos"** (`design/cms-contenidos.html` §2/§3): cierra la fuga de búsqueda de Docusaurus y habilita las demos HTML interactivas de forma segura. Incluye los fixes del code review (10 hallazgos, uno de seguridad); detalle en comentario.

> **PR apilado sobre `feature/cms-recursos` (US-4, PR #26).** Orden de merge: #25 → #26 → este → US-6.

## Cambios

### Búsqueda (`GET /api/contenidos/busqueda?q=`)
- Full-text sobre **títulos** (Documento) y **cuerpos publicados exactos** (DocumentoVersion vía `matchesKeyInQuery` contra `Documento.version` — ni borradores ni historial), **siempre restringida a las colecciones permitidas** del usuario: es imposible que sugiera contenido ajeno.
- Índice de texto de Mongo (`scripts/crear-indices-busqueda.ts`, idempotente — correr una vez por entorno) con **degradación a regex** memoizada si falta.
- Snippets centrados en el término (Markdown y HTML → texto plano); buscador en el topbar del visor con resultados desplegables.

### Páginas HTML crudas (end-to-end)
- **`GET /api/contenidos/:slug/html/*`** — cuerpo crudo con **CSP que incluye `sandbox allow-scripts`** (el sandbox lo impone el SERVIDOR: un link directo top-level también corre sandboxeado), `form-action 'none'`, sin recursos externos, `nosniff`, `no-store`.
- El visor lo descarga **autenticado por header** y lo monta como **blob en `iframe sandbox="allow-scripts"`** (sin `allow-same-origin`: origen opaco — sin cookies, sin llamadas al API). Nunca se inyecta al DOM.
- Slug `busqueda` reservado.

## Seguridad probada
- 23/23 tests (snippets, scope de poda, sanitización, admonitions/fences, TOC con entidades).
- Matriz: búsqueda anónima 401; scope solo-permitidas verificado en el diseño del query (imposible por construcción).

## Checklist
- [x] `tsc --noEmit` web y api; builds pasan
- [x] Code review (10 hallazgos) atendido
- [ ] Correr `crear-indices-busqueda.ts` en el servidor al desplegar
- [ ] Validación funcional manual