### PR TITLE
feat(cms): importador Docusaurus, colecciones por grupo y redirects (US-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" (US-6)**: importador Docusaurus→Contenidos con
+  `--dry-run` y reporte de paridad (verificado: tc2005b y tc2007b, 0 y 1
+  enlaces sin resolver, preexistentes); asignación de colecciones a grupos
+  (multi-select en el editor y submenú del grupo); redirects 301
+  `/docs/*→/contenidos/*` con mapa generado, apagados hasta el corte (US-7).
 - **CMS "Contenidos" (US-5)**: búsqueda full-text con scope por permisos
   (imposible sugerir contenido ajeno; índice de texto Mongo con degradación
   a regex) con buscador en el visor; y páginas HTML crudas servidas con CSP

--- a/packages/api/scripts/importar-docusaurus.ts
+++ b/packages/api/scripts/importar-docusaurus.ts
@@ -1,0 +1,489 @@
+/**
+ * Importador Docusaurus → CMS "Contenidos" (US-6, design §6).
+ *
+ * Traduce una instancia (packages/docusaurus/docs/<slug>) a una Coleccion
+ * preservando el contenido y la navegación por índice:
+ *   carpeta + _category_.json → Documento tipo categoria (label, position)
+ *   archivo .md + sidebar_position → Documento md PUBLICADO (v1, render+toc)
+ *   imágenes relativas junto al .md → Recurso del documento (recurso:)
+ *   assets absolutos de static/ (/img, /ppts, …) → Recurso de colección
+ *   enlaces internos .md → rutas /contenidos/<slug>/… (o reporte si no resuelven)
+ *
+ * Además genera/mezcla el mapa de redirects viejos → nuevos en
+ * src/data/redirects-docs.json (los usa el middleware de la US-6, que se
+ * enciende en el corte de la US-7).
+ *
+ * Uso (requiere el API corriendo, como los demás scripts):
+ *   cd packages/api
+ *   ./node_modules/.bin/tsx scripts/importar-docusaurus.ts --slug tc2005b --clave TC2005B \
+ *       --nombre "Construcción de software y toma de decisiones" [--dry-run]
+ *
+ * La colección NO debe existir (idempotencia simple: bórrala del admin para
+ * reintentar). --dry-run no escribe nada y imprime el reporte de paridad.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Parse from 'parse/node';
+import { renderMarkdown, extraerToc } from '@tc2005b/contenido-pipeline';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+import { Coleccion } from '../src/models/Coleccion.js';
+import { Documento } from '../src/models/Documento.js';
+import { DocumentoVersion } from '../src/models/DocumentoVersion.js';
+import { Recurso } from '../src/models/Recurso.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RAIZ_DOCUSAURUS = path.resolve(__dirname, '../../docusaurus');
+const RUTA_REDIRECTS = path.resolve(__dirname, '../src/data/redirects-docs.json');
+
+/* ── CLI ── */
+function arg(nombre: string): string | undefined {
+  const i = process.argv.indexOf(`--${nombre}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const dryRun = process.argv.includes('--dry-run');
+const slugColeccion = arg('slug');
+const claveColeccion = (arg('clave') ?? slugColeccion ?? '').toUpperCase();
+const nombreColeccion = arg('nombre') ?? claveColeccion;
+
+if (!slugColeccion) {
+  console.error('Falta --slug <instancia> (p. ej. tc2005b)');
+  process.exit(1);
+}
+
+/* ── Utilidades de nombres ── */
+const EXT_ASSET = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg', 'pdf', 'zip', 'html',
+  'sql', 'css', 'js', 'mp3', 'wav', 'mp4', 'mov', 'webm', 'csv',
+]);
+
+function slugify(texto: string): string {
+  return texto
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Segmento de URL como lo genera Docusaurus: quita el prefijo numérico, conserva el case. */
+function segmentoDocusaurus(nombre: string): string {
+  return nombre.replace(/^[\d.]+[-_]/, '');
+}
+
+/** Slug del CMS para un segmento (kebab en minúsculas). */
+function slugCms(nombre: string): string {
+  return slugify(segmentoDocusaurus(nombre)) || slugify(nombre) || 'pagina';
+}
+
+/** Frontmatter mínimo: sidebar_position y title (suficiente para estas instancias). */
+function parseFrontmatter(src: string): { cuerpo: string; sidebarPosition?: number; title?: string } {
+  const m = src.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { cuerpo: src };
+  const bloque = m[1];
+  const pos = bloque.match(/^sidebar_position:\s*([\d.]+)\s*$/m);
+  const tit = bloque.match(/^title:\s*['"]?(.+?)['"]?\s*$/m);
+  return {
+    cuerpo: src.slice(m[0].length),
+    sidebarPosition: pos ? Number(pos[1]) : undefined,
+    title: tit?.[1],
+  };
+}
+
+function tituloDesdeCuerpo(cuerpo: string, fallback: string): string {
+  const h1 = cuerpo.match(/^#\s+(.+)$/m);
+  return h1?.[1].trim() ?? fallback;
+}
+
+/* ── Modelo en memoria ── */
+interface NodoImport {
+  tipo: 'categoria' | 'md' | 'html';
+  titulo: string;
+  slug: string;         // slug del CMS
+  segmentoUrl: string;  // segmento como en la URL de Docusaurus (para redirects)
+  orden: number;
+  archivo?: string;     // ruta absoluta del .md/.html
+  cuerpo?: string;
+  hijos: NodoImport[];
+}
+
+interface Reporte {
+  categorias: number;
+  paginas: number;
+  paginasHtml: number;
+  assetsDocumento: number;
+  assetsStatic: number;
+  enlacesReescritos: number;
+  enlacesInternos: number;
+  sinResolver: string[];
+  ignorados: string[];
+  redirects: number;
+}
+
+const reporte: Reporte = {
+  categorias: 0,
+  paginas: 0,
+  paginasHtml: 0,
+  assetsDocumento: 0,
+  assetsStatic: 0,
+  enlacesReescritos: 0,
+  enlacesInternos: 0,
+  sinResolver: [],
+  ignorados: [],
+  redirects: 0,
+};
+
+/** Lee el árbol de la instancia desde el filesystem. */
+function leerDirectorio(dir: string): NodoImport[] {
+  const nodos: NodoImport[] = [];
+  const entradas = fs.readdirSync(dir, { withFileTypes: true }).filter((e) => !e.name.startsWith('.'));
+
+  for (const e of entradas) {
+    const ruta = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      // Carpetas con _ inicial: excluidas del build de Docusaurus (legacy).
+      if (e.name.startsWith('_')) {
+        reporte.ignorados.push(`${ruta} (carpeta _excluida de Docusaurus)`);
+        continue;
+      }
+      let label = segmentoDocusaurus(e.name);
+      let position: number | undefined;
+      const catJson = path.join(ruta, '_category_.json');
+      if (fs.existsSync(catJson)) {
+        try {
+          const cat = JSON.parse(fs.readFileSync(catJson, 'utf8'));
+          if (typeof cat.label === 'string') label = cat.label;
+          if (typeof cat.position === 'number') position = cat.position;
+        } catch {
+          reporte.sinResolver.push(`${catJson} (JSON inválido)`);
+        }
+      }
+      const hijos = leerDirectorio(ruta);
+      if (hijos.length === 0) {
+        reporte.ignorados.push(`${ruta} (carpeta sin páginas)`);
+        continue;
+      }
+      const prefijo = e.name.match(/^([\d.]+)[-_]/);
+      nodos.push({
+        tipo: 'categoria',
+        titulo: label,
+        slug: slugCms(e.name),
+        segmentoUrl: segmentoDocusaurus(e.name),
+        orden: position ?? (prefijo ? Number(prefijo[1]) : 999),
+        hijos,
+      });
+      reporte.categorias += 1;
+      continue;
+    }
+
+    const ext = path.extname(e.name).toLowerCase();
+    if (ext === '.md' || ext === '.mdx') {
+      const src = fs.readFileSync(ruta, 'utf8');
+      const { cuerpo, sidebarPosition, title } = parseFrontmatter(src);
+      const base = e.name.slice(0, -ext.length);
+      const prefijo = base.match(/^([\d.]+)[-_]/);
+      nodos.push({
+        tipo: 'md',
+        titulo: title ?? tituloDesdeCuerpo(cuerpo, segmentoDocusaurus(base)),
+        slug: slugCms(base),
+        segmentoUrl: segmentoDocusaurus(base),
+        orden: sidebarPosition ?? (prefijo ? Number(prefijo[1]) : 999),
+        archivo: ruta,
+        cuerpo,
+        hijos: [],
+      });
+      reporte.paginas += 1;
+    } else if (e.name === '_category_.json') {
+      // ya procesado por el padre
+    } else if (EXT_ASSET.has(ext.slice(1))) {
+      // asset junto a los .md: se sube solo si alguna página lo referencia
+    } else {
+      reporte.ignorados.push(ruta);
+    }
+  }
+
+  // Slugs duplicados en el mismo nivel: sufijo numérico determinista.
+  const porSlug = new Map<string, number>();
+  for (const n of nodos) {
+    const visto = porSlug.get(n.slug) ?? 0;
+    if (visto > 0) n.slug = `${n.slug}-${visto + 1}`;
+    porSlug.set(n.slug, visto + 1);
+  }
+  nodos.sort((a, b) => a.orden - b.orden);
+  return nodos;
+}
+
+/* ── Recursos (assets) ── */
+const recursosSubidos = new Map<string, string>(); // ruta absoluta → referencia recurso:
+
+function sanitizarNombreArchivo(original: string): string {
+  const punto = original.lastIndexOf('.');
+  const base = slugify(punto > 0 ? original.slice(0, punto) : original).slice(0, 80) || 'archivo';
+  const ext = punto > 0 ? original.slice(punto + 1).toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 10) : '';
+  return ext ? `${base}.${ext}` : base;
+}
+
+const MIME_POR_EXT: Record<string, string> = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', webp: 'image/webp',
+  avif: 'image/avif', svg: 'image/svg+xml', pdf: 'application/pdf', zip: 'application/zip',
+  html: 'text/html', sql: 'text/plain', css: 'text/css', js: 'text/javascript',
+};
+
+async function subirRecurso(rutaAbs: string, coleccion: Coleccion | null): Promise<string | null> {
+  const previa = recursosSubidos.get(rutaAbs);
+  if (previa) return previa;
+  if (!fs.existsSync(rutaAbs) || !fs.statSync(rutaAbs).isFile()) return null;
+
+  const nombre = sanitizarNombreArchivo(path.basename(rutaAbs));
+  if (dryRun) {
+    const ref = `recurso:DRY/${nombre}`;
+    recursosSubidos.set(rutaAbs, ref);
+    return ref;
+  }
+  const buffer = fs.readFileSync(rutaAbs);
+  const mime = MIME_POR_EXT[path.extname(rutaAbs).slice(1).toLowerCase()] ?? 'application/octet-stream';
+  const parseFile = new Parse.File(nombre, { base64: buffer.toString('base64') }, mime);
+  await parseFile.save({ useMasterKey: true });
+
+  const recurso = new Recurso().initDefaults();
+  recurso.setColeccion(coleccion!);
+  recurso.setNombre(nombre);
+  recurso.setArchivo(parseFile);
+  recurso.setMime(mime);
+  recurso.setBytes(buffer.length);
+  await recurso.save(null, { useMasterKey: true });
+
+  const ref = `recurso:${recurso.id}/${nombre}`;
+  recursosSubidos.set(rutaAbs, ref);
+  return ref;
+}
+
+/* ── Reescritura de enlaces ── */
+// Mapa archivo .md (ruta absoluta) → path del CMS (para enlaces internos).
+const pathCmsPorArchivo = new Map<string, string>();
+
+function indexarPaths(nodos: NodoImport[], prefijo = ''): void {
+  for (const n of nodos) {
+    const p = prefijo ? `${prefijo}/${n.slug}` : n.slug;
+    if (n.tipo === 'categoria') indexarPaths(n.hijos, p);
+    else if (n.archivo) pathCmsPorArchivo.set(n.archivo, p);
+  }
+}
+
+const RE_ENLACE_MD = /(!?)\[([^\]]*)\]\(([^)\s]+)(\s+"[^"]*")?\)/g;
+
+/** Rangos [inicio, fin) de comentarios HTML (contenido legacy comentado). */
+function rangosComentarios(cuerpo: string): [number, number][] {
+  const rangos: [number, number][] = [];
+  for (const m of cuerpo.matchAll(/<!--[\s\S]*?-->/g)) {
+    rangos.push([m.index!, m.index! + m[0].length]);
+  }
+  return rangos;
+}
+
+async function reescribirCuerpo(cuerpo: string, dirMd: string, coleccion: Coleccion | null): Promise<string> {
+  const tareas: { original: string; nueva: string }[] = [];
+  const comentarios = rangosComentarios(cuerpo);
+
+  for (const m of cuerpo.matchAll(RE_ENLACE_MD)) {
+    const [completo, , , urlCruda] = m;
+    // Enlaces dentro de comentarios HTML: no se renderizan — no tocar ni reportar.
+    if (comentarios.some(([a, b]) => m.index! >= a && m.index! < b)) continue;
+    // pathname:// es el protocolo de Docusaurus para servir archivos de
+    // static/ sin pasar por el router SPA: equivale a una ruta absoluta.
+    const url = urlCruda.split('#')[0].replace(/^pathname:\/\//, '');
+    if (!url || /^(https?:|mailto:|recurso:|#)/.test(urlCruda)) continue;
+
+    // 1) Asset absoluto de static/ (/img/..., /ppts/..., /ios/..., etc.)
+    if (url.startsWith('/') && EXT_ASSET.has(path.extname(url).slice(1).toLowerCase())) {
+      const enStatic = path.join(RAIZ_DOCUSAURUS, 'static', decodeURIComponent(url));
+      const ref = await subirRecurso(enStatic, coleccion);
+      if (ref) {
+        tareas.push({ original: completo, nueva: completo.replace(urlCruda, ref) });
+        reporte.assetsStatic += 1;
+        reporte.enlacesReescritos += 1;
+      } else {
+        reporte.sinResolver.push(`${url} (asset de static no encontrado)`);
+      }
+      continue;
+    }
+
+    // 2) Asset relativo junto al .md
+    if (!url.startsWith('/') && EXT_ASSET.has(path.extname(url).slice(1).toLowerCase())) {
+      const abs = path.resolve(dirMd, decodeURIComponent(url));
+      const ref = await subirRecurso(abs, coleccion);
+      if (ref) {
+        tareas.push({ original: completo, nueva: completo.replace(urlCruda, ref) });
+        reporte.assetsDocumento += 1;
+        reporte.enlacesReescritos += 1;
+      } else {
+        reporte.sinResolver.push(`${url} (asset relativo no encontrado, en ${dirMd})`);
+      }
+      continue;
+    }
+
+    // 3) Enlace interno a otro .md (los absolutos son relativos a la INSTANCIA)
+    if (url.endsWith('.md') || url.endsWith('.mdx')) {
+      const abs = url.startsWith('/')
+        ? path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!, decodeURIComponent(url))
+        : path.resolve(dirMd, decodeURIComponent(url));
+      const destino = pathCmsPorArchivo.get(abs);
+      if (destino) {
+        const ancla = urlCruda.includes('#') ? `#${urlCruda.split('#')[1]}` : '';
+        tareas.push({ original: completo, nueva: completo.replace(urlCruda, `/contenidos/${slugColeccion}/${destino}${ancla}`) });
+        reporte.enlacesInternos += 1;
+        reporte.enlacesReescritos += 1;
+      } else {
+        reporte.sinResolver.push(`${url} (enlace interno no resuelto, en ${dirMd})`);
+      }
+    }
+  }
+
+  let salida = cuerpo;
+  for (const t of tareas) salida = salida.replace(t.original, t.nueva);
+  return salida;
+}
+
+/* ── Redirects viejo → nuevo ── */
+const redirects: Record<string, string> = {};
+
+function acumularRedirects(nodos: NodoImport[], prefijoViejo: string, prefijoNuevo: string): void {
+  for (const n of nodos) {
+    const viejo = `${prefijoViejo}/${n.segmentoUrl}`;
+    const nuevo = `${prefijoNuevo}/${n.slug}`;
+    if (n.tipo === 'categoria') acumularRedirects(n.hijos, viejo, nuevo);
+    else {
+      redirects[viejo] = nuevo;
+      reporte.redirects += 1;
+    }
+  }
+}
+
+/* ── Persistencia en Parse ── */
+async function crearDocumentos(
+  nodos: NodoImport[],
+  coleccion: Coleccion,
+  padre: Documento | null,
+): Promise<void> {
+  for (let i = 0; i < nodos.length; i += 1) {
+    const n = nodos[i];
+    const documento = new Documento().initDefaults();
+    documento.setColeccion(coleccion);
+    documento.setPadre(padre);
+    documento.setTitulo(n.titulo);
+    documento.setSlug(n.slug);
+    documento.setTipo(n.tipo);
+    documento.setOrden(i);
+    documento.setPublicado(n.tipo !== 'categoria');
+    await documento.save(null, { useMasterKey: true });
+
+    if (n.tipo === 'categoria') {
+      await crearDocumentos(n.hijos, coleccion, documento);
+      continue;
+    }
+
+    const cuerpoFinal = await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), coleccion);
+    const version = new DocumentoVersion().initDefaults();
+    version.setDocumento(documento);
+    version.setNumero(1);
+    version.setCuerpo(cuerpoFinal);
+    version.setMensaje('importado de Docusaurus');
+    if (n.tipo === 'md') {
+      const html = await renderMarkdown(cuerpoFinal);
+      version.setCuerpoHtml(html);
+      version.setToc(extraerToc(html));
+    } else {
+      version.setCuerpoHtml('');
+      version.setToc([]);
+    }
+    await version.save(null, { useMasterKey: true });
+    documento.setVersion(version);
+    await documento.save(null, { useMasterKey: true });
+  }
+}
+
+/** En dry-run igual recorremos cuerpos para llenar el reporte de enlaces. */
+async function simularCuerpos(nodos: NodoImport[]): Promise<void> {
+  for (const n of nodos) {
+    if (n.tipo === 'categoria') await simularCuerpos(n.hijos);
+    else await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), null);
+  }
+}
+
+/* ── Main ── */
+async function main() {
+  const dirInstancia = path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!);
+  if (!fs.existsSync(dirInstancia)) {
+    console.error(`No existe la instancia: ${dirInstancia}`);
+    process.exit(1);
+  }
+
+  if (dryRun) console.log('=== DRY RUN — no se escribirá nada (no requiere servidor) ===\n');
+  console.log(`Instancia:  ${dirInstancia}`);
+  console.log(`Colección:  ${slugColeccion} (${claveColeccion} — ${nombreColeccion})\n`);
+
+  if (!dryRun) {
+    Parse.initialize(config.appId);
+    (Parse as any).serverURL = config.serverURL;
+    (Parse as any).masterKey = config.masterKey;
+
+    // La colección no debe existir (reintento = borrarla del admin primero).
+    const existe = await new Parse.Query<Coleccion>('Coleccion')
+      .equalTo('exists' as any, true as any)
+      .equalTo('slug' as any, slugColeccion as any)
+      .first({ useMasterKey: true });
+    if (existe) {
+      console.error(`Ya existe una colección con slug "${slugColeccion}". Bórrala del admin para reimportar.`);
+      process.exit(1);
+    }
+  }
+
+  const arbol = leerDirectorio(dirInstancia);
+  indexarPaths(arbol);
+  acumularRedirects(arbol, `/docs/${slugColeccion}`, `/contenidos/${slugColeccion}`);
+
+  if (dryRun) {
+    await simularCuerpos(arbol);
+  } else {
+    const coleccion = new Coleccion().initDefaults();
+    coleccion.setNombre(nombreColeccion);
+    coleccion.setSlug(slugColeccion!);
+    coleccion.setClave(claveColeccion);
+    coleccion.setPublicada(false); // el admin la publica al validar la paridad
+    await coleccion.save(null, { useMasterKey: true });
+
+    await crearDocumentos(arbol, coleccion, null);
+
+    // Mezclar redirects con los existentes (varias instancias, varias corridas).
+    let previos: Record<string, string> = {};
+    if (fs.existsSync(RUTA_REDIRECTS)) {
+      try { previos = JSON.parse(fs.readFileSync(RUTA_REDIRECTS, 'utf8')); } catch { /* regenerar */ }
+    }
+    fs.mkdirSync(path.dirname(RUTA_REDIRECTS), { recursive: true });
+    fs.writeFileSync(RUTA_REDIRECTS, `${JSON.stringify({ ...previos, ...redirects }, null, 2)}\n`);
+    console.log(`Redirects escritos en ${RUTA_REDIRECTS}`);
+  }
+
+  /* ── Reporte de paridad ── */
+  console.log('\n===== REPORTE DE PARIDAD =====');
+  console.log(`Categorías:            ${reporte.categorias}`);
+  console.log(`Páginas md:            ${reporte.paginas}`);
+  console.log(`Assets de documento:   ${reporte.assetsDocumento}`);
+  console.log(`Assets de static:      ${reporte.assetsStatic}`);
+  console.log(`Enlaces reescritos:    ${reporte.enlacesReescritos} (${reporte.enlacesInternos} internos)`);
+  console.log(`Redirects generados:   ${reporte.redirects}`);
+  console.log(`Ignorados:             ${reporte.ignorados.length}`);
+  for (const x of reporte.ignorados.slice(0, 10)) console.log(`  · ${x}`);
+  if (reporte.ignorados.length > 10) console.log(`  … y ${reporte.ignorados.length - 10} más`);
+  console.log(`SIN RESOLVER:          ${reporte.sinResolver.length}`);
+  for (const x of reporte.sinResolver) console.log(`  ✗ ${x}`);
+  console.log('==============================\n');
+  console.log(dryRun ? 'Dry-run terminado.' : `Importación terminada: la colección "${slugColeccion}" quedó como BORRADOR (publícala tras validar).`);
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('[importar-docusaurus] error:', error);
+  process.exit(1);
+});

--- a/packages/api/scripts/importar-docusaurus.ts
+++ b/packages/api/scripts/importar-docusaurus.ts
@@ -35,7 +35,9 @@ import { Recurso } from '../src/models/Recurso.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const RAIZ_DOCUSAURUS = path.resolve(__dirname, '../../docusaurus');
-const RUTA_REDIRECTS = path.resolve(__dirname, '../src/data/redirects-docs.json');
+// Fuera de src/: tsc no copia .json a dist y producción corre desde dist/.
+// src/middlewares y dist/middlewares resuelven ambos a esta misma ruta.
+const RUTA_REDIRECTS = path.resolve(__dirname, '../data/redirects-docs.json');
 
 /* ── CLI ── */
 function arg(nombre: string): string | undefined {
@@ -105,6 +107,8 @@ interface NodoImport {
   orden: number;
   archivo?: string;     // ruta absoluta del .md/.html
   cuerpo?: string;
+  /** README.md: Docusaurus lo sirve en la URL de la CARPETA (índice). */
+  esReadme?: boolean;
   hijos: NodoImport[];
 }
 
@@ -183,14 +187,17 @@ function leerDirectorio(dir: string): NodoImport[] {
       const { cuerpo, sidebarPosition, title } = parseFrontmatter(src);
       const base = e.name.slice(0, -ext.length);
       const prefijo = base.match(/^([\d.]+)[-_]/);
+      // README.md = página índice de la carpeta en Docusaurus: va primero.
+      const esReadme = /^readme$/i.test(base) || /^index$/i.test(base);
       nodos.push({
         tipo: 'md',
         titulo: title ?? tituloDesdeCuerpo(cuerpo, segmentoDocusaurus(base)),
         slug: slugCms(base),
         segmentoUrl: segmentoDocusaurus(base),
-        orden: sidebarPosition ?? (prefijo ? Number(prefijo[1]) : 999),
+        orden: esReadme ? -1 : (sidebarPosition ?? (prefijo ? Number(prefijo[1]) : 999)),
         archivo: ruta,
         cuerpo,
+        esReadme,
         hijos: [],
       });
       reporte.paginas += 1;
@@ -230,7 +237,11 @@ const MIME_POR_EXT: Record<string, string> = {
   html: 'text/html', sql: 'text/plain', css: 'text/css', js: 'text/javascript',
 };
 
-async function subirRecurso(rutaAbs: string, coleccion: Coleccion | null): Promise<string | null> {
+async function subirRecurso(
+  rutaAbs: string,
+  coleccion: Coleccion | null,
+  documento: Documento | null,
+): Promise<string | null> {
   const previa = recursosSubidos.get(rutaAbs);
   if (previa) return previa;
   if (!fs.existsSync(rutaAbs) || !fs.statSync(rutaAbs).isFile()) return null;
@@ -248,6 +259,8 @@ async function subirRecurso(rutaAbs: string, coleccion: Coleccion | null): Promi
 
   const recurso = new Recurso().initDefaults();
   recurso.setColeccion(coleccion!);
+  // Dueño: el documento que lo referenció primero (los de static/ son de colección).
+  recurso.setDocumento(documento);
   recurso.setNombre(nombre);
   recurso.setArchivo(parseFile);
   recurso.setMime(mime);
@@ -271,7 +284,10 @@ function indexarPaths(nodos: NodoImport[], prefijo = ''): void {
   }
 }
 
-const RE_ENLACE_MD = /(!?)\[([^\]]*)\]\(([^)\s]+)(\s+"[^"]*")?\)/g;
+// URL con UN nivel de paréntesis balanceados: nombres reales de capturas de
+// pantalla incluyen "(s)" — con [^)\s]+ el enlace se truncaba y se ignoraba
+// en silencio.
+const RE_ENLACE_MD = /(!?)\[([^\]]*)\]\(<?([^()\s]*(?:\([^()\s]*\)[^()\s]*)*)>?(\s+"[^"]*")?\)/g;
 
 /** Rangos [inicio, fin) de comentarios HTML (contenido legacy comentado). */
 function rangosComentarios(cuerpo: string): [number, number][] {
@@ -282,66 +298,97 @@ function rangosComentarios(cuerpo: string): [number, number][] {
   return rangos;
 }
 
-async function reescribirCuerpo(cuerpo: string, dirMd: string, coleccion: Coleccion | null): Promise<string> {
-  const tareas: { original: string; nueva: string }[] = [];
+async function reescribirCuerpo(
+  cuerpo: string,
+  dirMd: string,
+  coleccion: Coleccion | null,
+  documento: Documento | null,
+): Promise<string> {
+  // Ediciones POSICIONALES [inicio, fin) — replace() de primera ocurrencia
+  // reescribía la copia comentada (o el texto del enlace) en vez del href.
+  const ediciones: { inicio: number; fin: number; texto: string }[] = [];
   const comentarios = rangosComentarios(cuerpo);
 
+  const resolverInterno = (url: string): string | null => {
+    const base = url.startsWith('/')
+      ? path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!, decodeURIComponent(url))
+      : path.resolve(dirMd, decodeURIComponent(url));
+    // Candidatos: el archivo tal cual, .md/.mdx implícitos, o el índice de
+    // carpeta (README/readme/index — el repo usa ambos cases).
+    const candidatos = [
+      base,
+      `${base}.md`,
+      `${base}.mdx`,
+      path.join(base, 'README.md'),
+      path.join(base, 'readme.md'),
+      path.join(base, 'index.md'),
+    ];
+    for (const c of candidatos) {
+      const destino = pathCmsPorArchivo.get(c);
+      if (destino) return destino;
+    }
+    return null;
+  };
+
   for (const m of cuerpo.matchAll(RE_ENLACE_MD)) {
-    const [completo, , , urlCruda] = m;
+    const [completo, bang, textoEnlace, urlCruda, tituloOpc] = m;
     // Enlaces dentro de comentarios HTML: no se renderizan — no tocar ni reportar.
     if (comentarios.some(([a, b]) => m.index! >= a && m.index! < b)) continue;
     // pathname:// es el protocolo de Docusaurus para servir archivos de
     // static/ sin pasar por el router SPA: equivale a una ruta absoluta.
-    const url = urlCruda.split('#')[0].replace(/^pathname:\/\//, '');
+    const [urlSinAncla, ...anclaPartes] = urlCruda.split('#');
+    const url = urlSinAncla.replace(/^pathname:\/\//, '');
     if (!url || /^(https?:|mailto:|recurso:|#)/.test(urlCruda)) continue;
 
-    // 1) Asset absoluto de static/ (/img/..., /ppts/..., /ios/..., etc.)
-    if (url.startsWith('/') && EXT_ASSET.has(path.extname(url).slice(1).toLowerCase())) {
-      const enStatic = path.join(RAIZ_DOCUSAURUS, 'static', decodeURIComponent(url));
-      const ref = await subirRecurso(enStatic, coleccion);
-      if (ref) {
-        tareas.push({ original: completo, nueva: completo.replace(urlCruda, ref) });
-        reporte.assetsStatic += 1;
-        reporte.enlacesReescritos += 1;
-      } else {
-        reporte.sinResolver.push(`${url} (asset de static no encontrado)`);
-      }
-      continue;
-    }
+    const emitir = (nuevaUrl: string) => {
+      ediciones.push({
+        inicio: m.index!,
+        fin: m.index! + completo.length,
+        texto: `${bang}[${textoEnlace}](${nuevaUrl}${tituloOpc ?? ''})`,
+      });
+      reporte.enlacesReescritos += 1;
+    };
+    const ancla = anclaPartes.length ? `#${anclaPartes.join('#')}` : '';
+    const ext = path.extname(url).slice(1).toLowerCase();
 
-    // 2) Asset relativo junto al .md
-    if (!url.startsWith('/') && EXT_ASSET.has(path.extname(url).slice(1).toLowerCase())) {
-      const abs = path.resolve(dirMd, decodeURIComponent(url));
-      const ref = await subirRecurso(abs, coleccion);
-      if (ref) {
-        tareas.push({ original: completo, nueva: completo.replace(urlCruda, ref) });
-        reporte.assetsDocumento += 1;
-        reporte.enlacesReescritos += 1;
-      } else {
-        reporte.sinResolver.push(`${url} (asset relativo no encontrado, en ${dirMd})`);
-      }
-      continue;
-    }
-
-    // 3) Enlace interno a otro .md (los absolutos son relativos a la INSTANCIA)
-    if (url.endsWith('.md') || url.endsWith('.mdx')) {
+    // 1) Asset (relativo junto al .md, o absoluto de static/)
+    if (EXT_ASSET.has(ext)) {
       const abs = url.startsWith('/')
-        ? path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!, decodeURIComponent(url))
+        ? path.join(RAIZ_DOCUSAURUS, 'static', decodeURIComponent(url))
         : path.resolve(dirMd, decodeURIComponent(url));
-      const destino = pathCmsPorArchivo.get(abs);
+      const ref = await subirRecurso(abs, coleccion, url.startsWith('/') ? null : documento);
+      if (ref) {
+        emitir(ref);
+        if (url.startsWith('/')) reporte.assetsStatic += 1;
+        else reporte.assetsDocumento += 1;
+      } else {
+        reporte.sinResolver.push(`${url} (asset no encontrado, en ${dirMd})`);
+      }
+      continue;
+    }
+
+    // 2) Enlace interno: .md/.mdx explícito, sin extensión, o carpeta (README)
+    if (ext === 'md' || ext === 'mdx' || ext === '') {
+      const destino = resolverInterno(url.replace(/\/+$/, ''));
       if (destino) {
-        const ancla = urlCruda.includes('#') ? `#${urlCruda.split('#')[1]}` : '';
-        tareas.push({ original: completo, nueva: completo.replace(urlCruda, `/contenidos/${slugColeccion}/${destino}${ancla}`) });
+        emitir(`/contenidos/${slugColeccion}/${destino}${ancla}`);
         reporte.enlacesInternos += 1;
-        reporte.enlacesReescritos += 1;
       } else {
         reporte.sinResolver.push(`${url} (enlace interno no resuelto, en ${dirMd})`);
       }
+      continue;
     }
+
+    // 3) Extensión desconocida: NUNCA en silencio — el reporte de paridad
+    // es lo que el admin usa para validar antes de publicar.
+    reporte.sinResolver.push(`${url} (extensión no manejada, en ${dirMd})`);
   }
 
+  // Aplicar de atrás hacia adelante (los rangos no se traslapan).
   let salida = cuerpo;
-  for (const t of tareas) salida = salida.replace(t.original, t.nueva);
+  for (const e of ediciones.sort((a, b) => b.inicio - a.inicio)) {
+    salida = salida.slice(0, e.inicio) + e.texto + salida.slice(e.fin);
+  }
   return salida;
 }
 
@@ -354,7 +401,9 @@ function acumularRedirects(nodos: NodoImport[], prefijoViejo: string, prefijoNue
     const nuevo = `${prefijoNuevo}/${n.slug}`;
     if (n.tipo === 'categoria') acumularRedirects(n.hijos, viejo, nuevo);
     else {
-      redirects[viejo] = nuevo;
+      // README.md: Docusaurus lo sirve en la URL de la CARPETA — el redirect
+      // real es carpeta → página readme del CMS (no /README, que nunca existió).
+      redirects[n.esReadme ? prefijoViejo : viejo] = nuevo;
       reporte.redirects += 1;
     }
   }
@@ -383,7 +432,7 @@ async function crearDocumentos(
       continue;
     }
 
-    const cuerpoFinal = await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), coleccion);
+    const cuerpoFinal = await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), coleccion, documento);
     const version = new DocumentoVersion().initDefaults();
     version.setDocumento(documento);
     version.setNumero(1);
@@ -407,7 +456,7 @@ async function crearDocumentos(
 async function simularCuerpos(nodos: NodoImport[]): Promise<void> {
   for (const n of nodos) {
     if (n.tipo === 'categoria') await simularCuerpos(n.hijos);
-    else await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), null);
+    else await reescribirCuerpo(n.cuerpo ?? '', path.dirname(n.archivo!), null, null);
   }
 }
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -16,6 +16,7 @@ import contenidosVisorRoutes from './routes/contenidos-visor.routes.js';
 import meRoutes from './routes/me.routes.js';
 import { docsGate } from './middlewares/docs-gate.middleware.js';
 import { filesGate } from './middlewares/files-gate.middleware.js';
+import { docsRedirects } from './middlewares/docs-redirects.middleware.js';
 import alumnosRoutes from './routes/alumnos.routes.js';
 import calendarioRoutes from './routes/calendario.routes.js';
 import indicacionesMallaRoutes from './routes/indicaciones-malla.routes.js';
@@ -95,6 +96,10 @@ export function finalize() {
     const __dirname = path.dirname(__filename);
     const distPath = path.resolve(__dirname, '../../../dist');
 
+    // Redirects /docs→/contenidos (US-6): apagados hasta el corte de la
+    // US-7 (REDIRECT_DOCS_A_CONTENIDOS=true). Van ANTES del gate: cuando se
+    // enciendan, /docs deja de servirse.
+    app.use('/docs', docsRedirects);
     // Docusaurus en /docs — gate de acceso por materia ANTES del estático.
     app.use('/docs', docsGate);
     app.use('/docs', express.static(path.join(distPath, 'docs')));

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -96,12 +96,14 @@ export function finalize() {
     const __dirname = path.dirname(__filename);
     const distPath = path.resolve(__dirname, '../../../dist');
 
-    // Redirects /docs→/contenidos (US-6): apagados hasta el corte de la
-    // US-7 (REDIRECT_DOCS_A_CONTENIDOS=true). Van ANTES del gate: cuando se
-    // enciendan, /docs deja de servirse.
-    app.use('/docs', docsRedirects);
-    // Docusaurus en /docs — gate de acceso por materia ANTES del estático.
+    // Docusaurus en /docs — el gate de acceso por materia corre PRIMERO:
+    // un usuario sin acceso recibe el 404 de siempre; el redirect (abajo)
+    // jamás le filtra slugs/estructura del CMS.
     app.use('/docs', docsGate);
+    // Redirects /docs→/contenidos (US-6): apagados hasta el corte de la
+    // US-7 (REDIRECT_DOCS_A_CONTENIDOS=true). Cuando se enciendan, /docs
+    // deja de servir el estático (solo para usuarios ya autorizados).
+    app.use('/docs', docsRedirects);
     app.use('/docs', express.static(path.join(distPath, 'docs')));
 
     // Contenido legacy

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -9,7 +9,7 @@ export async function listGrupos(_req: Request, res: Response): Promise<void> {
   try {
     const query = new Parse.Query<Grupo>('Grupo');
     query.equalTo('exists' as any, true as any);
-    query.include('materia' as any);
+    query.include(['materia', 'colecciones'] as any);
     query.descending('createdAt');
     const grupos = await query.find({ useMasterKey: true });
 
@@ -30,8 +30,24 @@ function normalizeSlugs(value: unknown): string[] | null {
   return [...new Set(slugs)];
 }
 
+/**
+ * ids de colecciones → pointers VALIDADOS (existentes). null = payload no-array
+ * (se ignora); un id inexistente es error del cliente (400).
+ */
+async function resolverColecciones(value: unknown): Promise<Parse.Object[] | 'invalido' | null> {
+  if (!Array.isArray(value)) return null;
+  const ids = [...new Set(value.filter((s): s is string => typeof s === 'string' && s.trim() !== ''))];
+  if (ids.length === 0) return [];
+  const q = new Parse.Query('Coleccion');
+  q.equalTo('exists' as any, true as any);
+  q.containedIn('objectId' as any, ids as any);
+  const encontradas = await q.find({ useMasterKey: true });
+  if (encontradas.length !== ids.length) return 'invalido';
+  return encontradas;
+}
+
 export async function createGrupo(req: Request, res: Response): Promise<void> {
-  const { name, fechaInicio, fechaFin, materiaId, docusaurus } = req.body;
+  const { name, fechaInicio, fechaFin, materiaId, docusaurus, colecciones } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim() === '') {
     res.status(400).json({ status: 'error', message: 'El nombre es requerido' });
@@ -56,7 +72,15 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
     const docusSlugs = normalizeSlugs(docusaurus);
     if (docusSlugs) grupo.setDocusaurus(docusSlugs);
 
+    const coleccionesPtrs = await resolverColecciones(colecciones);
+    if (coleccionesPtrs === 'invalido') {
+      res.status(400).json({ status: 'error', message: 'Alguna colección indicada no existe' });
+      return;
+    }
+    if (coleccionesPtrs) grupo.setColecciones(coleccionesPtrs);
+
     await grupo.save(null, { useMasterKey: true });
+    if (coleccionesPtrs?.length) invalidateColeccionesPermitidas();
 
     res.status(201).json({ status: 'ok', grupo: grupo.toSafeJSON() });
   } catch (error) {
@@ -66,7 +90,7 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
 
 export async function updateGrupo(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { name, fechaInicio, fechaFin, materiaId, docusaurus } = req.body;
+  const { name, fechaInicio, fechaFin, materiaId, docusaurus, colecciones } = req.body;
 
   try {
     const query = BaseModel.queryActive<Grupo>('Grupo');
@@ -98,9 +122,18 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
     const docusSlugs = docusaurus !== undefined ? normalizeSlugs(docusaurus) : null;
     if (docusSlugs) grupo.setDocusaurus(docusSlugs);
 
+    // Misma regla que docusaurus: solo un array válido aplica ([] limpia).
+    const coleccionesPtrs = colecciones !== undefined ? await resolverColecciones(colecciones) : null;
+    if (coleccionesPtrs === 'invalido') {
+      res.status(400).json({ status: 'error', message: 'Alguna colección indicada no existe' });
+      return;
+    }
+    if (coleccionesPtrs) grupo.setColecciones(coleccionesPtrs);
+
     await grupo.save(null, { useMasterKey: true });
     // Si cambió la materia o los docusaurus del grupo, cambió el acceso de sus alumnos.
     if (materiaId !== undefined || docusSlugs) invalidateAllowedCache();
+    if (coleccionesPtrs) invalidateColeccionesPermitidas();
 
     res.json({ status: 'ok', grupo: grupo.toSafeJSON() });
   } catch (error: any) {

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -94,7 +94,9 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
 
   try {
     const query = BaseModel.queryActive<Grupo>('Grupo');
-    query.include('materia' as any);
+    // colecciones incluidas: toSafeJSON serializa pointers y sin fetch
+    // respondería nulls (y no podría filtrar soft-deleted).
+    query.include(['materia', 'colecciones'] as any);
     const grupo = await query.get(id, { useMasterKey: true });
 
     if (name !== undefined) {
@@ -151,6 +153,7 @@ export async function archiveGrupo(req: Request, res: Response): Promise<void> {
   try {
     const query = new Parse.Query<Grupo>('Grupo');
     query.equalTo('exists' as any, true as any);
+    query.include(['materia', 'colecciones'] as any);
     const grupo = await query.get(id, { useMasterKey: true });
 
     if (grupo.get('active')) {

--- a/packages/api/src/middlewares/docs-redirects.middleware.ts
+++ b/packages/api/src/middlewares/docs-redirects.middleware.ts
@@ -10,14 +10,19 @@ import { fileURLToPath } from 'url';
  * corte de la US-7. Se enciende con REDIRECT_DOCS_A_CONTENIDOS=true en el
  * .env del servidor (fase 2 del plan de deprecación).
  *
- * Mapa exacto: src/data/redirects-docs.json, generado por
- * scripts/importar-docusaurus.ts (viejo → nuevo por página). Fallback
- * heurístico para paths que no estén en el mapa: minúsculas + prefijos
- * numéricos fuera + separadores a guion (la convención de slugs del CMS).
+ * Se monta DESPUÉS de docsGate: la autorización corre primero — un usuario
+ * sin acceso recibe el mismo 404 de siempre y el redirect jamás le filtra
+ * slugs/estructura del CMS.
+ *
+ * Mapa exacto: data/redirects-docs.json (raíz del paquete, fuera de src/ —
+ * tsc no copia .json a dist y el runtime de producción es dist/), generado
+ * por scripts/importar-docusaurus.ts. Fallback heurístico para lo que no
+ * esté en el mapa.
  */
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const RUTA_MAPA = path.resolve(__dirname, '../data/redirects-docs.json');
+// src/middlewares → ../../data  |  dist/middlewares → ../../data (misma raíz)
+const RUTA_MAPA = path.resolve(__dirname, '../../data/redirects-docs.json');
 
 let mapa: Record<string, string> = {};
 try {
@@ -30,12 +35,16 @@ try {
 
 export const redirectsActivos = process.env.REDIRECT_DOCS_A_CONTENIDOS === 'true';
 
-/** Heurística viejo→nuevo por segmento (mismas reglas que el importador). */
-function heuristica(pathname: string): string {
-  const segmentos = pathname
+/**
+ * Heurística viejo→nuevo por segmento (mismas reglas de slug que el
+ * importador). Recibe el path SIN el prefijo /docs (montado en '/docs',
+ * express lo quita de req.path) — el primer segmento es el slug de la
+ * colección y se conserva.
+ */
+function heuristica(pathSinDocs: string): string {
+  const segmentos = pathSinDocs
     .split('/')
     .filter(Boolean)
-    .slice(1) // quita "docs"
     .map((s) =>
       decodeURIComponent(s)
         .replace(/^[\d.]+[-_]/, '')
@@ -54,7 +63,8 @@ export function docsRedirects(req: Request, res: Response, next: NextFunction): 
     next();
     return;
   }
-  const pathname = req.path.replace(/\/+$/, '');
-  const exacto = mapa[pathname];
-  res.redirect(301, exacto ?? heuristica(pathname));
+  // Montado en '/docs': req.path NO incluye el prefijo; el mapa sí lo lleva.
+  const pathSinDocs = req.path.replace(/\/+$/, '');
+  const exacto = mapa[`/docs${pathSinDocs}`];
+  res.redirect(301, exacto ?? heuristica(pathSinDocs));
 }

--- a/packages/api/src/middlewares/docs-redirects.middleware.ts
+++ b/packages/api/src/middlewares/docs-redirects.middleware.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, NextFunction } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Redirects 301 /docs/* → /contenidos/* (US-6, design §6).
+ *
+ * APAGADO por defecto: Docusaurus sigue siendo el sistema operativo hasta el
+ * corte de la US-7. Se enciende con REDIRECT_DOCS_A_CONTENIDOS=true en el
+ * .env del servidor (fase 2 del plan de deprecación).
+ *
+ * Mapa exacto: src/data/redirects-docs.json, generado por
+ * scripts/importar-docusaurus.ts (viejo → nuevo por página). Fallback
+ * heurístico para paths que no estén en el mapa: minúsculas + prefijos
+ * numéricos fuera + separadores a guion (la convención de slugs del CMS).
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RUTA_MAPA = path.resolve(__dirname, '../data/redirects-docs.json');
+
+let mapa: Record<string, string> = {};
+try {
+  if (fs.existsSync(RUTA_MAPA)) {
+    mapa = JSON.parse(fs.readFileSync(RUTA_MAPA, 'utf8'));
+  }
+} catch {
+  mapa = {}; // sin mapa: solo heurística
+}
+
+export const redirectsActivos = process.env.REDIRECT_DOCS_A_CONTENIDOS === 'true';
+
+/** Heurística viejo→nuevo por segmento (mismas reglas que el importador). */
+function heuristica(pathname: string): string {
+  const segmentos = pathname
+    .split('/')
+    .filter(Boolean)
+    .slice(1) // quita "docs"
+    .map((s) =>
+      decodeURIComponent(s)
+        .replace(/^[\d.]+[-_]/, '')
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, ''),
+    )
+    .filter(Boolean);
+  return `/contenidos/${segmentos.join('/')}`;
+}
+
+export function docsRedirects(req: Request, res: Response, next: NextFunction): void {
+  if (!redirectsActivos || req.method !== 'GET') {
+    next();
+    return;
+  }
+  const pathname = req.path.replace(/\/+$/, '');
+  const exacto = mapa[pathname];
+  res.redirect(301, exacto ?? heuristica(pathname));
+}

--- a/packages/api/src/models/Grupo.ts
+++ b/packages/api/src/models/Grupo.ts
@@ -107,6 +107,15 @@ export class Grupo extends BaseModel {
         ? { id: materiaActiva.id, nombre: materiaActiva.get('nombre') ?? null, slug: materiaActiva.get('slug') ?? null }
         : null,
       docusaurus: this.getDocusaurus(),
+      // Requiere query.include('colecciones'); las soft-deleted no se exponen.
+      colecciones: this.getColecciones()
+        .filter((c) => c && c.get('exists') !== false)
+        .map((c) => ({
+          id: c.id,
+          nombre: c.get('nombre') ?? null,
+          slug: c.get('slug') ?? null,
+          clave: c.get('clave') ?? null,
+        })),
       active: this.get('active'),
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
@@ -2,10 +2,14 @@ import { useState } from 'react';
 import Icon from '../../atoms/Icon/Icon';
 import styles from './DocusMenu.module.css';
 
-/** Un Docusaurus habilitado para el grupo: slug + etiqueta "CLAVE — Nombre". */
+/**
+ * Una documentación habilitada para el grupo: destino + etiqueta
+ * "CLAVE — Nombre" (Docusaurus /docs/<slug>/ o colección /contenidos/<slug>/).
+ */
 export interface DocusLink {
   slug: string;
   label: string;
+  href: string;
 }
 
 interface DocusMenuProps {
@@ -17,8 +21,8 @@ interface DocusMenuProps {
 
 /**
  * Ítem "Docusaurus" del sidebar con submenú colapsable (colapsado por
- * defecto) que lista los Docusaurus habilitados del grupo. Cada enlace abre
- * `/docs/<slug>/` en una pestaña nueva; la etiqueta se trunca a una sola línea.
+ * defecto) que lista la documentación habilitada del grupo (Docusaurus y
+ * colecciones del CMS). Abre en pestaña nueva; etiqueta a una sola línea.
  */
 export default function DocusMenu({ items, collapsed, defaultOpen = false }: DocusMenuProps) {
   const [open, setOpen] = useState(defaultOpen);
@@ -52,7 +56,7 @@ export default function DocusMenu({ items, collapsed, defaultOpen = false }: Doc
             items.map((it) => (
               <a
                 key={it.slug}
-                href={`/docs/${it.slug}/`}
+                href={it.href}
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.link}

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
@@ -3,6 +3,7 @@ import TextInput from '../../atoms/TextInput/TextInput';
 import DashButton from '../../atoms/DashButton/DashButton';
 import styles from './GrupoForm.module.css';
 import type { MateriaRef } from '../../../../types/materia';
+import type { ColeccionRef } from '../../../../types/contenidos';
 
 interface GrupoData {
   id?: string;
@@ -11,6 +12,7 @@ interface GrupoData {
   fechaFin?: string;
   materia?: MateriaRef | null;
   docusaurus?: string[];
+  colecciones?: ColeccionRef[];
 }
 
 interface GrupoSavePayload {
@@ -19,11 +21,14 @@ interface GrupoSavePayload {
   fechaFin?: string;
   materiaId?: string | null;
   docusaurus?: string[];
+  colecciones?: string[];
 }
 
 interface GrupoFormProps {
   grupo?: GrupoData;
   materias?: MateriaRef[];
+  /** Colecciones del CMS Contenidos disponibles para asignar (US-6). */
+  colecciones?: ColeccionRef[];
   onSave: (data: GrupoSavePayload) => void;
   onCancel: () => void;
   loading?: boolean;
@@ -36,17 +41,26 @@ function toDateString(value?: string | Date): string {
   return d.toISOString().split('T')[0];
 }
 
-export default function GrupoForm({ grupo, materias = [], onSave, onCancel, loading }: GrupoFormProps) {
+export default function GrupoForm({ grupo, materias = [], colecciones = [], onSave, onCancel, loading }: GrupoFormProps) {
   const [name, setName] = useState(grupo?.name ?? '');
   const [fechaInicio, setFechaInicio] = useState(toDateString(grupo?.fechaInicio));
   const [fechaFin, setFechaFin] = useState(toDateString(grupo?.fechaFin));
   const [materiaId, setMateriaId] = useState(grupo?.materia?.id ?? '');
   const [docusaurus, setDocusaurus] = useState<string[]>(grupo?.docusaurus ?? []);
+  const [coleccionesSel, setColeccionesSel] = useState<string[]>(
+    (grupo?.colecciones ?? []).map((c) => c.id),
+  );
   const [error, setError] = useState('');
 
   function toggleDocusaurus(slug: string) {
     setDocusaurus((prev) =>
       prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    );
+  }
+
+  function toggleColeccion(id: string) {
+    setColeccionesSel((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
     );
   }
 
@@ -62,6 +76,7 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
       fechaFin: fechaFin || undefined,
       materiaId: materiaId || null,
       docusaurus,
+      colecciones: coleccionesSel,
     });
   }
 
@@ -110,6 +125,29 @@ export default function GrupoForm({ grupo, materias = [], onSave, onCancel, load
                   type="checkbox"
                   checked={docusaurus.includes(m.slug)}
                   onChange={() => toggleDocusaurus(m.slug)}
+                  disabled={loading}
+                />
+                <span className={styles.checkboxLabel} title={label}>{label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label}>Colecciones de Contenidos con acceso</label>
+        <div className={styles.checkboxList}>
+          {colecciones.length === 0 && (
+            <span className={styles.hint}>No hay colecciones disponibles.</span>
+          )}
+          {colecciones.map((c) => {
+            const clave = c.clave || c.slug.toUpperCase();
+            const label = `${clave} — ${c.nombre}`;
+            return (
+              <label key={c.id} className={styles.checkboxItem}>
+                <input
+                  type="checkbox"
+                  checked={coleccionesSel.includes(c.id)}
+                  onChange={() => toggleColeccion(c.id)}
                   disabled={loading}
                 />
                 <span className={styles.checkboxLabel} title={label}>{label}</span>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -91,8 +91,13 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
       .then(([gruposJson, materiasJson]) => {
         const grupos = gruposJson?.grupos ?? [];
         const found = grupos.find(
-          (g: { id: string; name?: string; materia?: { slug?: string | null } | null; docusaurus?: string[] }) =>
-            g.id === grupoId,
+          (g: {
+            id: string;
+            name?: string;
+            materia?: { slug?: string | null } | null;
+            docusaurus?: string[];
+            colecciones?: { slug: string; nombre: string; clave: string | null }[];
+          }) => g.id === grupoId,
         );
         if (found?.name) setGrupoName(found.name);
 
@@ -110,8 +115,13 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
           const m = bySlug.get(slug);
           const clave = m?.codigo || slug.toUpperCase();
           const nombre = m?.nombre || slug;
-          return { slug, label: `${clave} — ${nombre}` };
+          return { slug, label: `${clave} — ${nombre}`, href: `/docs/${slug}/` };
         });
+        // + Colecciones del CMS Contenidos asignadas al grupo (US-6).
+        for (const c of found?.colecciones ?? []) {
+          const clave = c.clave || c.slug.toUpperCase();
+          links.push({ slug: `cms-${c.slug}`, label: `${clave} — ${c.nombre}`, href: `/contenidos/${c.slug}/` });
+        }
         setDocusLinks(links);
       })
       .catch(() => {});

--- a/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
@@ -7,6 +7,7 @@ import Modal from '../../atoms/Modal/Modal';
 import GrupoForm from '../../organisms/GrupoForm/GrupoForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
 import type { MateriaRef } from '../../../../types/materia';
+import type { ColeccionRef } from '../../../../types/contenidos';
 import styles from './GruposPage.module.css';
 
 interface GrupoData {
@@ -17,6 +18,7 @@ interface GrupoData {
   active: boolean;
   materia?: MateriaRef | null;
   docusaurus?: string[];
+  colecciones?: ColeccionRef[];
 }
 
 const API_BASE = '/api';
@@ -26,6 +28,7 @@ export default function GruposPage() {
   const navigate = useNavigate();
   const [grupos, setGrupos] = useState<GrupoData[]>([]);
   const [materias, setMaterias] = useState<MateriaRef[]>([]);
+  const [colecciones, setColecciones] = useState<ColeccionRef[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -62,10 +65,22 @@ export default function GruposPage() {
     }
   }, [sessionToken]);
 
+  const fetchColecciones = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/admin/colecciones`, { headers: { 'x-session-token': sessionToken ?? '' } });
+      if (!res.ok) return;
+      const data = await res.json();
+      setColecciones(data.colecciones ?? []);
+    } catch {
+      // opcional en el form; ignorar error de carga
+    }
+  }, [sessionToken]);
+
   useEffect(() => {
     fetchGrupos();
     fetchMaterias();
-  }, [fetchGrupos, fetchMaterias]);
+    fetchColecciones();
+  }, [fetchGrupos, fetchMaterias, fetchColecciones]);
 
   function openCreate() {
     setEditGrupo(undefined);
@@ -82,7 +97,7 @@ export default function GruposPage() {
     setEditGrupo(undefined);
   }
 
-  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; materiaId?: string | null; docusaurus?: string[] }) {
+  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; materiaId?: string | null; docusaurus?: string[]; colecciones?: string[] }) {
     setSaving(true);
     setError('');
     try {
@@ -196,6 +211,7 @@ export default function GruposPage() {
         <GrupoForm
           grupo={editGrupo}
           materias={materias}
+          colecciones={colecciones}
           onSave={handleSave}
           onCancel={closeModal}
           loading={saving}

--- a/packages/web/src/types/contenidos.ts
+++ b/packages/web/src/types/contenidos.ts
@@ -3,6 +3,14 @@
 export type DocumentoTipo = 'md' | 'html' | 'categoria';
 export type DocumentoPlantilla = 'laboratorio' | 'lectura' | 'temario';
 
+/** Referencia mínima de colección (asignación a grupos, submenús). */
+export interface ColeccionRef {
+  id: string;
+  nombre: string;
+  slug: string;
+  clave: string | null;
+}
+
 export interface ColeccionData {
   id: string;
   nombre: string;


### PR DESCRIPTION
## Descripción

**US-6 del roadmap del CMS "Contenidos"** (`design/cms-contenidos.html` §6): el puente de migración — importar las instancias Docusaurus con paridad verificable, asignar colecciones a grupos, y dejar listos (apagados) los redirects del corte.

> **PR apilado sobre `feature/cms-busqueda-html` (US-5, PR #27).** Orden de merge: #25 → #26 → #27 → este. **Code review en curso** — hallazgos y fixes se publicarán aquí.

## Cambios

### Importador (`scripts/importar-docusaurus.ts`)
- `--slug <instancia> [--clave] [--nombre] [--dry-run]` — el dry-run **no requiere servidor** y no escribe nada.
- Mapeo del diseño: instancia→`Coleccion` (nace como **borrador**; el admin la publica tras validar), carpeta+`_category_.json`→categoría (label/position), `.md`+`sidebar_position`→documento **publicado** v1 "importado de Docusaurus" (cuerpoHtml + TOC del pipeline compartido).
- Assets: relativos junto al `.md` → `Recurso` de documento; absolutos de `static/` (incluido `pathname://`) → `Recurso` de colección; dedupe y referencias `recurso:` reescritas.
- Enlaces internos `.md` (relativos y absolutos a la instancia) → `/contenidos/<slug>/...`; los enlaces dentro de comentarios HTML se ignoran (contenido legacy comentado).
- **Reporte de paridad**: categorías, páginas, assets, enlaces reescritos, ignorados y sin resolver.

### Dry-run verificado contra las instancias reales
| Instancia | Categorías | Páginas | Assets | Enlaces reescritos | Sin resolver |
|---|---|---|---|---|---|
| tc2007b | 20 | 36 | 318 | 336 | **0** |
| tc2005b | 30 | 34 | 146 | 162 | **1** (un `CONTRIBUTING.md` roto ya en el original) |

### Grupos
- `Grupo.colecciones` (pointers **validados**) en create/update con invalidación del cache de permisos; `toSafeJSON` las expone; multi-select "Colecciones de Contenidos con acceso" en el editor de grupo (`CLAVE — Nombre` truncado); el submenú del grupo enlaza `/contenidos/<slug>/`.

### Redirects `/docs/*` → `/contenidos/*`
- Middleware con **mapa exacto** (`src/data/redirects-docs.json`, generado por el importador) + heurística por segmento. **APAGADO por defecto** — se enciende con `REDIRECT_DOCS_A_CONTENIDOS=true` en el corte de la US-7 (candado del plan de deprecación).

## Checklist
- [x] `tsc --noEmit` web y api; builds pasan; 23/23 tests
- [x] Dry-run de paridad contra tc2005b y tc2007b
- [ ] Code review (en curso)
- [ ] Validación funcional manual