### PR TITLE
feat(cms): storage en S3 con migración desde GridFS (US-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" (US-8)**: storage en AWS S3 — el files adapter cambia a
+  `@parse/s3-files-adapter` cuando el `.env` trae credenciales (bucket
+  privado `groups-meeplab-contenidos`; `directAccess` desactivado: S3 jamás
+  sirve directo) + script de migración GridFS→S3 con `--dry-run`.
 - **CMS "Contenidos" (US-6)**: importador Docusaurus→Contenidos con
   `--dry-run` y reporte de paridad (verificado: tc2005b y tc2007b, 0 y 1
   enlaces sin resolver, preexistentes); asignación de colecciones a grupos

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest --globals"
   },
   "dependencies": {
+    "@parse/s3-files-adapter": "^4.1.0",
     "@tc2005b/contenido-pipeline": "0.1.0",
     "bcryptjs": "^3.0.3",
     "cookie-parser": "^1.4.7",

--- a/packages/api/scripts/migrar-archivos-s3.ts
+++ b/packages/api/scripts/migrar-archivos-s3.ts
@@ -1,0 +1,110 @@
+/**
+ * Migración de archivos GridFS → S3 (US-8, design §8/US-8).
+ *
+ * Prerrequisitos:
+ *   1. Variables S3_* en el .env del servidor (de ~/.parse-contenidos-s3.env)
+ *      y API REINICIADO — el adapter activo debe ser YA S3 (este script
+ *      guarda los archivos nuevos a través del server).
+ *   2. El server corriendo (como el resto de los scripts).
+ *
+ * Qué hace: por cada Recurso con archivo, lee los bytes DIRECTO de GridFS
+ * (el adapter S3 ya no puede leer los viejos), los re-guarda como Parse.File
+ * (que ahora aterriza en S3) y actualiza el pointer del Recurso. Los blobs
+ * de GridFS se conservan como respaldo salvo --borrar-gridfs.
+ *
+ * Uso:
+ *   cd packages/api
+ *   ./node_modules/.bin/tsx scripts/migrar-archivos-s3.ts [--dry-run] [--borrar-gridfs]
+ */
+import { MongoClient, GridFSBucket } from 'mongodb';
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+import { Recurso } from '../src/models/Recurso.js';
+
+const dryRun = process.argv.includes('--dry-run');
+const borrarGridfs = process.argv.includes('--borrar-gridfs');
+
+async function leerDeGridFS(bucket: GridFSBucket, nombre: string): Promise<Buffer | null> {
+  const archivos = await bucket.find({ filename: nombre }).toArray();
+  if (archivos.length === 0) return null;
+  const chunks: Buffer[] = [];
+  return new Promise((resolve, reject) => {
+    bucket
+      .openDownloadStreamByName(nombre)
+      .on('data', (c) => chunks.push(c))
+      .on('end', () => resolve(Buffer.concat(chunks)))
+      .on('error', reject);
+  });
+}
+
+async function main() {
+  Parse.initialize(config.appId);
+  (Parse as any).serverURL = config.serverURL;
+  (Parse as any).masterKey = config.masterKey;
+
+  if (!dryRun && !process.env.S3_BUCKET) {
+    console.error('El .env de este proceso no trae S3_BUCKET — el server debe estar ya en S3.');
+    console.error('(El script solo verifica su propio entorno; asegúrate de que el SERVER también lo tenga.)');
+  }
+  if (dryRun) console.log('=== DRY RUN — no se migrará nada ===\n');
+
+  const cliente = new MongoClient(config.databaseURI);
+  await cliente.connect();
+  const bucket = new GridFSBucket(cliente.db());
+
+  const q = new Parse.Query<Recurso>('Recurso');
+  q.equalTo('exists' as any, true as any);
+  q.limit(100000);
+  const recursos = await q.find({ useMasterKey: true });
+  console.log(`Recursos con archivo: ${recursos.length}\n`);
+
+  let migrados = 0;
+  let yaEnS3 = 0;
+  let sinBlob = 0;
+
+  for (const recurso of recursos) {
+    const archivo = recurso.getArchivo();
+    if (!archivo) continue;
+    const nombreInterno = archivo.name();
+
+    const bytes = await leerDeGridFS(bucket, nombreInterno);
+    if (!bytes) {
+      // No está en GridFS: o ya migró (vive en S3) o el blob se perdió.
+      yaEnS3 += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`migraría: ${recurso.getNombre()} (${(bytes.length / 1024).toFixed(0)} KB)`);
+      migrados += 1;
+      continue;
+    }
+
+    const nuevo = new Parse.File(recurso.getNombre(), { base64: bytes.toString('base64') }, recurso.getMime());
+    await nuevo.save({ useMasterKey: true }); // adapter actual = S3
+    recurso.setArchivo(nuevo);
+    await recurso.save(null, { useMasterKey: true });
+    migrados += 1;
+
+    if (borrarGridfs) {
+      for (const f of await bucket.find({ filename: nombreInterno }).toArray()) {
+        await bucket.delete(f._id);
+      }
+    }
+    console.log(`migrado: ${recurso.getNombre()} (${(bytes.length / 1024).toFixed(0)} KB)`);
+  }
+
+  console.log('\n===== RESUMEN =====');
+  console.log(`Migrados:        ${migrados}${dryRun ? ' (dry-run)' : ''}`);
+  console.log(`Ya fuera de GridFS: ${yaEnS3}`);
+  if (sinBlob) console.log(`Sin blob:        ${sinBlob}`);
+  console.log(`GridFS ${borrarGridfs ? 'LIMPIADO' : 'conservado como respaldo (usa --borrar-gridfs tras validar)'}`);
+  await cliente.close();
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error('[migrar-archivos-s3] error:', error);
+  process.exit(1);
+});

--- a/packages/api/scripts/migrar-archivos-s3.ts
+++ b/packages/api/scripts/migrar-archivos-s3.ts
@@ -1,16 +1,23 @@
 /**
- * Migración de archivos GridFS → S3 (US-8, design §8/US-8).
+ * Migración de archivos GridFS → S3 (US-8, design decisión #5).
  *
  * Prerrequisitos:
  *   1. Variables S3_* en el .env del servidor (de ~/.parse-contenidos-s3.env)
- *      y API REINICIADO — el adapter activo debe ser YA S3 (este script
- *      guarda los archivos nuevos a través del server).
+ *      y API REINICIADO — el adapter activo debe ser YA S3.
  *   2. El server corriendo (como el resto de los scripts).
  *
- * Qué hace: por cada Recurso con archivo, lee los bytes DIRECTO de GridFS
- * (el adapter S3 ya no puede leer los viejos), los re-guarda como Parse.File
- * (que ahora aterriza en S3) y actualiza el pointer del Recurso. Los blobs
- * de GridFS se conservan como respaldo salvo --borrar-gridfs.
+ * El script VERIFICA con una sonda que el server realmente guarda en S3
+ * (guarda un archivo de prueba y comprueba que NO aterrizó en GridFS): si el
+ * operador olvidó reiniciar con las S3_*, abortamos — sin la sonda, la
+ * "migración" re-subiría los blobs DENTRO de GridFS con nombres nuevos y
+ * reportaría éxito.
+ *
+ * Por cada archivo (deduplicado por nombre interno; puede compartirse entre
+ * varios Recursos): lee los bytes directo de GridFS, los re-guarda como
+ * Parse.File (aterriza en S3) y actualiza TODOS los pointers que lo usan.
+ * Con --borrar-gridfs, el blob viejo se borra SOLO tras actualizar todos
+ * sus pointers. Incluye Recursos soft-deleted (sus blobs también migran:
+ * podrían restaurarse).
  *
  * Uso:
  *   cd packages/api
@@ -38,70 +45,140 @@ async function leerDeGridFS(bucket: GridFSBucket, nombre: string): Promise<Buffe
   });
 }
 
+/** Borra un Parse.File del adapter actual vía REST (best-effort). */
+async function borrarParseFile(nombreInterno: string): Promise<void> {
+  try {
+    await fetch(`${config.serverURL}/files/${encodeURIComponent(nombreInterno)}`, {
+      method: 'DELETE',
+      headers: { 'X-Parse-Application-Id': config.appId, 'X-Parse-Master-Key': config.masterKey },
+    });
+  } catch {
+    // best-effort: si falla, queda huérfano y se reporta el nombre
+  }
+}
+
+/**
+ * Sonda: guarda un archivo de prueba vía el server y verifica que NO cayó
+ * en GridFS (⇒ el adapter activo es S3). Limpia la sonda al terminar.
+ */
+async function verificarServerEnS3(bucket: GridFSBucket): Promise<boolean> {
+  const sonda = new Parse.File('sonda-migracion-s3.txt', { base64: Buffer.from('sonda').toString('base64') }, 'text/plain');
+  await sonda.save({ useMasterKey: true });
+  const nombre = sonda.name();
+  const enGridfs = await bucket.find({ filename: nombre }).toArray();
+  if (enGridfs.length > 0) {
+    // El server sigue en GridFS: limpiar la sonda de GridFS y abortar.
+    for (const f of enGridfs) await bucket.delete(f._id);
+    return false;
+  }
+  await borrarParseFile(nombre); // sonda en S3: limpiar
+  return true;
+}
+
 async function main() {
   Parse.initialize(config.appId);
   (Parse as any).serverURL = config.serverURL;
   (Parse as any).masterKey = config.masterKey;
 
-  if (!dryRun && !process.env.S3_BUCKET) {
-    console.error('El .env de este proceso no trae S3_BUCKET — el server debe estar ya en S3.');
-    console.error('(El script solo verifica su propio entorno; asegúrate de que el SERVER también lo tenga.)');
-  }
   if (dryRun) console.log('=== DRY RUN — no se migrará nada ===\n');
 
   const cliente = new MongoClient(config.databaseURI);
   await cliente.connect();
   const bucket = new GridFSBucket(cliente.db());
 
+  if (!dryRun) {
+    console.log('Verificando con sonda que el server guarda en S3…');
+    if (!(await verificarServerEnS3(bucket))) {
+      console.error('\nABORTADO: el server sigue guardando en GridFS.');
+      console.error('Configura S3_BUCKET/S3_REGION/S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY en el .env del SERVER y reinícialo.');
+      await cliente.close();
+      process.exit(1);
+    }
+    console.log('Sonda OK: el adapter activo es S3.\n');
+  }
+
+  // TODOS los Recursos (incluidos soft-deleted: sus blobs podrían restaurarse).
   const q = new Parse.Query<Recurso>('Recurso');
-  q.equalTo('exists' as any, true as any);
   q.limit(100000);
   const recursos = await q.find({ useMasterKey: true });
-  console.log(`Recursos con archivo: ${recursos.length}\n`);
+
+  // Dedupe por nombre interno: un mismo Parse.File puede compartirse entre
+  // Recursos — se migra UNA vez y se actualizan TODOS sus pointers.
+  const porNombre = new Map<string, Recurso[]>();
+  let sinArchivo = 0;
+  for (const r of recursos) {
+    const archivo = r.getArchivo();
+    if (!archivo) {
+      sinArchivo += 1;
+      continue;
+    }
+    const nombre = archivo.name();
+    if (!porNombre.has(nombre)) porNombre.set(nombre, []);
+    porNombre.get(nombre)!.push(r);
+  }
+  console.log(`Recursos: ${recursos.length} (${sinArchivo} sin archivo) · archivos únicos: ${porNombre.size}\n`);
 
   let migrados = 0;
-  let yaEnS3 = 0;
-  let sinBlob = 0;
+  let borrados = 0;
+  const fueraDeGridFS: string[] = [];
+  const fallidos: string[] = [];
 
-  for (const recurso of recursos) {
-    const archivo = recurso.getArchivo();
-    if (!archivo) continue;
-    const nombreInterno = archivo.name();
-
-    const bytes = await leerDeGridFS(bucket, nombreInterno);
-    if (!bytes) {
-      // No está en GridFS: o ya migró (vive en S3) o el blob se perdió.
-      yaEnS3 += 1;
-      continue;
-    }
-
-    if (dryRun) {
-      console.log(`migraría: ${recurso.getNombre()} (${(bytes.length / 1024).toFixed(0)} KB)`);
-      migrados += 1;
-      continue;
-    }
-
-    const nuevo = new Parse.File(recurso.getNombre(), { base64: bytes.toString('base64') }, recurso.getMime());
-    await nuevo.save({ useMasterKey: true }); // adapter actual = S3
-    recurso.setArchivo(nuevo);
-    await recurso.save(null, { useMasterKey: true });
-    migrados += 1;
-
-    if (borrarGridfs) {
-      for (const f of await bucket.find({ filename: nombreInterno }).toArray()) {
-        await bucket.delete(f._id);
+  for (const [nombreInterno, duenos] of porNombre) {
+    try {
+      const bytes = await leerDeGridFS(bucket, nombreInterno);
+      if (!bytes) {
+        // No está en GridFS: ya migrado a S3 en una corrida previa, o blob
+        // perdido — se lista para que el operador lo verifique en el visor.
+        fueraDeGridFS.push(`${nombreInterno} (recursos: ${duenos.map((d) => d.getNombre()).join(', ')})`);
+        continue;
       }
+
+      if (dryRun) {
+        console.log(`migraría: ${nombreInterno} (${(bytes.length / 1024).toFixed(0)} KB, ${duenos.length} pointer/s)`);
+        migrados += 1;
+        continue;
+      }
+
+      const primero = duenos[0];
+      const nuevo = new Parse.File(primero.getNombre(), { base64: bytes.toString('base64') }, primero.getMime());
+      await nuevo.save({ useMasterKey: true }); // adapter actual = S3 (verificado)
+
+      try {
+        for (const r of duenos) {
+          r.setArchivo(nuevo);
+          await r.save(null, { useMasterKey: true });
+        }
+      } catch (err) {
+        // Pointer(s) sin actualizar: borrar el objeto recién subido a S3
+        // para no dejar huérfanos de pago; el blob viejo sigue intacto.
+        await borrarParseFile(nuevo.name());
+        throw err;
+      }
+
+      migrados += 1;
+      console.log(`migrado: ${nombreInterno} (${(bytes.length / 1024).toFixed(0)} KB, ${duenos.length} pointer/s)`);
+
+      // Borrar el blob viejo SOLO tras actualizar todos sus pointers.
+      if (borrarGridfs) {
+        for (const f of await bucket.find({ filename: nombreInterno }).toArray()) {
+          await bucket.delete(f._id);
+          borrados += 1;
+        }
+      }
+    } catch (err) {
+      fallidos.push(`${nombreInterno}: ${err instanceof Error ? err.message : String(err)}`);
     }
-    console.log(`migrado: ${recurso.getNombre()} (${(bytes.length / 1024).toFixed(0)} KB)`);
   }
 
   console.log('\n===== RESUMEN =====');
-  console.log(`Migrados:        ${migrados}${dryRun ? ' (dry-run)' : ''}`);
-  console.log(`Ya fuera de GridFS: ${yaEnS3}`);
-  if (sinBlob) console.log(`Sin blob:        ${sinBlob}`);
-  console.log(`GridFS ${borrarGridfs ? 'LIMPIADO' : 'conservado como respaldo (usa --borrar-gridfs tras validar)'}`);
+  console.log(`Archivos migrados:   ${migrados}${dryRun ? ' (dry-run)' : ''}`);
+  console.log(`Ya fuera de GridFS:  ${fueraDeGridFS.length} (migrados antes o blob perdido — verificar en el visor)`);
+  for (const x of fueraDeGridFS.slice(0, 20)) console.log(`  · ${x}`);
+  console.log(`Blobs GridFS borrados: ${borrados}${borrarGridfs ? '' : ' (respaldo conservado; usa --borrar-gridfs EN LA MISMA corrida de migración)'}`);
+  console.log(`FALLIDOS:            ${fallidos.length}`);
+  for (const x of fallidos) console.log(`  ✗ ${x}`);
   await cliente.close();
-  process.exit(0);
+  process.exit(fallidos.length > 0 ? 1 : 0);
 }
 
 main().catch((error) => {

--- a/packages/api/src/config/parse.ts
+++ b/packages/api/src/config/parse.ts
@@ -1,7 +1,40 @@
 import { config } from './index.js';
 
+/**
+ * Files adapter (US-8, design decisión #5): si el .env trae credenciales S3,
+ * los Parse.File van al bucket privado (groups-meeplab-contenidos); si no,
+ * GridFS (default) — dev funciona sin AWS y producción cambia SOLO con
+ * configuración. La lectura sigue siendo exclusiva del endpoint gated de
+ * Recursos (files-gate); directAccess desactivado: S3 jamás sirve directo.
+ *
+ * Variables (ver ~/.parse-contenidos-s3.env del usuario):
+ *   S3_BUCKET, S3_REGION, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
+ */
+async function crearFilesAdapter(): Promise<unknown | undefined> {
+  const { S3_BUCKET, S3_REGION, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY } = process.env;
+  if (!S3_BUCKET || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY) return undefined;
+
+  const { default: S3Adapter } = (await import('@parse/s3-files-adapter')) as any;
+  return new S3Adapter({
+    bucket: S3_BUCKET,
+    region: S3_REGION || 'us-east-1',
+    directAccess: false,
+    s3overrides: {
+      credentials: {
+        accessKeyId: S3_ACCESS_KEY_ID,
+        secretAccessKey: S3_SECRET_ACCESS_KEY,
+      },
+    },
+  });
+}
+
 export async function initializeParseServer() {
   const { default: ParseServer } = (await import('parse-server')) as any;
+
+  const filesAdapter = await crearFilesAdapter();
+  if (filesAdapter) {
+    console.log(`[api] Files adapter: S3 (${process.env.S3_BUCKET})`);
+  }
 
   const parseServer = new ParseServer({
     databaseURI: config.databaseURI,
@@ -11,6 +44,7 @@ export async function initializeParseServer() {
     publicServerURL: config.serverURL,
     masterKeyIps: ['0.0.0.0/0', '::/0'],
     allowClientClassCreation: config.environment === 'development',
+    ...(filesAdapter ? { filesAdapter } : {}),
   });
 
   await parseServer.start();

--- a/packages/api/src/config/parse.ts
+++ b/packages/api/src/config/parse.ts
@@ -11,18 +11,36 @@ import { config } from './index.js';
  *   S3_BUCKET, S3_REGION, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY
  */
 async function crearFilesAdapter(): Promise<unknown | undefined> {
-  const { S3_BUCKET, S3_REGION, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY } = process.env;
-  if (!S3_BUCKET || !S3_ACCESS_KEY_ID || !S3_SECRET_ACCESS_KEY) return undefined;
+  const vars = {
+    S3_BUCKET: process.env.S3_BUCKET,
+    S3_REGION: process.env.S3_REGION,
+    S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID,
+    S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY,
+  };
+  const faltantes = Object.entries(vars).filter(([, v]) => !v).map(([k]) => k);
+
+  // Sin ninguna variable: GridFS a propósito (dev). Con ALGUNA definida, la
+  // intención era S3: degradar en silencio subiría archivos a GridFS que el
+  // adapter S3 nunca podría leer — mejor no arrancar. La región también es
+  // obligatoria: un default equivocado falla en runtime (301 de AWS), no al
+  // arrancar.
+  if (faltantes.length === 4) return undefined;
+  if (faltantes.length > 0) {
+    throw new Error(
+      `Configuración S3 incompleta (faltan: ${faltantes.join(', ')}). ` +
+        'Define las 4 variables S3_* o ninguna (GridFS).',
+    );
+  }
 
   const { default: S3Adapter } = (await import('@parse/s3-files-adapter')) as any;
   return new S3Adapter({
-    bucket: S3_BUCKET,
-    region: S3_REGION || 'us-east-1',
+    bucket: vars.S3_BUCKET,
+    region: vars.S3_REGION,
     directAccess: false,
     s3overrides: {
       credentials: {
-        accessKeyId: S3_ACCESS_KEY_ID,
-        secretAccessKey: S3_SECRET_ACCESS_KEY,
+        accessKeyId: vars.S3_ACCESS_KEY_ID,
+        secretAccessKey: vars.S3_SECRET_ACCESS_KEY,
       },
     },
   });

--- a/packages/api/src/types/parse-s3-files-adapter.d.ts
+++ b/packages/api/src/types/parse-s3-files-adapter.d.ts
@@ -1,0 +1,2 @@
+// El adapter no publica tipos; se consume vía import dinámico y opciones any.
+declare module '@parse/s3-files-adapter';

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,6 +298,479 @@
   resolved "https://registry.yarnpkg.com/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz#e72bc512582a6f26af150439f7eb7473b46ba874"
   integrity sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==
 
+"@aws-crypto/sha1-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz#b0ee2d2821d3861f017e965ef3b4cb38e3b6a0f4"
+  integrity sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==
+  dependencies:
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/checksums@^3.1000.12":
+  version "3.1000.12"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/checksums/-/checksums-3.1000.12.tgz#5b2436bfdc6eaaa27f8cdcc4c49c324e7e8711be"
+  integrity sha512-RgNDWfhNRIlNEzePIRrYTNi/6q+wwRMMapojn8YVzw4ZcJRa/gxVMtUbeZARR1gmopuv6oIhMbY7J66qIQ0ynw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-s3@3.986.0":
+  version "3.986.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.986.0.tgz#38ecea36c41b36748b7c703ba09d77ce95c7d6ee"
+  integrity sha512-IcDJ8shVVvbxgMe8+dLWcv6uhSwmX65PHTVGX81BhWAElPnp3CL8w/5uzOPRo4n4/bqIk9eskGVEIicw2o+SrA==
+  dependencies:
+    "@aws-crypto/sha1-browser" "5.2.0"
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.973.7"
+    "@aws-sdk/credential-provider-node" "^3.972.6"
+    "@aws-sdk/middleware-bucket-endpoint" "^3.972.3"
+    "@aws-sdk/middleware-expect-continue" "^3.972.3"
+    "@aws-sdk/middleware-flexible-checksums" "^3.972.5"
+    "@aws-sdk/middleware-host-header" "^3.972.3"
+    "@aws-sdk/middleware-location-constraint" "^3.972.3"
+    "@aws-sdk/middleware-logger" "^3.972.3"
+    "@aws-sdk/middleware-recursion-detection" "^3.972.3"
+    "@aws-sdk/middleware-sdk-s3" "^3.972.7"
+    "@aws-sdk/middleware-ssec" "^3.972.3"
+    "@aws-sdk/middleware-user-agent" "^3.972.7"
+    "@aws-sdk/region-config-resolver" "^3.972.3"
+    "@aws-sdk/signature-v4-multi-region" "3.986.0"
+    "@aws-sdk/types" "^3.973.1"
+    "@aws-sdk/util-endpoints" "3.986.0"
+    "@aws-sdk/util-user-agent-browser" "^3.972.3"
+    "@aws-sdk/util-user-agent-node" "^3.972.5"
+    "@smithy/config-resolver" "^4.4.6"
+    "@smithy/core" "^3.22.1"
+    "@smithy/eventstream-serde-browser" "^4.2.8"
+    "@smithy/eventstream-serde-config-resolver" "^4.3.8"
+    "@smithy/eventstream-serde-node" "^4.2.8"
+    "@smithy/fetch-http-handler" "^5.3.9"
+    "@smithy/hash-blob-browser" "^4.2.9"
+    "@smithy/hash-node" "^4.2.8"
+    "@smithy/hash-stream-node" "^4.2.8"
+    "@smithy/invalid-dependency" "^4.2.8"
+    "@smithy/md5-js" "^4.2.8"
+    "@smithy/middleware-content-length" "^4.2.8"
+    "@smithy/middleware-endpoint" "^4.4.13"
+    "@smithy/middleware-retry" "^4.4.30"
+    "@smithy/middleware-serde" "^4.2.9"
+    "@smithy/middleware-stack" "^4.2.8"
+    "@smithy/node-config-provider" "^4.3.8"
+    "@smithy/node-http-handler" "^4.4.9"
+    "@smithy/protocol-http" "^5.3.8"
+    "@smithy/smithy-client" "^4.11.2"
+    "@smithy/types" "^4.12.0"
+    "@smithy/url-parser" "^4.2.8"
+    "@smithy/util-base64" "^4.3.0"
+    "@smithy/util-body-length-browser" "^4.2.0"
+    "@smithy/util-body-length-node" "^4.2.1"
+    "@smithy/util-defaults-mode-browser" "^4.3.29"
+    "@smithy/util-defaults-mode-node" "^4.2.32"
+    "@smithy/util-endpoints" "^3.2.8"
+    "@smithy/util-middleware" "^4.2.8"
+    "@smithy/util-retry" "^4.2.8"
+    "@smithy/util-stream" "^4.5.11"
+    "@smithy/util-utf8" "^4.2.0"
+    "@smithy/util-waiter" "^4.2.8"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.973.7", "@aws-sdk/core@^3.974.27":
+  version "3.974.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.27.tgz#c3f2745490089ce1809344837652ee2907f309e3"
+  integrity sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.15"
+    "@aws-sdk/xml-builder" "^3.972.33"
+    "@aws/lambda-invoke-store" "^0.3.0"
+    "@smithy/core" "^3.29.0"
+    "@smithy/signature-v4" "^5.6.1"
+    "@smithy/types" "^4.15.1"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.53.tgz#8afea29ea7030937fb63d406025a2d4aa5f9a3ce"
+  integrity sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.55":
+  version "3.972.55"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.55.tgz#cd12f71ce0e8ae8f3ab18afe68da862623aa71da"
+  integrity sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/fetch-http-handler" "^5.6.2"
+    "@smithy/node-http-handler" "^4.9.2"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.60":
+  version "3.972.60"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.60.tgz#b22360181e61b5f294d529d94c6afffe211627eb"
+  integrity sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/credential-provider-env" "^3.972.53"
+    "@aws-sdk/credential-provider-http" "^3.972.55"
+    "@aws-sdk/credential-provider-login" "^3.972.59"
+    "@aws-sdk/credential-provider-process" "^3.972.53"
+    "@aws-sdk/credential-provider-sso" "^3.972.59"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.59"
+    "@aws-sdk/nested-clients" "^3.997.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/credential-provider-imds" "^4.4.5"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.59":
+  version "3.972.59"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.59.tgz#49357020e69e5c0d679ae2ee5deb3a6f0e18f996"
+  integrity sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/nested-clients" "^3.997.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.6":
+  version "3.972.62"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.62.tgz#189426cb8d8778db4d831f23010f46b20dbeee80"
+  integrity sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.53"
+    "@aws-sdk/credential-provider-http" "^3.972.55"
+    "@aws-sdk/credential-provider-ini" "^3.972.60"
+    "@aws-sdk/credential-provider-process" "^3.972.53"
+    "@aws-sdk/credential-provider-sso" "^3.972.59"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.59"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/credential-provider-imds" "^4.4.5"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.53.tgz#fb02d94096496671548afad9f004b4ed81b6b129"
+  integrity sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.59":
+  version "3.972.59"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.59.tgz#f19af269b9921c4e8a872465a3d275048359b573"
+  integrity sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/nested-clients" "^3.997.27"
+    "@aws-sdk/token-providers" "3.1079.0"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.59":
+  version "3.972.59"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.59.tgz#ee5a1bd31f67ebecdfe7d2de68bd1fd8cfa2336b"
+  integrity sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/nested-clients" "^3.997.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-bucket-endpoint@^3.972.3":
+  version "3.972.31"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.31.tgz#5ecf260f08544c0d16e1914b4140fb8c5d4aadc5"
+  integrity sha512-qAq2i5wj8wnZ+V/WlwwE0cfvJamyvV2k6v9Iq7UfDYzQC60xCHG/4/f4hJG4DELoCQeR6DstbD93pR7wLtfOtg==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.58"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-expect-continue@^3.972.3":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.27.tgz#06baaf3fefdff7eaa037a74ddf7864a5174a89e5"
+  integrity sha512-yqwl26dLHxWYVcF8drGETF5vU0rmoYd6tY89qeoe9lsS+NWerD/0YkgUnRe1p4ZALiO3vHcxWYoi3dtahAvDZQ==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.58"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-flexible-checksums@^3.972.5":
+  version "3.974.37"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.37.tgz#4eb8feaa8308121e94b85d25ddfde46ea9c259be"
+  integrity sha512-EI6E7KlYzEGXCqfznmkmqebY3XLcqHQNnl/o3rOFRX//LJ4Vc81igwtohmfM/kHnqxE8J/hyItwL5+LdDynXQg==
+  dependencies:
+    "@aws-sdk/checksums" "^3.1000.12"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-host-header@^3.972.3":
+  version "3.972.28"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.28.tgz#e07bfd0457e515d31eb4afecdf3b7de55309882a"
+  integrity sha512-2w4cKugljxKCgBPL5LQJLj+1kUBkWG8HO7C+7GYTS7UNATMijEK+MCEktnCpfA2koBZFcf7Ioe5YhNZ5vh5ruw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-location-constraint@^3.972.3":
+  version "3.972.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.24.tgz#b79f6ac89bec2bf6fc2136917d3132e74b86621f"
+  integrity sha512-a/1rbT9Vhz8Z6KXppZFFh+2zuFclkeTkzVJcRHfd4ejqkO/Gdsy7OINCAQHfX3VV0yDhRb7HjoAXy03D9N56rA==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.58"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-logger@^3.972.3":
+  version "3.972.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.972.27.tgz#70eb8d83ba222b06e6b67687a27fab6d8f0b9867"
+  integrity sha512-Qia7FsijpSh+LL9H6i9HQ3JZQsN9qdOQjwCAIi4Zi9Xqc62N7c3udBOfliavqn40FKZlgpgV/Js+NpKguyXfiA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@^3.972.3":
+  version "3.972.29"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.29.tgz#dacc0b96d8dac27ae5b547191e1056d02b46454c"
+  integrity sha512-iM0ZSNerIexGGFokLEJqEr/H2kV+WiTENZXHLb391q1ldF+qWDn86MpyH4HKfKwQRzEhInehwX9u9/a1IXAz6g==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-sdk-s3@^3.972.5", "@aws-sdk/middleware-sdk-s3@^3.972.58", "@aws-sdk/middleware-sdk-s3@^3.972.7":
+  version "3.972.58"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.58.tgz#c1312382c88dd8a04552947ee4538c4c34eb3b48"
+  integrity sha512-6uaWRRYJGhOqc9EoTSbLDf9nI/doSAb5vAwGshs5/Hlv5Ce25b246lBkbRd/77fLAi+uMI1a70mJzVyLyCEufQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.38"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-ssec@^3.972.3":
+  version "3.972.24"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.24.tgz#d5d94d9acdcd0731d58a343f9c028465a0b1dd51"
+  integrity sha512-m/+ToPJQkdRF0o9CWaQWFwdsCM1IEsppDHff43/o4fAADAZPx7YRxo18XsKStjghr7QBTdEinE4PdLcmxNqf0w==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.58"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-user-agent@^3.972.7":
+  version "3.972.57"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.57.tgz#517b122e8c3556b8f1874026f6b402b0220fcbb0"
+  integrity sha512-4gstakrfAVK7CAQ8Rar4Sig7Ztjxdp+Xt/A48VwTxwPVVNs+lAWs1+ZTGF+zlT65qWbnihUsX7uzBdPEllzLSA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.27":
+  version "3.997.27"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.27.tgz#61d65c1c027fe55144214c323f7397f7481f97d7"
+  integrity sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.38"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/fetch-http-handler" "^5.6.2"
+    "@smithy/node-http-handler" "^4.9.2"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@^3.972.3":
+  version "3.972.31"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.31.tgz#7b41689341d9c49f0bb777670ce2f494ee900c69"
+  integrity sha512-5qLGtfKWyPK/eSLxIzsrNRfHVYZliXxe5mXYldmVB1Ca5VCpz0TjZhIb9otq1eUER8m2AQ1Jy0EBeR6qC65wvg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/s3-request-presigner@3.980.0":
+  version "3.980.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.980.0.tgz#eb06d1b4fb6b3b732d4b0447b5eebc09740d8794"
+  integrity sha512-qX1Ptvja9Le0Wt1VadgsJ7Kw8Xf57pTIVmIcvYD5HrdAot71qgXdfBtcbuvNKZPeD+HfcUITwxxHpDiXfSoTsA==
+  dependencies:
+    "@aws-sdk/signature-v4-multi-region" "3.980.0"
+    "@aws-sdk/types" "^3.973.1"
+    "@aws-sdk/util-format-url" "^3.972.3"
+    "@smithy/middleware-endpoint" "^4.4.12"
+    "@smithy/protocol-http" "^5.3.8"
+    "@smithy/smithy-client" "^4.11.1"
+    "@smithy/types" "^4.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@3.980.0":
+  version "3.980.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.980.0.tgz#dfcb3eb7fa85d4e2149f29d73aa7c8ebbc560b3e"
+  integrity sha512-tO2jBj+ZIVM0nEgi1SyxWtaYGpuAJdsrugmWcI3/U2MPWCYsrvKasUo0026NvJJao38wyUq9B8XTG8Xu53j/VA==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.5"
+    "@aws-sdk/types" "^3.973.1"
+    "@smithy/protocol-http" "^5.3.8"
+    "@smithy/signature-v4" "^5.3.8"
+    "@smithy/types" "^4.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@3.986.0":
+  version "3.986.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.986.0.tgz#bd34f23daee028905640023c483fdc12eda9a4e6"
+  integrity sha512-Upw+rw7wCH93E6QWxqpAqJLrUmJYVUAWrk4tCOBnkeuwzGERZvJFL5UQ6TAJFj9T18Ih+vNFaACh8J5aP4oTBw==
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3" "^3.972.7"
+    "@aws-sdk/types" "^3.973.1"
+    "@smithy/protocol-http" "^5.3.8"
+    "@smithy/signature-v4" "^5.3.8"
+    "@smithy/types" "^4.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.38":
+  version "3.996.38"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz#8e603b2a916499f573b537e13860b074950bd29b"
+  integrity sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==
+  dependencies:
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/signature-v4" "^5.6.1"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1079.0":
+  version "3.1079.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1079.0.tgz#f5d500b5da93ff9015d4d2f89ab4c8f795463c1f"
+  integrity sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    "@aws-sdk/nested-clients" "^3.997.27"
+    "@aws-sdk/types" "^3.973.15"
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.973.1", "@aws-sdk/types@^3.973.15":
+  version "3.973.15"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.15.tgz#98a4860bed33c32c7088924d0ab52f9eabbdf7c3"
+  integrity sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-endpoints@3.986.0":
+  version "3.986.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.986.0.tgz#16d3bd7227e5c3797a10a95d37898e511e75a72a"
+  integrity sha512-Mqi79L38qi1gCG3adlVdbNrSxvcm1IPDLiJPA3OBypY5ewxUyWbaA3DD4goG+EwET6LSFgZJcRSIh6KBNpP5pA==
+  dependencies:
+    "@aws-sdk/types" "^3.973.1"
+    "@smithy/types" "^4.12.0"
+    "@smithy/url-parser" "^4.2.8"
+    "@smithy/util-endpoints" "^3.2.8"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-format-url@^3.972.3":
+  version "3.972.29"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-format-url/-/util-format-url-3.972.29.tgz#27af61e202db0ae32392068154b6e7bf42e34538"
+  integrity sha512-r47hxRqvahtf/udnvUnVKcznbokohwl3N/+5oXqBlu3Jah0aOBRwpd0HCt5/uzaOs4ojvOAg/Jcr3UrjW0OAyg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.965.8"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz#d9a6bede3c136f433441391615da68c924692487"
+  integrity sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-browser@^3.972.3":
+  version "3.972.28"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.28.tgz#b09c56459ead26fb5ebf910762d04f56937d1cd3"
+  integrity sha512-qr0fi8bkpkALaVPQzPinjAlWYR9/gswh4JUXHMoCBKS9YnoHCX+1qHROYGxWRI13BRg+OD4Wpl2NcuM0eFPyUA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@^3.972.5":
+  version "3.973.43"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.43.tgz#8039442f07498317052c87b4cd1c424aff96e583"
+  integrity sha512-sM+qbPrMr3kLDSJi6J93On74p9IFNzI2Jx4JyO/8TvYB9sn2e0EbBt2z7pES+NCfKI+ITSqixY8pM+RZdT0Qow==
+  dependencies:
+    "@aws-sdk/core" "^3.974.27"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.33":
+  version "3.972.33"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz#5cf4c5c74003382ff14928199a6745d4f3201eef"
+  integrity sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz#708802d987f8e17bdf4af4de1031660ce1cdd65f"
+  integrity sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
@@ -3462,6 +3935,14 @@
     parse "6.0.0"
     web-push "3.6.7"
 
+"@parse/s3-files-adapter@^4.1.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@parse/s3-files-adapter/-/s3-files-adapter-4.2.1.tgz#14566f2304820ee68797d03a409e830d9356eddc"
+  integrity sha512-E4AfaoB/QXvpVCADxd7PD6v85o0FgW5Kzrtab0XmlUBXvBnun53po7SsOX6rOuytaufdyK7tmZUO38vW1adaeA==
+  dependencies:
+    "@aws-sdk/client-s3" "3.986.0"
+    "@aws-sdk/s3-request-presigner" "3.980.0"
+
 "@peculiar/asn1-cms@^2.6.0", "@peculiar/asn1-cms@^2.6.1":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz#cb5445c1bad9197d176073bf142a5c035b460640"
@@ -3880,6 +4361,313 @@
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.1.0"
     micromark-util-symbol "^1.0.1"
+
+"@smithy/config-resolver@^4.4.6":
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/@smithy/config-resolver/-/config-resolver-4.6.5.tgz#82d46a3d01611f0d370c2abec43491642eae7728"
+  integrity sha512-EWaWeWXmEa2BMk6x0I++Nec4lMmTgzBI48ri7Ct6vv3YdcTzM3JrHMC3R3JkUVohMxA5D81WDhcCP+fs6kv4AQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/core@^3.22.1", "@smithy/core@^3.29.0":
+  version "3.29.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.29.0.tgz#d6f70b1a2d34675595a3cdfd551c519e0029a196"
+  integrity sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==
+  dependencies:
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.4.5":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.5.tgz#a4541f5b13cf1de067afe3ffaec14688f7b60e64"
+  integrity sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-browser@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.4.5.tgz#a3f73efd1797f7c0beab158dfdd2124ec135be2b"
+  integrity sha512-ZSlxtaQb9gWepJ8jrDIN7rmtJHyWch/K2XHajzmuo7ITBIMS6weW+V2XgYFbCSDdWYULN7j7E84Wxmqag90Uvg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-config-resolver@^4.3.8":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.5.5.tgz#0723f21aaed0abe496655f3e592e894291374d64"
+  integrity sha512-rGVPd0cmbJsbVK0+KJR2FZTA1ManrUTGqBokKrSTHwJJJq1eFkSpuZS+6H4MVtSm1wvKN6ckyKbt77E3l3RHkg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/eventstream-serde-node@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.4.5.tgz#1e2c9e2c5b1d4fc202a730c830d54ea6a103ba87"
+  integrity sha512-ENdwCKyljKbtjTyfjSr6YqZ8Zv2J7TX+XTY3x4bhzud5MPnhjoJ9t0/ng1ZJUWJ/1dRMYxACEyQ0CPnDVWZedA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.3.9", "@smithy/fetch-http-handler@^5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.2.tgz#d960c22c9c3c5926c5203d1b5a03e94e7058c538"
+  integrity sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/hash-blob-browser@^4.2.9":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-blob-browser/-/hash-blob-browser-4.4.5.tgz#c05811baeb851bcdbcab12390c5782afa958980d"
+  integrity sha512-MthLGLiSV8NDVK/oXLCdmIa50/uNTJqDjDc4KwCeWEKGkLBzgDqQmi/3FeobPbm3FtuBddXDiyNWR4FKi4Yj3A==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/hash-node@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-node/-/hash-node-4.4.5.tgz#4c2fce87476c3c0d22065ab26b4090e93668a8f7"
+  integrity sha512-2pyNsNH0rQJLTdIYDpona33axUSwhTPjJ5wl4twukJpEwgvltNL/mqZ7Tcgohz4DB8rhFwRPDd/3BlYuIvMYvw==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/hash-stream-node@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/hash-stream-node/-/hash-stream-node-4.4.5.tgz#4aadccff454f46ae89be9cfd8c515ac25c50f11e"
+  integrity sha512-DPb90h30aQ/4damqbUg1cw5hY88BvAbOEOclgBuYr1iXqVlMvMM+3fjo2VRMq7F6F8zO3+vjhVTJc34RghQXKA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/invalid-dependency@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/invalid-dependency/-/invalid-dependency-4.4.5.tgz#d2c499f186ff3ff27ddcba3269a185f178d373ab"
+  integrity sha512-CzXd06th+MmAoq7dfmP2Olg4ZIpnkcJnnx20Kgusc6dBC0we6+nyaJEdY78aGiAX95Oss4x4FRS6GlXttVzN6w==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/md5-js@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/md5-js/-/md5-js-4.4.5.tgz#a370808dbfcc6e6027a552a2ae0f3386944067b5"
+  integrity sha512-SP7u/vrmCVIMk3stk44ZBNqoyoZ39DtBk6nk1JiTDy2G2RZ/IMKMs13Q2b8pZSyMaC+4yljP2nI4YXrniS43TA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-content-length@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-content-length/-/middleware-content-length-4.4.5.tgz#d11c3285e38a2eefdd1936b25a5f21ee1bfcb9e5"
+  integrity sha512-civiAZI/EGJP9Y+MKZYAgGc02A6w32GwPMPGnVygNst6BzS/s9hGqlLtRI6QjhGy34tEAb8asr1hs19ARMWZOQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-endpoint@^4.4.12", "@smithy/middleware-endpoint@^4.4.13":
+  version "4.6.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-endpoint/-/middleware-endpoint-4.6.5.tgz#7a15609314fc0333aa83b328eae680fccc3ff419"
+  integrity sha512-8j/B9zIZOWgxEaq223MXRta/0AKpIEoEsIWE76SG2a5FIOrjUAQ9AvJn2oLekzzy5qH0d7y+bHDnJ7FOUFM8dw==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-retry@^4.4.30":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-retry/-/middleware-retry-4.7.5.tgz#5d5d8bf86e8fbc45e2802347e5cab9a861e38b50"
+  integrity sha512-fzLQbh4izNu+dCxm8mZOg0oujgkQyk8lCbWnstpxagVwqu9nTDByrlISaEAvlsQ9d9+lbvifmPjBLrRoEDrmPQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-serde@^4.2.9":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-serde/-/middleware-serde-4.4.5.tgz#8b555931ebe931fc01116268bb267301c7a0c08f"
+  integrity sha512-zyU0JL6kC23EBoMRHsrPNK+zRaBjFFVcuAhxvTAgusYv89HWzveG94kGLsHCRdawTLqeYjnX34lqY1mY680WSg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/middleware-stack@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/middleware-stack/-/middleware-stack-4.4.5.tgz#b7b0d8c35cb18f48adf820ef1917e01444e93aad"
+  integrity sha512-VCHV2Zqk5YC0AB938oL40HMvLcVPk9DFzjs511aseB1gVnC5ZJJckdaLyH14WrLOVAFMF4hIKZ3YenBlUa+uWQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/node-config-provider@^4.3.8":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/node-config-provider/-/node-config-provider-4.5.5.tgz#3438380008b8246185d1f2bdc5ef9ed500460a6c"
+  integrity sha512-oYaPOb+00xXWDUb5t05b0trcnZ4XSr/cDKioiZSwSKk8crvnu8AlElTddpq6s9HT4lELJuuduCAsbco8AjZUOQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.4.9", "@smithy/node-http-handler@^4.9.2":
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.9.2.tgz#4e8fbc9f5b8e51b1b1bc28a611e8ee721f6abe22"
+  integrity sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/protocol-http@^5.3.8":
+  version "5.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/protocol-http/-/protocol-http-5.5.5.tgz#7d09b6d9326da238e52035a7d96002235f41a0ce"
+  integrity sha512-3qVnJJQN0P5tHAui6Pusz958lyXLgUezbh3wiDL6xqMY90TvSB7knLIDNr2xPCF2E5TsUfYt5aRUS3466RFkuQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.3.8", "@smithy/signature-v4@^5.6.1":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.6.1.tgz#79cd89777d22a3d3460660bf3ac32ae21f9e1d4a"
+  integrity sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/smithy-client@^4.11.1", "@smithy/smithy-client@^4.11.2":
+  version "4.14.5"
+  resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.14.5.tgz#dca139cd4f99eb67ce6d3a07d55b8bb04d3bdf3e"
+  integrity sha512-gS9pgeFjdrgh8kzqZ/AgF71wUSI4nlLl0S0t7SdnK9+NNqLEIfaihFBfxCOIrjlWU1tELHi5Zw0u7r64pPpKHQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    "@smithy/types" "^4.15.1"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.12.0", "@smithy/types@^4.15.1":
+  version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.15.1.tgz#cdad0fdf4c5d1f5788dc21a3f1fb6af523d79da0"
+  integrity sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/url-parser@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/url-parser/-/url-parser-4.4.5.tgz#a298a1a2f9b37c8b17c393f22b0cbd8fcae2da1b"
+  integrity sha512-NSjOFRLW50LQR4TgJE68yiqdxFb73bg15T1rwe5U7WBFutN7Xck12H9/RkHYAXwX1xjzzRRD2S1YLDrnziuYjA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-base64@^4.3.0":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-base64/-/util-base64-4.5.5.tgz#292584f679f808c29693d187409e9654f6f488ed"
+  integrity sha512-iglQGUEglrtJofbabyVe4LPK6J8Hpn1nmdmxXkKsBhnmhndjJI78QpA1uKZnyiEuT3w66b4DTA+blXqExczMlw==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-browser@^4.2.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-browser/-/util-body-length-browser-4.4.5.tgz#ff81d60458b39923a2577ec0f48e59fb48fc38a7"
+  integrity sha512-8s1zynpaBil1uLzyzYC7wzN1Es/3KsQc1sp4dJAsLbpWtO03+QjxSqbjKdFuLcSVmg36KeMoFarovR1OLrF0eQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-body-length-node@^4.2.1":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-body-length-node/-/util-body-length-node-4.4.5.tgz#5cf2faa1ad008b107f849d6b143df8865dc78e84"
+  integrity sha512-IEBuUoh5lRA95ji4heI1P4eTqAoKnPiAc02g9Rls7QYdsg4KvAWU9nBdAXgBzWWsWTaqT3C8lWANZGm9loftRA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-browser@^4.3.29":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.5.5.tgz#8337d311517fbdd7fe29cfc188993e3af0587ee9"
+  integrity sha512-1jQUxgC5rcf7RwW7cWtvw3/JfTIlGPo4kgXcVXdYPiOLMtZcDp5nVrtPNsaIBGCLJDGd8oiwIKEbMfHqJjFNyg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-defaults-mode-node@^4.2.32":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.4.5.tgz#cc910371d0d655e928448c7dde1106820a640cea"
+  integrity sha512-HMQZY7lISfAjIL0JvcY4ayjWWk5p4l+SkqLr7CNOaqHsYSwUenrM+Q+RrunHo+fbqsUVS9rvLIaBzje85UqPXg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-endpoints@^3.2.8":
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-endpoints/-/util-endpoints-3.6.5.tgz#8679d1b22c9d4cddc3055ba665344edcbdb900cb"
+  integrity sha512-uweecdwyeAKKlvvkI7Y7Hm67OJPNrdPmoVI9oK1guNMnh/4Rnk5A3YqYhA3UFqNQFeejO003jsavN7EZ68ilfQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-middleware@^4.2.8":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-middleware/-/util-middleware-4.4.5.tgz#fe4fdc55c294f04416aa68a66b4523c6a22cbf83"
+  integrity sha512-bneMfanzxnbeRnLNq7q4cNC0tth2aI+0pWFarj9vYWs/J1F1dw1dMCSVduKCyGNW2x/eizQHdJZ+025J2aSMxg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-retry@^4.2.8":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-retry/-/util-retry-4.5.5.tgz#8f92361483a8fb66bf1ddbe8ff46454ebbd0967a"
+  integrity sha512-meg/9Fq4dK1+jImK2DvlMBZuJhI3AdbcVG6VbR2NF1FNwDHgIl9PHDwIoFECJQEinySGuVXf04Z9p7gNkQ2Dfg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-stream@^4.5.11":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-stream/-/util-stream-4.7.5.tgz#97944f6841fb6309d886df85627b7e97c772ca14"
+  integrity sha512-vuvn/ICZD8nqNc1yzrPSypGqmXNVi8O6alMe5By8ATvF6GVzxaNe3M4a+V5s6FwQhyEjGKUlZJ9LGzPA/iayDA==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^4.2.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-4.4.5.tgz#fa0d0b4fdd5affbd350bfef1407c146931f99fbe"
+  integrity sha512-ZS7Y5X8mU9qRSsqwOeGKw86WWtPsRxa396kX2HyhYwADRqFHJ0cb3p2uFk6QnFF3BluUUBHTZJpPA9QuEl0tlg==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
+
+"@smithy/util-waiter@^4.2.8":
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/@smithy/util-waiter/-/util-waiter-4.5.5.tgz#5aaa182c8ce11deaecb2b72b10f7515418425c2d"
+  integrity sha512-srpGlNMPxeCQvj/C5E28wuM936CBw8aaY0edfdXeDPHUqNULGCjQHzLdWvCLI3kaAR+E9yJIaDjmq+feMl9cuQ==
+  dependencies:
+    "@smithy/core" "^3.29.0"
+    tslib "^2.6.2"
 
 "@so-ric/colorspace@^1.1.6":
   version "1.1.6"
@@ -5402,6 +6190,11 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 boxen@^6.2.1:
   version "6.2.1"
@@ -13469,7 +14262,7 @@ tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.0, tslib@^2.6.3, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.0, tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Descripción

**US-8 del roadmap del CMS "Contenidos"** (decisión #5 del diseño, ajustada por el usuario a AWS S3): el storage de assets pasa del GridFS de Mongo al **bucket privado ya aprovisionado** (`groups-meeplab-contenidos`, us-east-1, acceso público bloqueado, SSE-S3, política IAM de mínimo privilegio).

> **PR apilado sobre `feature/cms-importador` (US-6, PR #28).** Orden de merge: #25 → #26 → #27 → #28 → este.
> ⚠️ **La ACTIVACIÓN va después del corte de la US-7** (el roadmap la pone al final "para no detener el avance") — mergear este PR es inocuo: sin credenciales S3 en el `.env`, todo sigue en GridFS.

## Cambios

- **`config/parse.ts`** — files adapter condicional: con `S3_BUCKET`/`S3_ACCESS_KEY_ID`/`S3_SECRET_ACCESS_KEY` en el env usa `@parse/s3-files-adapter`; sin ellas, GridFS (default). **Dev no necesita AWS; producción cambia solo con configuración.** `directAccess: false` — S3 jamás sirve directo; la lectura sigue siendo exclusiva del endpoint gated de Recursos.
- **`scripts/migrar-archivos-s3.ts`** — migración con `--dry-run`: lee los blobs directo de GridFS (el adapter S3 ya no ve los viejos), los re-guarda vía `Parse.File` (aterrizan en S3) y actualiza el pointer de cada `Recurso`. GridFS se conserva como respaldo salvo `--borrar-gridfs`.

## Runbook de activación (post US-7)

1. Copiar las variables de `~/.parse-contenidos-s3.env` al `.env` del servidor (incluye `S3_BUCKET=groups-meeplab-contenidos`).
2. Reiniciar el API (log esperado: `Files adapter: S3 (groups-meeplab-contenidos)`).
3. `./node_modules/.bin/tsx scripts/migrar-archivos-s3.ts --dry-run` → revisar el listado.
4. Sin `--dry-run` para migrar; validar recursos en el visor; después `--borrar-gridfs` si se desea limpiar.

## Checklist

- [x] `tsc --noEmit` y build del api pasan
- [x] Adapter instanciable verificado con las opciones usadas
- [x] Mergearlo NO cambia comportamiento (activación por env)
- [ ] Activación y migración en servidor (post US-7)