### PR TITLE
feat(contenidos): flujo de autoría de contenido (preview local + importador de markdown)

### DIFF
--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -1,0 +1,186 @@
+# Generación de contenido (CMS "Contenidos")
+
+Guía para escribir tutoriales/documentación con **agentes de IA** (Claude Code) o a
+mano, revisarlos localmente y subirlos al CMS. Reemplaza el flujo que dábamos con
+Docusaurus ("escribir archivos → probar → desplegar"), pero ahora la **fuente de
+verdad es la base de datos**, no archivos en el repo.
+
+> TL;DR del loop:
+> **1)** escribe `.md` en una carpeta → **2)** `preview-contenido.ts` lo renderiza en
+> el navegador (sin servidor) → **3)** `importar-markdown.ts` lo sube como **BORRADOR**
+> → **4)** lo revisas en el admin y lo **publicas**.
+
+---
+
+## Modelo mental
+
+El contenido vive en Parse (MongoDB), no en el filesystem:
+
+- **Colección** (`Coleccion`) — un "sitio de docs" por materia (p. ej. `tc2005b`,
+  `tc2007b`). Ya existen; **este flujo agrega páginas a una colección existente**, no
+  crea colecciones (eso se hace desde el admin o con `importar-docusaurus.ts`).
+- **Documento** — una página (`tipo: 'md'` o `'html'`) o una **categoría**
+  (`tipo: 'categoria'`, agrupa páginas), identificada por su `slug` dentro de su padre.
+- **DocumentoVersion** — el cuerpo. Cada página tiene una **versión publicada**
+  (`version`) y/o un **borrador** en curso (`borrador`). Publicar congela el borrador
+  como nueva versión inmutable.
+- **Recurso** — un archivo (imagen, PDF…) ligado a un documento; se sirve por un
+  endpoint con permisos (`/api/contenidos/recursos/`), nunca directo desde S3.
+
+**Draft-first:** el importador sube todo como **borrador** por defecto. Un borrador
+**no es visible para los alumnos** hasta que lo publicas. Así puedes revisar sin riesgo.
+
+---
+
+## Requisitos
+
+- **API corriendo** (los scripts hablan con Parse):
+  ```bash
+  cd packages/api
+  yarn dev            # o: ./node_modules/.bin/tsx src/index.ts
+  ```
+- ⚠️ **El entorno de desarrollo comparte la BD de PRODUCCIÓN** (Atlas). Todo lo que el
+  importador escribe cae en la base real. Por eso: **usa siempre `--dry-run` primero**,
+  y deja el contenido como **borrador** hasta validarlo.
+
+---
+
+## Paso 1 — Escribir los `.md`
+
+Crea una carpeta (fuera del repo o en un scratch; no necesita vivir en el árbol del
+proyecto). Estructura:
+
+```
+mi-tutorial/
+  _category_.json          (opcional: { "label": "Mi Módulo", "position": 3 })
+  00-intro.md
+  01-instalacion.md
+  temas-avanzados/         (subcarpeta = categoría anidada)
+    _category_.json
+    caching.md
+  imagenes/                (carpeta SIN .md = solo assets; NO se vuelve categoría)
+    diagrama.png
+```
+
+Reglas de la estructura:
+
+- **Subcarpeta con `.md` → categoría.** El nombre (o `_category_.json.label`) es su título.
+- **Subcarpeta sin ningún `.md` → assets.** Ahí guardas imágenes; el importador no la
+  convierte en categoría, solo resuelve las imágenes que referencies.
+- **Prefijos numéricos** (`00-`, `01-`) ordenan y se quitan del slug/título
+  (`00-intro.md` → slug `intro`).
+- **Frontmatter** opcional por archivo:
+  ```yaml
+  ---
+  title: Título visible de la página
+  slug: mi-slug-estable          # recomendado: fija el slug (la idempotencia se basa en él)
+  sidebar_position: 2            # orden dentro de su categoría
+  ---
+  ```
+  Sin `title`, se usa el primer `# H1`. Sin `slug`, se deriva del nombre del archivo.
+
+### Markdown soportado
+
+El pipeline (`@tc2005b/contenido-pipeline`) es el **mismo** que renderiza el visor en
+producción. Soporta:
+
+- **GFM**: tablas, listas de tareas, tachado, autolinks.
+- **Admonitions** estilo Docusaurus (directivas `:::`):
+  ```markdown
+  :::tip Título opcional
+  Contenido del aviso.
+  :::
+  ```
+  Tipos: `note`, `tip`, `info`, `warning`, `danger`, `caution`.
+- **Bloques de código** con resaltado (```` ```js ````, etc.).
+- **Imágenes relativas**: `![alt](imagenes/diagrama.png)`. El importador las **sube como
+  Recurso** y reescribe el enlace a `recurso:<id>/<archivo>` automáticamente.
+- **Enlaces internos** entre páginas del CMS: usa rutas absolutas del visor,
+  `[ver](/contenidos/tc2005b/backend/node/instalacion)`.
+
+⚠️ **HTML crudo se sanea**: `<script>`, `<iframe>`, estilos inline y handlers se
+eliminan (allowlist de `rehype-sanitize`). No metas HTML arbitrario esperando que pase.
+
+---
+
+## Paso 2 — Previsualizar localmente (sin servidor ni BD)
+
+```bash
+cd packages/api
+./node_modules/.bin/tsx scripts/preview-contenido.ts <archivo.md | carpeta>
+```
+
+Renderiza con el pipeline real + los estilos del visor y abre un HTML autocontenido en
+el navegador. Útil para iterar rápido con el agente antes de tocar la BD.
+
+- `--no-open` genera el HTML sin abrir el navegador (imprime la ruta).
+- Las imágenes por referencia `recurso:` **no** cargan en el preview local (aún no
+  existen en el CMS); es esperado. Lo demás (texto, admonitions, tablas, código) se ve
+  igual que en producción.
+
+---
+
+## Paso 3 — Importar como borrador
+
+**Siempre en seco primero:**
+
+```bash
+cd packages/api
+./node_modules/.bin/tsx scripts/importar-markdown.ts \
+    --coleccion tc2005b --dry-run mi-tutorial/
+```
+
+Reporta qué páginas **crearía** vs **actualizaría** y cuántas imágenes subiría, sin
+escribir nada. Cuando el reporte se vea bien, quita `--dry-run`:
+
+```bash
+./node_modules/.bin/tsx scripts/importar-markdown.ts \
+    --coleccion tc2005b mi-tutorial/
+```
+
+Opciones:
+
+| Flag | Efecto |
+|------|--------|
+| `--coleccion <slug>` | **Requerido.** Colección destino (debe existir): `tc2005b`, `tc2007b`. |
+| `--padre <slug/slug/...>` | Cuelga el contenido bajo una **categoría existente** (p. ej. `backend/node`) en vez de la raíz. |
+| `--dry-run` | No escribe; solo reporta. |
+| `--publish` | Publica directo además de subir (salta la revisión). Úsalo solo si ya validaste con preview + dry-run. |
+
+**Idempotencia:** la identidad de una página es `(colección, categoría padre, slug)`.
+Re-ejecutar el importador tras editar los `.md` **actualiza el borrador** de cada página
+—no duplica— y **reutiliza** el Recurso de cada imagen (no deja huérfanos). Por eso
+conviene **fijar `slug:` en el frontmatter**: si renombras el archivo sin `slug`, el
+importador lo verá como página nueva.
+
+---
+
+## Paso 4 — Revisar y publicar
+
+1. Entra al admin: **`/admin/contenidos`** → abre la colección → verás la página con su
+   borrador (`admin/contenidos/:id/editar/:docId`).
+2. Revisa el render y el contenido. Si algo no cuadra, corrige los `.md` y re-importa
+   (paso 3); el borrador se actualiza.
+3. **Publica** desde el admin (o corre el import con `--publish`). Recién publicado, el
+   contenido es visible para los alumnos con acceso a esa materia en
+   `/contenidos/<slug>/...`.
+
+---
+
+## Receta para un agente (resumen accionable)
+
+> Objetivo: agregar un tutorial a la colección `<coleccion>`.
+>
+> 1. Asegúrate de que el API corre (`cd packages/api && yarn dev`).
+> 2. Escribe los `.md` en una carpeta temporal, con frontmatter `title` + `slug`
+>    estables, admonitions `:::`, imágenes relativas en una subcarpeta `imagenes/`.
+> 3. `./node_modules/.bin/tsx scripts/preview-contenido.ts <carpeta>` y revisa el HTML.
+> 4. `./node_modules/.bin/tsx scripts/importar-markdown.ts --coleccion <coleccion> --dry-run <carpeta>`;
+>    verifica el reporte (crea/actualiza esperados, 0 "sin resolver").
+> 5. Repite sin `--dry-run` para subir como **borrador**.
+> 6. **NO publiques automáticamente.** Avisa al humano para que revise en `/admin/contenidos`
+>    y publique. (La BD de dev es la de producción — no dejes basura ni publiques sin visto bueno.)
+
+Scripts: [`packages/api/scripts/preview-contenido.ts`](./packages/api/scripts/preview-contenido.ts),
+[`packages/api/scripts/importar-markdown.ts`](./packages/api/scripts/importar-markdown.ts).
+Migración masiva desde un Docusaurus completo: [`importar-docusaurus.ts`](./packages/api/scripts/importar-docusaurus.ts).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" — flujo de autoría de contenido**: par de scripts para
+  escribir y probar contenido antes de publicar, recuperando lo que daba
+  Docusaurus pero contra la BD. `preview-contenido.ts` renderiza `.md` con el
+  pipeline real y los estilos del visor a un HTML autocontenido (sin servidor
+  ni BD); `importar-markdown.ts` sube una carpeta de `.md` a una colección
+  existente como **borrador** (o `--publish`), idempotente por
+  `(colección, padre, slug)`, con `--padre`, `--dry-run` y subida de imágenes
+  relativas como Recurso. Documentado en `AUTHORING.md` y `CLAUDE.md`.
 - **CMS "Contenidos" (US-8)**: storage en AWS S3 — el files adapter cambia a
   `@parse/s3-files-adapter` cuando el `.env` trae credenciales (bucket
   privado `groups-meeplab-contenidos`; `directAccess` desactivado: S3 jamás

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,17 @@ Legacy static HTML content (ejercicios, laboratorios, lecturas, documentos) live
 - **Data pattern:** Each lab/avance is a separate TS file with typed `export default`. Barrel exports use dynamic imports for code splitting.
 - **Links:** Internal links use React Router paths (`/labs/lab1`, `/avances/av1`). External links use full URLs.
 
+## Generación de contenido (CMS "Contenidos")
+
+La documentación por materia vive en la **BD** (colecciones/documentos/versiones/recursos en Parse), **no en archivos del repo**. Para escribir tutoriales con agentes de IA o a mano y subirlos, sigue el flujo documentado en [`AUTHORING.md`](./AUTHORING.md). Loop corto:
+
+1. Escribe `.md` en una carpeta (frontmatter `title`/`slug` estables, admonitions `:::note/tip/...`, imágenes relativas). El pipeline es `@tc2005b/contenido-pipeline` (mismo que el visor).
+2. **Previsualiza** sin servidor: `cd packages/api && ./node_modules/.bin/tsx scripts/preview-contenido.ts <carpeta>`.
+3. **Importa como BORRADOR** (idempotente por `slug`): `./node_modules/.bin/tsx scripts/importar-markdown.ts --coleccion <slug> [--padre <ruta>] [--dry-run] <carpeta>`. Requiere el API corriendo.
+4. Revisa en `/admin/contenidos` y **publica** ahí (o `--publish`).
+
+⚠️ **Dev comparte la BD de PRODUCCIÓN.** Corre `--dry-run` primero, deja todo como borrador y **no publiques sin visto bueno humano**. No crear colecciones por este flujo (solo agrega a `tc2005b`/`tc2007b` existentes).
+
 ## Development workflow
 
 Full rules in [`CONTRIBUTING.md`](./CONTRIBUTING.md). Key points (mandatory):

--- a/packages/api/scripts/importar-markdown.ts
+++ b/packages/api/scripts/importar-markdown.ts
@@ -1,0 +1,300 @@
+/**
+ * Importa una carpeta de Markdown a una colección del CMS "Contenidos".
+ *
+ * Pensado para el flujo de autoría con agentes de IA: el agente escribe los
+ * `.md`, se revisan con `preview-contenido.ts`, y este script los sube como
+ * BORRADOR (o publicados con --publish). Es IDEMPOTENTE: re-ejecutarlo tras
+ * editar los archivos actualiza el borrador de cada página (no duplica).
+ *
+ * Requiere el API corriendo (como el resto de los scripts).
+ *
+ * Uso:
+ *   cd packages/api
+ *   ./node_modules/.bin/tsx scripts/importar-markdown.ts \
+ *       --coleccion <slug> [--padre <slug/slug/...>] [--publish] [--dry-run] <carpeta>
+ *
+ * Estructura de la carpeta:
+ *   subcarpetas  → categorías (agrupan páginas); `_category_.json` opcional
+ *                  ({ "label": "...", "position": N }) da nombre/orden.
+ *   archivos .md → páginas. Frontmatter opcional: title, slug, sidebar_position.
+ *   imágenes relativas junto al .md → se suben como Recurso y se referencian.
+ */
+import fs from 'fs';
+import path from 'path';
+import Parse from 'parse/node';
+import { renderMarkdown, extraerToc } from '@tc2005b/contenido-pipeline';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+import { Coleccion } from '../src/models/Coleccion.js';
+import { Documento } from '../src/models/Documento.js';
+import { DocumentoVersion } from '../src/models/DocumentoVersion.js';
+import { Recurso } from '../src/models/Recurso.js';
+
+/* ── CLI ── */
+function arg(nombre: string): string | undefined {
+  const i = process.argv.indexOf(`--${nombre}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+const dryRun = process.argv.includes('--dry-run');
+const publicar = process.argv.includes('--publish');
+const coleccionSlug = arg('coleccion');
+const padreRuta = arg('padre'); // slug/slug/... de una categoría existente
+const carpeta = process.argv.slice(2).find(
+  (a, i, arr) => !a.startsWith('--') && arr[i - 1] !== '--coleccion' && arr[i - 1] !== '--padre',
+);
+
+if (!coleccionSlug || !carpeta) {
+  console.error('Uso: importar-markdown.ts --coleccion <slug> [--padre <ruta>] [--publish] [--dry-run] <carpeta>');
+  process.exit(1);
+}
+
+const EXT_IMG = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'svg']);
+const MIME: Record<string, string> = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+  webp: 'image/webp', avif: 'image/avif', svg: 'image/svg+xml',
+};
+
+function slugify(t: string): string {
+  return t.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+function segmento(nombre: string): string {
+  return nombre.replace(/^[\d.]+[-_]/, '');
+}
+function parseFrontmatter(src: string): { cuerpo: string; sidebarPosition?: number; title?: string; slug?: string } {
+  const m = src.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) return { cuerpo: src };
+  const b = m[1];
+  const pos = b.match(/^sidebar_position:\s*([\d.]+)\s*$/m);
+  const tit = b.match(/^title:\s*['"]?(.+?)['"]?\s*$/m);
+  const slg = b.match(/^slug:\s*['"]?([a-z0-9-]+)['"]?\s*$/m);
+  return { cuerpo: src.slice(m[0].length), sidebarPosition: pos ? Number(pos[1]) : undefined, title: tit?.[1], slug: slg?.[1] };
+}
+function tituloH1(cuerpo: string, fallback: string): string {
+  return cuerpo.match(/^#\s+(.+)$/m)?.[1].trim() ?? fallback;
+}
+/** ¿La carpeta contiene algún .md/.mdx (recursivo)? Si no, es solo de assets. */
+function tieneMarkdown(dir: string): boolean {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name.startsWith('.')) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) { if (tieneMarkdown(full)) return true; }
+    else if (/\.mdx?$/.test(e.name)) return true;
+  }
+  return false;
+}
+
+const reporte = { categorias: 0, paginasNuevas: 0, paginasActualizadas: 0, recursos: 0, publicadas: 0, sinResolver: [] as string[] };
+
+/* ── Subida de imágenes relativas → Recurso (idempotente por ruta absoluta) ── */
+const recursosSubidos = new Map<string, string>();
+async function subirImagen(abs: string, coleccion: Coleccion, documento: Documento): Promise<string | null> {
+  if (recursosSubidos.has(abs)) return recursosSubidos.get(abs)!;
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) return null;
+  const nombre = slugify(path.basename(abs).replace(/\.[^.]+$/, '')).slice(0, 80) + path.extname(abs).toLowerCase();
+  const mime = MIME[path.extname(abs).slice(1).toLowerCase()] ?? 'application/octet-stream';
+  if (dryRun) { const r = `recurso:DRY/${nombre}`; recursosSubidos.set(abs, r); return r; }
+  const buffer = fs.readFileSync(abs);
+  const file = new Parse.File(nombre, { base64: buffer.toString('base64') }, mime);
+  await file.save({ useMasterKey: true });
+  // Reusar el Recurso existente de este documento con el mismo nombre (idempotencia:
+  // re-importar tras editar no debe dejar Recursos huérfanos en la BD ni en S3).
+  const recurso = (await new Parse.Query<Recurso>('Recurso')
+    .equalTo('documento' as any, documento as any)
+    .equalTo('nombre' as any, nombre as any)
+    .first({ useMasterKey: true })) ?? new Recurso().initDefaults();
+  recurso.setColeccion(coleccion);
+  recurso.setDocumento(documento);
+  recurso.setNombre(nombre);
+  recurso.setArchivo(file);
+  recurso.setMime(mime);
+  recurso.setBytes(buffer.length);
+  await recurso.save(null, { useMasterKey: true });
+  const ref = `recurso:${recurso.id}/${nombre}`;
+  recursosSubidos.set(abs, ref);
+  return ref;
+}
+
+const RE_IMG = /(!\[[^\]]*\]\()([^)\s]+)(\))/g;
+async function reescribir(cuerpo: string, dirMd: string, coleccion: Coleccion, documento: Documento): Promise<string> {
+  const tareas: { de: string; a: string }[] = [];
+  for (const m of cuerpo.matchAll(RE_IMG)) {
+    const url = m[2];
+    if (/^(https?:|recurso:|\/)/.test(url)) continue; // externas/absolutas/ya-recurso: se dejan
+    const abs = path.resolve(dirMd, decodeURIComponent(url));
+    const ref = await subirImagen(abs, coleccion, documento);
+    if (ref) { tareas.push({ de: m[0], a: `${m[1]}${ref}${m[3]}` }); reporte.recursos += 1; }
+    else reporte.sinResolver.push(`${url} (imagen no encontrada, en ${dirMd})`);
+  }
+  let out = cuerpo;
+  for (const t of tareas) out = out.replace(t.de, t.a);
+  return out;
+}
+
+/* ── Hijos existentes de un padre en la colección (para idempotencia) ── */
+function queryDocs(coleccion: Coleccion) {
+  const q = new Parse.Query<Documento>('Documento');
+  q.equalTo('exists' as any, true as any);
+  q.equalTo('coleccion' as any, coleccion as any);
+  return q;
+}
+async function hallarPorSlug(coleccion: Coleccion, padre: Documento | null, slug: string): Promise<Documento | null> {
+  const q = queryDocs(coleccion).equalTo('slug' as any, slug as any);
+  if (padre) q.equalTo('padre' as any, padre as any); else q.doesNotExist('padre' as any);
+  q.include(['version', 'borrador'] as any);
+  return (await q.first({ useMasterKey: true })) ?? null;
+}
+async function nHermanos(coleccion: Coleccion, padre: Documento | null): Promise<number> {
+  const q = queryDocs(coleccion);
+  if (padre) q.equalTo('padre' as any, padre as any); else q.doesNotExist('padre' as any);
+  return q.count({ useMasterKey: true });
+}
+
+/** Resuelve --padre (slug/slug/...) a un Documento categoría existente. */
+async function resolverPadre(coleccion: Coleccion, ruta: string): Promise<Documento | null> {
+  let padre: Documento | null = null;
+  for (const slug of ruta.split('/').filter(Boolean)) {
+    const encontrado = await hallarPorSlug(coleccion, padre, slug);
+    if (!encontrado || encontrado.getTipo() !== 'categoria') {
+      console.error(`--padre: no existe la categoría "${slug}" en la ruta indicada.`);
+      process.exit(1);
+    }
+    padre = encontrado;
+  }
+  return padre;
+}
+
+/* ── Crea/actualiza una página (idempotente) ── */
+async function upsertPagina(
+  coleccion: Coleccion, padre: Documento | null, archivo: string, orden: number,
+): Promise<void> {
+  const src = fs.readFileSync(archivo, 'utf8');
+  const { cuerpo, sidebarPosition, title, slug: slugFm } = parseFrontmatter(src);
+  const base = path.basename(archivo).replace(/\.mdx?$/, '');
+  const slug = slugFm ?? (slugify(segmento(base)) || 'pagina');
+  const titulo = title ?? tituloH1(cuerpo, segmento(base));
+
+  let doc = await hallarPorSlug(coleccion, padre, slug);
+  const esNueva = !doc;
+  if (dryRun) {
+    console.log(`${esNueva ? 'CREARÍA' : 'ACTUALIZARÍA'} página: ${slug} ("${titulo}")`);
+    await reescribir(cuerpo, path.dirname(archivo), coleccion, doc as any); // cuenta recursos
+    esNueva ? reporte.paginasNuevas++ : reporte.paginasActualizadas++;
+    return;
+  }
+  if (!doc) {
+    doc = new Documento().initDefaults();
+    doc.setColeccion(coleccion);
+    doc.setPadre(padre);
+    doc.setTipo('md');
+    doc.setSlug(slug);
+    doc.setOrden(sidebarPosition ?? orden);
+    doc.setPublicado(false);
+    reporte.paginasNuevas++;
+  } else {
+    reporte.paginasActualizadas++;
+  }
+  doc.setTitulo(titulo);
+  if (sidebarPosition !== undefined) doc.setOrden(sidebarPosition);
+  await doc.save(null, { useMasterKey: true });
+
+  const cuerpoFinal = await reescribir(cuerpo, path.dirname(archivo), coleccion, doc);
+
+  // Guardar/actualizar el BORRADOR único de la página.
+  let borrador = doc.getBorrador();
+  if (!borrador) {
+    borrador = new DocumentoVersion().initDefaults();
+    borrador.setDocumento(doc);
+    borrador.setNumero((doc.getVersion()?.getNumero() ?? 0) + 1);
+  }
+  borrador.setCuerpo(cuerpoFinal);
+  borrador.setMensaje('importado de markdown');
+  await borrador.save(null, { useMasterKey: true });
+  if (!doc.getBorrador()) { doc.setBorrador(borrador); await doc.save(null, { useMasterKey: true }); }
+
+  if (publicar) {
+    const html = await renderMarkdown(cuerpoFinal);
+    borrador.setCuerpoHtml(html);
+    borrador.setToc(extraerToc(html));
+    borrador.setNumero((doc.getVersion()?.getNumero() ?? 0) + 1);
+    await borrador.save(null, { useMasterKey: true });
+    doc.setVersion(borrador);
+    doc.setBorrador(null);
+    doc.setPublicado(true);
+    await doc.save(null, { useMasterKey: true });
+    reporte.publicadas++;
+  }
+}
+
+/* ── Recorre la carpeta creando categorías + páginas ── */
+async function procesar(coleccion: Coleccion, dir: string, padre: Documento | null): Promise<void> {
+  const entradas = fs.readdirSync(dir, { withFileTypes: true }).filter((e) => !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  let orden = 0;
+  for (const e of entradas) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      // Carpetas sin markdown (imagenes/, assets/…) solo guardan recursos: no son categorías.
+      if (!tieneMarkdown(full)) continue;
+      let label = segmento(e.name);
+      let position: number | undefined;
+      const catJson = path.join(full, '_category_.json');
+      if (fs.existsSync(catJson)) {
+        try { const c = JSON.parse(fs.readFileSync(catJson, 'utf8')); if (c.label) label = c.label; if (typeof c.position === 'number') position = c.position; } catch { /* ignore */ }
+      }
+      const slug = slugify(segmento(e.name)) || 'cat';
+      let cat = await hallarPorSlug(coleccion, padre, slug);
+      if (dryRun) {
+        console.log(`${cat ? 'EXISTE' : 'CREARÍA'} categoría: ${slug} ("${label}")`);
+        reporte.categorias++;
+      } else if (!cat) {
+        cat = new Documento().initDefaults();
+        cat.setColeccion(coleccion); cat.setPadre(padre); cat.setTipo('categoria');
+        cat.setTitulo(label); cat.setSlug(slug); cat.setOrden(position ?? orden); cat.setPublicado(false);
+        await cat.save(null, { useMasterKey: true });
+        reporte.categorias++;
+      }
+      await procesar(coleccion, full, cat);
+    } else if (/\.mdx?$/.test(e.name)) {
+      await upsertPagina(coleccion, padre, full, orden);
+    }
+    orden += 1;
+  }
+}
+
+async function main() {
+  const abs = path.resolve(process.cwd(), carpeta!);
+  if (!fs.existsSync(abs)) { console.error(`No existe la carpeta: ${abs}`); process.exit(1); }
+
+  Parse.initialize(config.appId);
+  (Parse as any).serverURL = config.serverURL;
+  (Parse as any).masterKey = config.masterKey;
+
+  const coleccion = await new Parse.Query<Coleccion>('Coleccion')
+    .equalTo('slug' as any, coleccionSlug as any).equalTo('exists' as any, true as any)
+    .first({ useMasterKey: true });
+  if (!coleccion) { console.error(`No existe la colección "${coleccionSlug}".`); process.exit(1); }
+
+  const padre = padreRuta ? await resolverPadre(coleccion, padreRuta) : null;
+
+  if (dryRun) console.log('=== DRY RUN — no se escribe nada ===\n');
+  console.log(`Colección: ${coleccionSlug}${padreRuta ? ` · bajo /${padreRuta}` : ''} · modo: ${publicar ? 'PUBLICAR' : 'BORRADOR'}\n`);
+
+  // orden base = después de los hijos ya existentes del destino
+  const base = await nHermanos(coleccion, padre);
+  await procesar(coleccion, abs, padre);
+  void base;
+
+  console.log('\n===== REPORTE =====');
+  console.log(`Categorías:            ${reporte.categorias}`);
+  console.log(`Páginas nuevas:        ${reporte.paginasNuevas}`);
+  console.log(`Páginas actualizadas:  ${reporte.paginasActualizadas}`);
+  console.log(`Imágenes subidas:      ${reporte.recursos}`);
+  console.log(`Publicadas:            ${reporte.publicadas}`);
+  console.log(`Sin resolver:          ${reporte.sinResolver.length}`);
+  for (const x of reporte.sinResolver) console.log(`  ✗ ${x}`);
+  console.log('===================\n');
+  console.log(dryRun ? 'Dry-run terminado.' : `Listo. ${publicar ? 'Publicado.' : 'Quedó como BORRADOR — revísalo en el visor (admin) y publícalo.'}`);
+  process.exit(0);
+}
+
+main().catch((error) => { console.error('[importar-markdown] error:', error); process.exit(1); });

--- a/packages/api/scripts/preview-contenido.ts
+++ b/packages/api/scripts/preview-contenido.ts
@@ -1,0 +1,112 @@
+/**
+ * Preview local de contenido del CMS "Contenidos" — SIN servidor ni BD.
+ *
+ * Renderiza uno o más `.md` con el MISMO pipeline que usa el visor en
+ * producción (@tc2005b/contenido-pipeline) y los estilos reales
+ * (contenido-render.css), genera un HTML autocontenido y lo abre en el
+ * navegador. Recupera el "escribir y probar directo antes de desplegar" que
+ * daba Docusaurus, pero contra este CMS.
+ *
+ * Uso:
+ *   cd packages/api
+ *   ./node_modules/.bin/tsx scripts/preview-contenido.ts <archivo.md | carpeta> [--no-open]
+ *
+ * Ejemplos:
+ *   ./node_modules/.bin/tsx scripts/preview-contenido.ts ../../borradores/mi-tutorial.md
+ *   ./node_modules/.bin/tsx scripts/preview-contenido.ts ../../borradores/modulo-nuevo/
+ */
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import { execFile } from 'child_process';
+import { renderMarkdown } from '@tc2005b/contenido-pipeline';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CSS_VISOR = path.resolve(__dirname, '../../web/src/styles/contenido-render.css');
+
+// Tokens de tema claro (subconjunto de variables.css que usa contenido-render).
+const TOKENS = `:root{
+  --bg-page:#f8fafc; --bg-card:#ffffff; --text-primary:#0f172a;
+  --text-secondary:#475569; --text-muted:#94a3b8; --border-color:#e2e8f0;
+  --sidebar-active-color:#2563eb; --dash-primary:#5d87ff; --dash-success:#13deb9;
+  --dash-warning:#ffae1f; --dash-danger:#fa896b; --dash-info:#539bff;
+}
+body{margin:0;background:var(--bg-page);font-family:Inter,-apple-system,"Segoe UI",Roboto,sans-serif;}
+.pagina{max-width:820px;margin:0 auto;padding:32px 40px;background:var(--bg-card);}
+.aviso{max-width:820px;margin:0 auto;padding:8px 40px;color:var(--text-muted);font-size:12.5px;}
+.sep{max-width:820px;margin:24px auto;border:none;border-top:2px dashed var(--border-color);}`;
+
+const args = process.argv.slice(2);
+const noOpen = args.includes('--no-open');
+const target = args.find((a) => !a.startsWith('--'));
+
+if (!target) {
+  console.error('Uso: preview-contenido.ts <archivo.md | carpeta> [--no-open]');
+  process.exit(1);
+}
+
+/** Recolecta los .md/.mdx del target (archivo suelto o carpeta, recursivo). */
+function recolectar(p: string): string[] {
+  const stat = fs.statSync(p);
+  if (stat.isFile()) return /\.mdx?$/.test(p) ? [p] : [];
+  const out: string[] = [];
+  for (const e of fs.readdirSync(p, { withFileTypes: true })) {
+    if (e.name.startsWith('.')) continue;
+    const full = path.join(p, e.name);
+    if (e.isDirectory()) out.push(...recolectar(full));
+    else if (/\.mdx?$/.test(e.name)) out.push(full);
+  }
+  return out.sort();
+}
+
+/** Quita el frontmatter YAML del cuerpo (el preview no lo renderiza). */
+function sinFrontmatter(src: string): string {
+  const m = src.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  return m ? src.slice(m[0].length) : src;
+}
+
+async function main() {
+  const abs = path.resolve(process.cwd(), target!);
+  if (!fs.existsSync(abs)) {
+    console.error(`No existe: ${abs}`);
+    process.exit(1);
+  }
+
+  const archivos = recolectar(abs);
+  if (archivos.length === 0) {
+    console.error('No se encontraron archivos .md/.mdx.');
+    process.exit(1);
+  }
+
+  const css = fs.existsSync(CSS_VISOR) ? fs.readFileSync(CSS_VISOR, 'utf8') : '';
+  const secciones: string[] = [];
+  for (const f of archivos) {
+    const rel = path.relative(abs, f) || path.basename(f);
+    const html = await renderMarkdown(sinFrontmatter(fs.readFileSync(f, 'utf8')));
+    // NOTA: los recursos (recurso:/api/...) no resuelven fuera del CMS; en el
+    // preview local las imágenes por referencia recurso: no cargan (es esperado).
+    secciones.push(`<div class="aviso">📄 ${rel}</div><article class="pagina contenido-render">${html}</article>`);
+  }
+
+  const doc = `<!doctype html><html lang="es"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Preview — Contenidos</title><style>${TOKENS}\n${css}</style></head>
+<body>${secciones.join('<hr class="sep">')}</body></html>`;
+
+  const salida = path.join(os.tmpdir(), `preview-contenidos-${archivos.length}p.html`);
+  fs.writeFileSync(salida, doc);
+  console.log(`✓ ${archivos.length} página(s) renderizada(s) → ${salida}`);
+
+  if (!noOpen) {
+    const abrir = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
+    execFile(abrir, [salida], (err) => {
+      if (err) console.log(`(ábrelo manualmente: ${salida})`);
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error('[preview-contenido] error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Descripción

Recupera el flujo de trabajo que dábamos con Docusaurus —escribir contenido como archivos, probarlo localmente y desplegarlo— ahora contra el CMS "Contenidos", cuya **fuente de verdad es la base de datos**. Pensado para escribir tutoriales/documentación con agentes de IA (Claude Code) o a mano, revisarlos y subirlos como borrador antes de publicar.

Agrega dos scripts en `packages/api/scripts/` y la documentación del flujo:

- **`preview-contenido.ts`** — renderiza uno o varios `.md` con el **mismo** pipeline del visor (`@tc2005b/contenido-pipeline`) y los estilos reales, genera un HTML autocontenido y lo abre en el navegador. Sin servidor ni BD. Recupera el "probar antes de desplegar".
- **`importar-markdown.ts`** — sube una carpeta de `.md` a una colección **existente** como **borrador** (o `--publish`). Idempotente por `(colección, padre, slug)`: re-importar tras editar actualiza el borrador de cada página, no duplica, y reutiliza el Recurso de cada imagen (sin huérfanos en BD/S3). Subcarpetas con `.md` = categorías; carpetas solo-assets se ignoran como categoría; imágenes relativas se suben como Recurso y se reescriben a `recurso:`. Flags: `--coleccion`, `--padre <ruta>`, `--dry-run`, `--publish`.
- **`AUTHORING.md`** (raíz) + sección en **`CLAUDE.md`** — documentan el loop (preview → dry-run → import borrador → revisar en `/admin/contenidos` → publicar) para que humanos y agentes que tomen el proyecto sepan generar contenido de forma segura. Se recalca que dev comparte la BD de producción: `--dry-run` primero, draft-first, no publicar sin visto bueno humano.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)
- [x] `docs` — solo documentación (AUTHORING.md, CLAUDE.md, CHANGELOG.md)

## ¿Cómo se probó?

- `cd packages/api && npx tsc --noEmit` sin errores.
- **Preview:** render de una carpeta de prueba (admonitions `:::`, tabla GFM, bloque de código, imagen relativa) → el HTML contiene `admonition admonition-note`, `<table>` y `class="hljs` (resaltado). ✅
- **Import (contra la BD de dev = prod, con datos de prueba efímeros y limpieza posterior):**
  - `--dry-run` reporta correctamente crear-vs-actualizar (detecta colisión de slug con página existente) y no escribe nada.
  - Import real: crea la página como borrador (`publicado=false`), sube la imagen a S3 como Recurso y reescribe el enlace a `recurso:<id>/<archivo>`. ✅
  - **Idempotencia:** re-importar deja 0 páginas nuevas / 1 actualizada y **1 solo Recurso** por imagen (sin duplicados). ✅
  - Artefactos de prueba eliminados (documento + versión + recursos); confirmado sin rastro en la BD.
- [x] `cd packages/api && rtk tsc --noEmit` sin errores

## Checklist

- [x] La rama sigue Conventional Branch (`feat/generacion-contenido`)
- [x] Los commits siguen Conventional Commits
- [x] Actualicé `CHANGELOG.md` (Added, Unreleased)
- [x] Actualicé documentación relevante (`AUTHORING.md`, `CLAUDE.md`)
- [x] No hay commits directos a `main`; este cambio entra vía PR revisado