### PR TITLE
fix(contenidos): retoques post-Docusaurus + mejoras de autoría y lectura del CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   La documentación vive ahora en el CMS "Contenidos".
 
 ### Changed
+- **CMS "Contenidos" — retoques de nombre y enlaces tras el retiro de
+  Docusaurus**: el menú del sidebar del grupo pasa de "Docusaurus" a
+  "Contenidos"; las descripciones/enlaces de los labs que decían "Docusaurus
+  del curso" ahora apuntan a la documentación del CMS (incluye reponer un
+  enlace muerto de lab11). En la BD, los enlaces `/docs/...` de las Páginas se
+  migran al visor `/contenidos/...` (21 páginas, 22 enlaces) con un script
+  idempotente que respeta los `/docs/...` externos (MDN, Node, Tailwind…).
 - El Docusaurus se sirve ahora en `/docs/...` en lugar de `/docs/docs/...`
   (`routeBasePath: '/'`). Las páginas registradas en BD y los enlaces de los
   labs se migraron al nuevo esquema.
@@ -28,6 +35,13 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   Se removieron los workflows de GitHub Pages, `.nojekyll` y el hack SPA `?/`.
 
 ### Added
+- **CMS "Contenidos" — mejoras de autoría y lectura**: en el editor de Páginas,
+  el bloque "Práctica" incluye un selector "Seleccionar del CMS" que enlaza a una
+  página publicada (colección → página, con búsqueda) sin teclear la ruta. En el
+  visor: el árbol lateral se puede colapsar/mostrar con un botón (útil al
+  presentar con alumnos; se recuerda en `localStorage`), las barras de scroll del
+  árbol y del TOC se ocultan (el scroll sigue activo), y cada bloque de código
+  tiene un botón para copiarlo al portapapeles.
 - **CMS "Contenidos" — flujo de autoría de contenido**: par de scripts para
   escribir y probar contenido antes de publicar, recuperando lo que daba
   Docusaurus pero contra la BD. `preview-contenido.ts` renderiza `.md` con el

--- a/data-source/labs/lab1.js
+++ b/data-source/labs/lab1.js
@@ -75,6 +75,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Intro a Desarrollo Web con HTML",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab1HTML/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab1.js
+++ b/data-source/labs/lab1.js
@@ -74,7 +74,7 @@ const LAB = {
   entrega: 'Una vez que termines, registra la actividad en tu plan de aprendizaje. Guarda tu trabajo en tu computadora personal. En el laboratorio 2 se dar\u00e1n las instrucciones para la entrega de este laboratorio y de todos los siguientes.',
   practica: {
     titulo: "Pr\u00e1ctica: Intro a Desarrollo Web con HTML",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab1HTML/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab1html/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab10.js
+++ b/data-source/labs/lab10.js
@@ -39,6 +39,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Rutas y Formas",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab10RutasYFormas/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab10.js
+++ b/data-source/labs/lab10.js
@@ -38,7 +38,7 @@ const LAB = {
   entrega: 'A traves de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Rutas y Formas",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab10RutasYFormas/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab10rutasyformas/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab11.js
+++ b/data-source/labs/lab11.js
@@ -89,7 +89,7 @@ const LAB = {
         '<ul>' +
           '<li>La aplicacion debe poder responder al menos a 5 rutas diferentes, distribuidas en al menos 2 modulos, y mandar una respuesta HTTP 404 cuando la ruta no existe.</li>' +
           '<li>En alguna de las rutas, la aplicacion debe contener al menos 1 forma que debe enviar datos al servidor por POST. El servidor debe reaccionar ante este envio y guardar los datos en un archivo de texto dentro del mismo servidor.</li>' +
-          '<li>Deberas separar las rutas creadas en un archivo diferente y seguir lo visto en la practica del <a href="https://meeplab2015.github.io/tc2005b-docusaurus/docs/backend/node/tutorials/intro_web/Lab11Express/#separando-en-clases">Docusaurus.</a> La seccion que dice separando en clases.</li>' +
+          '<li>Deberas separar las rutas creadas en un archivo diferente y seguir lo visto en la practica de la <a href="/contenidos/tc2005b/backend/node/tutorials/intro-web/lab11express/readme#separando-en-clases">documentaci\u00f3n.</a> La seccion que dice separando en clases.</li>' +
         '</ul>' +
       '</li>' +
     '</ol>',
@@ -107,6 +107,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Express",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab11Express/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab11.js
+++ b/data-source/labs/lab11.js
@@ -106,7 +106,7 @@ const LAB = {
   entrega: 'A traves de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Express",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab11Express/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab11express/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab12.js
+++ b/data-source/labs/lab12.js
@@ -96,7 +96,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: EJS",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab12EJS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab12ejs/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab12.js
+++ b/data-source/labs/lab12.js
@@ -97,6 +97,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: EJS",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab12EJS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab13.js
+++ b/data-source/labs/lab13.js
@@ -86,7 +86,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: MVC",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB13MVC/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab13mvc/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab13.js
+++ b/data-source/labs/lab13.js
@@ -87,6 +87,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: MVC",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB13MVC/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab14.js
+++ b/data-source/labs/lab14.js
@@ -85,6 +85,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Sesiones",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB14Sesiones/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab14.js
+++ b/data-source/labs/lab14.js
@@ -84,7 +84,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Sesiones",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB14Sesiones/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab14sesiones/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab17.js
+++ b/data-source/labs/lab17.js
@@ -123,7 +123,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Interacci\u00f3n con Base de Datos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab17BD/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab17bd/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab17.js
+++ b/data-source/labs/lab17.js
@@ -124,6 +124,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Interacci\u00f3n con Base de Datos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab17BD/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab18.js
+++ b/data-source/labs/lab18.js
@@ -116,6 +116,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Autenticaci\u00f3n",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab18Autenticacion/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab18.js
+++ b/data-source/labs/lab18.js
@@ -115,7 +115,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Autenticaci\u00f3n",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab18Autenticacion/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab18autenticacion/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab19.js
+++ b/data-source/labs/lab19.js
@@ -42,7 +42,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de Bitbucket o GitHub (Repositorio de Equipo).',
   practica: {
     titulo: "Pr\u00e1ctica: RBAC",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab19RBAC/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab19rbac/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab19.js
+++ b/data-source/labs/lab19.js
@@ -43,6 +43,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: RBAC",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab19RBAC/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab2.js
+++ b/data-source/labs/lab2.js
@@ -32,6 +32,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Git",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab2Git/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab2.js
+++ b/data-source/labs/lab2.js
@@ -31,7 +31,7 @@ const LAB = {
   entrega: 'En tu malla de evaluaci\u00f3n individual en la secci\u00f3n correspondiente',
   practica: {
     titulo: "Pr\u00e1ctica: Git",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab2Git/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab2git/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab22.js
+++ b/data-source/labs/lab22.js
@@ -86,7 +86,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Archivos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab22Archivos/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab22archivos/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab22.js
+++ b/data-source/labs/lab22.js
@@ -87,6 +87,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Archivos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab22Archivos/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab24.js
+++ b/data-source/labs/lab24.js
@@ -87,7 +87,7 @@ const LAB = {
   entrega: 'A traves de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: AJAX",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab24AJAX/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab24ajax/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab24.js
+++ b/data-source/labs/lab24.js
@@ -88,6 +88,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: AJAX",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab24AJAX/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab3.js
+++ b/data-source/labs/lab3.js
@@ -56,7 +56,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: CSS",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab3CSS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab3css/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab3.js
+++ b/data-source/labs/lab3.js
@@ -57,6 +57,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: CSS",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab3CSS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab4.js
+++ b/data-source/labs/lab4.js
@@ -116,6 +116,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: JavaScript",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab4JS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab4.js
+++ b/data-source/labs/lab4.js
@@ -115,7 +115,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal',
   practica: {
     titulo: "Pr\u00e1ctica: JavaScript",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab4JS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab4js/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab5.js
+++ b/data-source/labs/lab5.js
@@ -327,6 +327,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Frameworks de estilo",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab5StyleFramework/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab5.js
+++ b/data-source/labs/lab5.js
@@ -326,7 +326,7 @@ const LAB = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Frameworks de estilo",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab5StyleFramework/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab5styleframework/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab6.js
+++ b/data-source/labs/lab6.js
@@ -43,7 +43,7 @@ const LAB = {
   entrega: 'A traves de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: Programaci\u00f3n Orientada a Eventos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab6POE/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab6poe/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab6.js
+++ b/data-source/labs/lab6.js
@@ -44,6 +44,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Programaci\u00f3n Orientada a Eventos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab6POE/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab7.js
+++ b/data-source/labs/lab7.js
@@ -53,6 +53,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Ramas en Git",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab7Branches/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab7.js
+++ b/data-source/labs/lab7.js
@@ -52,7 +52,7 @@ const LAB = {
   entrega: 'En el canal de discord del equipo',
   practica: {
     titulo: "Pr\u00e1ctica: Ramas en Git",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab7Branches/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab7branches/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab8.js
+++ b/data-source/labs/lab8.js
@@ -40,6 +40,6 @@ const LAB = {
   practica: {
     titulo: "Pr\u00e1ctica: Intro al Backend",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab8IntroBackend/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/data-source/labs/lab8.js
+++ b/data-source/labs/lab8.js
@@ -39,7 +39,7 @@ const LAB = {
   entrega: 'A traves de tu repositorio personal',
   practica: {
     titulo: "Pr\u00e1ctica: Intro al Backend",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab8IntroBackend/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab8introbackend/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/api/scripts/migrate-paginas-contenidos-url.ts
+++ b/packages/api/scripts/migrate-paginas-contenidos-url.ts
@@ -28,7 +28,12 @@ const MAPA: Record<string, string> = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../data/redirects-docs.json'), 'utf8'),
 );
 
-const RE_DOCS = /\/docs\/[A-Za-z0-9_\-/]+\/?(?:#[A-Za-z0-9_-]+)?/g;
+// Solo enlaces ROOT-RELATIVE: un `/docs/` que NO venga precedido por caracteres
+// de host/ruta (`\w`, `.`, `:`, `/`, `-`). Así los `/docs/...` embebidos en URLs
+// absolutas externas (p. ej. `https://host/.../docs/...` o incluso un Docusaurus
+// autoalojado que comparte nuestra estructura de rutas) se IGNORAN y no se
+// corrompen. El `.` en las clases evita truncar rutas/anclas con puntos.
+const RE_DOCS = /(?<![\w.:/-])\/docs\/[A-Za-z0-9_.\-/]+\/?(?:#[A-Za-z0-9_.-]+)?/g;
 
 interface Reporte { mapeados: number; sinResolver: Set<string>; }
 
@@ -36,10 +41,12 @@ function reescribirString(s: string, rep: Reporte): string {
   return s.replace(RE_DOCS, (full) => {
     const [rutaCruda, ancla] = full.split('#');
     const limpia = rutaCruda.replace(/\/+$/, '');
-    // 1) match directo; 2) fallback formato viejo sin `/tc2005b` (p. ej.
-    //    `/docs/backend/...`): probamos con el prefijo insertado. Ambos casos
-    //    dependen de que la clave EXISTA en el mapa, así que los `/docs/...`
-    //    externos (MDN, Node, Tailwind…) nunca colisionan y quedan intactos.
+    // 1) match directo; 2) fallback formato viejo sin `/tc2005b` (p. ej. un
+    //    link root-relative `/docs/backend/...`): probamos con el prefijo
+    //    insertado. El fallback es SEGURO solo porque RE_DOCS ya descartó los
+    //    `/docs/...` embebidos en URLs absolutas (lookbehind): sin ese guard,
+    //    una URL externa de un Docusaurus autoalojado que comparte nuestra
+    //    estructura de rutas SÍ colisionaría con el mapa y se corrompería.
     const destino = MAPA[limpia] ?? MAPA[`/docs/tc2005b${limpia.slice('/docs'.length)}`];
     if (destino) {
       rep.mapeados += 1;
@@ -75,6 +82,9 @@ async function main() {
   q.limit(10000);
   const paginas = await q.find({ useMasterKey: true });
   console.log(`Cargadas ${paginas.length} páginas.\n`);
+  if (paginas.length === 10000) {
+    console.warn('⚠️ Se alcanzó el límite de 10000; podrían faltar páginas. Reejecuta con paginación (Query.each).\n');
+  }
 
   const rep: Reporte = { mapeados: 0, sinResolver: new Set() };
   let cambiadas = 0;

--- a/packages/api/scripts/migrate-paginas-contenidos-url.ts
+++ b/packages/api/scripts/migrate-paginas-contenidos-url.ts
@@ -1,0 +1,113 @@
+/**
+ * Migración: reescribe los enlaces del Docusaurus viejo (`/docs/...`) en las
+ * Páginas del sitio (modelo `Pagina`) hacia el visor del CMS Contenidos
+ * (`/contenidos/...`), usando el mismo mapa que el middleware de redirects
+ * (`data/redirects-docs.json`).
+ *
+ * Recorre TODOS los valores string de los bloques de cada página (no solo el
+ * `enlace` de la práctica), normaliza cada `/docs/...` (quita `/` final y
+ * ancla), lo busca en el mapa y conserva la `#ancla`. Los `/docs/...` que no
+ * estén en el mapa se reportan como "sin resolver" para revisión humana.
+ *
+ * Uso:
+ *   cd packages/api && ./node_modules/.bin/tsx scripts/migrate-paginas-contenidos-url.ts --dry-run
+ *   cd packages/api && ./node_modules/.bin/tsx scripts/migrate-paginas-contenidos-url.ts
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+import { Pagina } from '../src/models/Pagina.js';
+
+const dryRun = process.argv.includes('--dry-run');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const MAPA: Record<string, string> = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../data/redirects-docs.json'), 'utf8'),
+);
+
+const RE_DOCS = /\/docs\/[A-Za-z0-9_\-/]+\/?(?:#[A-Za-z0-9_-]+)?/g;
+
+interface Reporte { mapeados: number; sinResolver: Set<string>; }
+
+function reescribirString(s: string, rep: Reporte): string {
+  return s.replace(RE_DOCS, (full) => {
+    const [rutaCruda, ancla] = full.split('#');
+    const limpia = rutaCruda.replace(/\/+$/, '');
+    // 1) match directo; 2) fallback formato viejo sin `/tc2005b` (p. ej.
+    //    `/docs/backend/...`): probamos con el prefijo insertado. Ambos casos
+    //    dependen de que la clave EXISTA en el mapa, así que los `/docs/...`
+    //    externos (MDN, Node, Tailwind…) nunca colisionan y quedan intactos.
+    const destino = MAPA[limpia] ?? MAPA[`/docs/tc2005b${limpia.slice('/docs'.length)}`];
+    if (destino) {
+      rep.mapeados += 1;
+      return ancla ? `${destino}#${ancla}` : destino;
+    }
+    rep.sinResolver.add(full);
+    return full;
+  });
+}
+
+/** Reescribe recursivamente todos los strings de un valor JSON. */
+function reescribir(valor: unknown, rep: Reporte): unknown {
+  if (typeof valor === 'string') return reescribirString(valor, rep);
+  if (Array.isArray(valor)) return valor.map((v) => reescribir(v, rep));
+  if (valor && typeof valor === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(valor)) out[k] = reescribir(v, rep);
+    return out;
+  }
+  return valor;
+}
+
+async function main() {
+  Parse.initialize(config.appId);
+  (Parse as any).serverURL = config.serverURL;
+  (Parse as any).masterKey = config.masterKey;
+
+  if (dryRun) console.log('=== DRY RUN — no se guardará nada ===\n');
+  console.log(`Parse: ${config.serverURL}\n`);
+
+  const q = new Parse.Query<Pagina>('Pagina');
+  q.equalTo('exists' as any, true as any);
+  q.limit(10000);
+  const paginas = await q.find({ useMasterKey: true });
+  console.log(`Cargadas ${paginas.length} páginas.\n`);
+
+  const rep: Reporte = { mapeados: 0, sinResolver: new Set() };
+  let cambiadas = 0;
+  let sinCambio = 0;
+
+  for (const pagina of paginas) {
+    const bloques = pagina.getBloques();
+    const antes = JSON.stringify(bloques);
+    if (!antes.includes('/docs/')) { sinCambio += 1; continue; }
+
+    const nuevos = reescribir(bloques, rep) as typeof bloques;
+    const despues = JSON.stringify(nuevos);
+    if (antes === despues) { sinCambio += 1; continue; } // solo tenía /docs/ sin mapeo
+
+    const n = (antes.match(/\/docs\//g) ?? []).length;
+    if (dryRun) {
+      console.log(`  CAMBIARÍA ${pagina.getSlug()} (${n} enlace/s /docs/)`);
+    } else {
+      pagina.setBloques(nuevos);
+      await pagina.save(null, { useMasterKey: true });
+      console.log(`  ✓ ${pagina.getSlug()} (${n} enlace/s /docs/)`);
+    }
+    cambiadas += 1;
+  }
+
+  console.log('\n===== REPORTE =====');
+  console.log(`${dryRun ? 'Se cambiarían' : 'Cambiadas'}:   ${cambiadas} páginas`);
+  console.log(`Sin cambios:     ${sinCambio}`);
+  console.log(`Enlaces mapeados:${rep.mapeados}`);
+  console.log(`Sin resolver:    ${rep.sinResolver.size}`);
+  for (const x of [...rep.sinResolver].sort()) console.log(`  ✗ ${x}`);
+  console.log('===================\n');
+  process.exit(0);
+}
+
+main().catch((error) => { console.error('Migración fallida:', error); process.exit(1); });

--- a/packages/web/src/components/contenidos/VisorContenidoPage.module.css
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.module.css
@@ -50,6 +50,26 @@
   cursor: pointer;
   font-size: 14px;
 }
+/* Botón show/hide del árbol lateral. */
+.arbolToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 4px 7px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+.arbolToggle:hover {
+  color: var(--text-primary);
+  background: var(--bg-page, rgba(0, 0, 0, 0.03));
+}
+.arbolToggle .material-icons {
+  font-size: 20px;
+}
 .panelLink {
   color: var(--text-secondary);
   text-decoration: none;
@@ -65,8 +85,16 @@
   flex: 1;
   min-height: 0;
 }
+/* Árbol colapsado: la columna del menú desaparece y el contenido se expande. */
+.cuerpo.cuerpoSinArbol {
+  grid-template-columns: minmax(0, 1fr) 190px;
+}
+.cuerpoSinArbol .arbol {
+  display: none;
+}
 @media (max-width: 1100px) {
   .cuerpo { grid-template-columns: 250px minmax(0, 1fr); }
+  .cuerpo.cuerpoSinArbol { grid-template-columns: minmax(0, 1fr); }
   .toc { display: none; }
 }
 @media (max-width: 768px) {
@@ -83,6 +111,18 @@
   position: sticky;
   top: 53px;
   height: calc(100vh - 53px);
+}
+/* Scroll sin barras visibles (estorban al presentar); el scroll sigue activo. */
+.arbol,
+.toc {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* Edge/IE */
+}
+.arbol::-webkit-scrollbar,
+.toc::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none; /* WebKit */
 }
 .arbolTitulo {
   font-size: 11px;

--- a/packages/web/src/components/contenidos/VisorContenidoPage.tsx
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
 import type { TocEntry } from '@tc2005b/contenido-pipeline';
 import { useAuth } from '../../context/AuthContext';
@@ -63,6 +63,7 @@ export default function VisorContenidoPage() {
   // Árbol lateral colapsable: útil al presentar contenido con alumnos (estorba).
   const [arbolOculto, setArbolOculto] = useState(() => localStorage.getItem(ARBOL_KEY) === '1');
   const [reintento, setReintento] = useState(0);
+  const articleRef = useRef<HTMLElement>(null);
 
   // Búsqueda (US-5): server-side, con scope por permisos.
   const [consulta, setConsulta] = useState('');
@@ -94,6 +95,41 @@ export default function VisorContenidoPage() {
       return !v;
     });
   }
+
+  // Botón "copiar" en cada bloque de código. El cuerpo se inserta como HTML
+  // (dangerouslySetInnerHTML), así que enriquecemos los <pre> tras el render;
+  // al cambiar de página React reemplaza el HTML y el efecto vuelve a correr.
+  useEffect(() => {
+    const article = articleRef.current;
+    if (!article) return;
+    // Icono Material como texto (ligadura) — sin innerHTML, sin riesgo de XSS.
+    const icono = (nombre: string) => {
+      const s = document.createElement('span');
+      s.className = 'material-icons';
+      s.textContent = nombre;
+      return s;
+    };
+    article.querySelectorAll('pre').forEach((pre) => {
+      if (pre.querySelector('.contenido-copy-btn')) return; // idempotente
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'contenido-copy-btn';
+      btn.setAttribute('aria-label', 'Copiar código');
+      btn.appendChild(icono('content_copy'));
+      btn.addEventListener('click', () => {
+        const codigo = pre.querySelector('code')?.textContent ?? '';
+        navigator.clipboard?.writeText(codigo.replace(/\n$/, '')).then(() => {
+          btn.classList.add('copiado');
+          btn.replaceChildren(icono('check'));
+          window.setTimeout(() => {
+            btn.classList.remove('copiado');
+            btn.replaceChildren(icono('content_copy'));
+          }, 1500);
+        });
+      });
+      pre.appendChild(btn);
+    });
+  }, [pagina]);
 
   /* ── Árbol de la colección (autorizado por request) ── */
   useEffect(() => {
@@ -436,7 +472,7 @@ export default function VisorContenidoPage() {
                    pipeline compartido (rehype-sanitize, allowlist) — scripts,
                    handlers e iframes se eliminan (design §3). El HTML crudo de
                    páginas tipo `html` NUNCA pasa por aquí (iframe sandbox, US-5). */
-                <article className="contenido-render" dangerouslySetInnerHTML={{ __html: pagina.cuerpoHtml }} />
+                <article ref={articleRef} className="contenido-render" dangerouslySetInnerHTML={{ __html: pagina.cuerpoHtml }} />
               )}
               <div className={styles.prevNext}>
                 {pagina.prev ? (

--- a/packages/web/src/components/contenidos/VisorContenidoPage.tsx
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.tsx
@@ -8,6 +8,7 @@ import styles from './VisorContenidoPage.module.css';
 
 const API_BASE = '/api';
 const TEMA_KEY = 'contenidos-tema';
+const ARBOL_KEY = 'contenidos-arbol-oculto';
 
 interface NodoVisor {
   id: string;
@@ -59,6 +60,8 @@ export default function VisorContenidoPage() {
   const [cargando, setCargando] = useState(true);
   const [expandidos, setExpandidos] = useState<Set<string>>(new Set());
   const [oscuro, setOscuro] = useState(() => localStorage.getItem(TEMA_KEY) === 'oscuro');
+  // Árbol lateral colapsable: útil al presentar contenido con alumnos (estorba).
+  const [arbolOculto, setArbolOculto] = useState(() => localStorage.getItem(ARBOL_KEY) === '1');
   const [reintento, setReintento] = useState(0);
 
   // Búsqueda (US-5): server-side, con scope por permisos.
@@ -81,6 +84,13 @@ export default function VisorContenidoPage() {
   function toggleTema() {
     setOscuro((v) => {
       localStorage.setItem(TEMA_KEY, v ? 'claro' : 'oscuro');
+      return !v;
+    });
+  }
+
+  function toggleArbol() {
+    setArbolOculto((v) => {
+      localStorage.setItem(ARBOL_KEY, v ? '0' : '1');
       return !v;
     });
   }
@@ -304,6 +314,16 @@ export default function VisorContenidoPage() {
   return (
     <div className={`${styles.visor} ${oscuro ? `${styles.oscuro} tema-oscuro` : ''}`}>
       <header className={styles.topbar}>
+        <button
+          type="button"
+          className={styles.arbolToggle}
+          onClick={toggleArbol}
+          title={arbolOculto ? 'Mostrar menú de contenido' : 'Ocultar menú de contenido'}
+          aria-label={arbolOculto ? 'Mostrar menú de contenido' : 'Ocultar menú de contenido'}
+          aria-pressed={!arbolOculto}
+        >
+          <span className="material-icons">{arbolOculto ? 'menu' : 'menu_open'}</span>
+        </button>
         <span className={styles.brand} title={coleccion?.nombre}>
           📘 {coleccion ? `${coleccion.clave ? `${coleccion.clave} — ` : ''}${coleccion.nombre}` : '…'}
         </span>
@@ -365,7 +385,7 @@ export default function VisorContenidoPage() {
         <Link to={rutaPanel} className={styles.panelLink}>Mi panel</Link>
       </header>
 
-      <div className={styles.cuerpo}>
+      <div className={`${styles.cuerpo} ${arbolOculto ? styles.cuerpoSinArbol : ''}`}>
         <nav className={styles.arbol}>
           <div className={styles.arbolTitulo}>Contenido</div>
           {cargando ? <p className={styles.hint}>Cargando…</p> : arbol.map((n) => renderNodo(n, '', 0))}

--- a/packages/web/src/components/contenidos/VisorContenidoPage.tsx
+++ b/packages/web/src/components/contenidos/VisorContenidoPage.tsx
@@ -116,16 +116,34 @@ export default function VisorContenidoPage() {
       btn.className = 'contenido-copy-btn';
       btn.setAttribute('aria-label', 'Copiar código');
       btn.appendChild(icono('content_copy'));
+      const confirmar = () => {
+        btn.classList.add('copiado');
+        btn.replaceChildren(icono('check'));
+        window.setTimeout(() => {
+          btn.classList.remove('copiado');
+          btn.replaceChildren(icono('content_copy'));
+        }, 1500);
+      };
       btn.addEventListener('click', () => {
-        const codigo = pre.querySelector('code')?.textContent ?? '';
-        navigator.clipboard?.writeText(codigo.replace(/\n$/, '')).then(() => {
-          btn.classList.add('copiado');
-          btn.replaceChildren(icono('check'));
-          window.setTimeout(() => {
-            btn.classList.remove('copiado');
-            btn.replaceChildren(icono('content_copy'));
-          }, 1500);
-        });
+        const codigo = (pre.querySelector('code')?.textContent ?? '').replace(/\n$/, '');
+        if (navigator.clipboard?.writeText) {
+          navigator.clipboard.writeText(codigo).then(confirmar).catch(() => {});
+        } else {
+          // Contextos no seguros (http) o sin Clipboard API: fallback clásico.
+          const ta = document.createElement('textarea');
+          ta.value = codigo;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          try {
+            document.execCommand('copy');
+            confirmar();
+          } catch {
+            /* sin portapapeles disponible */
+          }
+          document.body.removeChild(ta);
+        }
       });
       pre.appendChild(btn);
     });

--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
 }
 
-/* Cabecera "Docusaurus": mismo look que un NavItem, pero es un botón toggle. */
+/* Cabecera "Contenidos": mismo look que un NavItem, pero es un botón toggle. */
 .header {
   display: flex;
   align-items: center;
@@ -44,7 +44,7 @@
   padding: 2px 0 2px 20px;
 }
 
-/* Cada Docusaurus: enlace truncado a una sola línea con … */
+/* Cada colección: enlace truncado a una sola línea con … */
 .link {
   display: block;
   padding: 8px 12px;

--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
@@ -20,9 +20,9 @@ interface DocusMenuProps {
 }
 
 /**
- * Ítem "Docusaurus" del sidebar con submenú colapsable (colapsado por
- * defecto) que lista la documentación habilitada del grupo (Docusaurus y
- * colecciones del CMS). Abre en pestaña nueva; etiqueta a una sola línea.
+ * Ítem "Contenidos" del sidebar con submenú colapsable (colapsado por
+ * defecto) que lista las colecciones del CMS habilitadas para el grupo.
+ * Abre en pestaña nueva; etiqueta a una sola línea.
  */
 export default function DocusMenu({ items, collapsed, defaultOpen = false }: DocusMenuProps) {
   const [open, setOpen] = useState(defaultOpen);
@@ -30,7 +30,7 @@ export default function DocusMenu({ items, collapsed, defaultOpen = false }: Doc
   // Rail colapsado: solo el icono como afordancia (sin submenú expandible).
   if (collapsed) {
     return (
-      <div className={`${styles.header} ${styles.collapsed}`} title="Docusaurus">
+      <div className={`${styles.header} ${styles.collapsed}`} title="Contenidos">
         <Icon name="menu_book" size="sm" />
       </div>
     );
@@ -45,13 +45,13 @@ export default function DocusMenu({ items, collapsed, defaultOpen = false }: Doc
         aria-expanded={open}
       >
         <Icon name="menu_book" size="sm" />
-        <span className={styles.headerLabel}>Docusaurus</span>
+        <span className={styles.headerLabel}>Contenidos</span>
         <Icon name={open ? 'expand_less' : 'expand_more'} size="sm" />
       </button>
       {open && (
         <div className={styles.list}>
           {items.length === 0 ? (
-            <span className={styles.hint}>Sin Docusaurus asignados</span>
+            <span className={styles.hint}>Sin contenidos asignados</span>
           ) : (
             items.map((it) => (
               <a

--- a/packages/web/src/components/dashboard/organisms/BlockEditor/BlockEditor.module.css
+++ b/packages/web/src/components/dashboard/organisms/BlockEditor/BlockEditor.module.css
@@ -195,6 +195,42 @@
   box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.1);
 }
 
+/* Campo de enlace con botón "Seleccionar del CMS" al lado. */
+.inputWithButton {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+.inputWithButton input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.pickerBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  padding: 8px 12px;
+  border: 1px solid var(--dash-primary);
+  border-radius: 6px;
+  background: white;
+  color: var(--dash-primary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.pickerBtn:hover {
+  background: rgba(37, 99, 235, 0.06);
+}
+.pickerBtn .material-icons {
+  font-size: 16px;
+}
+.fieldHint {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
 .htmlTextarea {
   font-family: 'Courier New', Consolas, monospace;
   font-size: 12px !important;

--- a/packages/web/src/components/dashboard/organisms/BlockEditor/blocks/PracticaBlock.tsx
+++ b/packages/web/src/components/dashboard/organisms/BlockEditor/blocks/PracticaBlock.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import styles from '../BlockEditor.module.css';
+import ContenidoPicker from '../../ContenidoPicker/ContenidoPicker';
 
 interface Props {
   datos: Record<string, unknown>;
@@ -6,6 +8,8 @@ interface Props {
 }
 
 export default function PracticaBlock({ datos, onChange }: Props) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
   return (
     <div className={styles.blockFields}>
       <div className={styles.field}>
@@ -28,13 +32,28 @@ export default function PracticaBlock({ datos, onChange }: Props) {
       </div>
       <div className={styles.field}>
         <label>Enlace</label>
-        <input
-          type="text"
-          value={(datos.enlace as string) ?? ''}
-          onChange={(e) => onChange({ ...datos, enlace: e.target.value })}
-          placeholder="URL o ruta interna"
-        />
+        <div className={styles.inputWithButton}>
+          <input
+            type="text"
+            value={(datos.enlace as string) ?? ''}
+            onChange={(e) => onChange({ ...datos, enlace: e.target.value })}
+            placeholder="Selecciona del CMS o pega una URL"
+          />
+          <button type="button" className={styles.pickerBtn} onClick={() => setPickerOpen(true)}>
+            <span className="material-icons">menu_book</span>
+            Seleccionar del CMS
+          </button>
+        </div>
+        <p className={styles.fieldHint}>
+          Elige una página del CMS "Contenidos" o pega una URL externa manualmente.
+        </p>
       </div>
+
+      <ContenidoPicker
+        isOpen={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(enlace) => onChange({ ...datos, enlace })}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/organisms/ContenidoPicker/ContenidoPicker.module.css
+++ b/packages/web/src/components/dashboard/organisms/ContenidoPicker/ContenidoPicker.module.css
@@ -1,0 +1,79 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 24px 24px;
+  min-height: 320px;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.select,
+.search {
+  flex: 1 1 200px;
+  padding: 9px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 14px;
+}
+.search:disabled {
+  background: var(--bg-page);
+  color: var(--text-muted);
+}
+
+.hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13.5px;
+}
+.error {
+  margin: 0;
+  color: var(--dash-danger);
+  font-size: 13.5px;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 46vh;
+  overflow-y: auto;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+.item:hover {
+  background: var(--bg-page);
+}
+.item .material-icons {
+  font-size: 18px;
+  color: var(--sidebar-active-color);
+  flex-shrink: 0;
+}
+
+.itemLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/web/src/components/dashboard/organisms/ContenidoPicker/ContenidoPicker.tsx
+++ b/packages/web/src/components/dashboard/organisms/ContenidoPicker/ContenidoPicker.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useAuth } from '../../../../context/AuthContext';
+import Modal from '../../atoms/Modal/Modal';
+import styles from './ContenidoPicker.module.css';
+
+const API_BASE = '/api';
+
+interface Nodo {
+  id: string;
+  titulo: string;
+  slug: string;
+  tipo: string;
+  hijos: Nodo[];
+}
+interface Coleccion {
+  id: string;
+  slug: string;
+  nombre: string;
+  clave?: string | null;
+}
+interface PaginaPlana {
+  path: string;
+  label: string;
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Recibe la ruta interna del visor, p. ej. `/contenidos/tc2005b/backend/.../readme`. */
+  onSelect: (enlace: string) => void;
+}
+
+/** Aplana el árbol del visor a páginas (no categorías) con su path y breadcrumb. */
+function aplanar(arbol: Nodo[], prefijoPath = '', prefijoLabel: string[] = []): PaginaPlana[] {
+  const out: PaginaPlana[] = [];
+  for (const n of arbol) {
+    const path = prefijoPath ? `${prefijoPath}/${n.slug}` : n.slug;
+    const label = [...prefijoLabel, n.titulo];
+    if (n.tipo === 'categoria') out.push(...aplanar(n.hijos, path, label));
+    else out.push({ path, label: label.join(' / ') });
+  }
+  return out;
+}
+
+/**
+ * Selector de contenido del CMS "Contenidos" para enlazar desde las páginas
+ * del sitio (bloque Práctica). Evita teclear/investigar la ruta: el usuario
+ * elige colección → página publicada y devolvemos la ruta del visor. Reusa los
+ * endpoints existentes (`/admin/colecciones` + `/contenidos/:slug/arbol`).
+ */
+export default function ContenidoPicker({ isOpen, onClose, onSelect }: Props) {
+  const { sessionToken } = useAuth();
+  const [colecciones, setColecciones] = useState<Coleccion[]>([]);
+  const [slug, setSlug] = useState('');
+  const [paginas, setPaginas] = useState<PaginaPlana[]>([]);
+  const [q, setQ] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setError('');
+    fetch(`${API_BASE}/admin/colecciones`, { headers: { 'x-session-token': sessionToken ?? '' } })
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d) => setColecciones(d.colecciones ?? []))
+      .catch(() => setError('No se pudieron cargar las colecciones.'));
+  }, [isOpen, sessionToken]);
+
+  useEffect(() => {
+    if (!slug) {
+      setPaginas([]);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    fetch(`${API_BASE}/contenidos/${slug}/arbol`, { headers: { 'x-session-token': sessionToken ?? '' } })
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d) => setPaginas(aplanar(d.arbol ?? [])))
+      .catch(() => setError('No se pudo cargar el contenido de la colección.'))
+      .finally(() => setLoading(false));
+  }, [slug, sessionToken]);
+
+  const filtradas = useMemo(() => {
+    const t = q.trim().toLowerCase();
+    if (!t) return paginas;
+    return paginas.filter((p) => p.label.toLowerCase().includes(t) || p.path.toLowerCase().includes(t));
+  }, [paginas, q]);
+
+  const elegir = (p: PaginaPlana) => {
+    onSelect(`/contenidos/${slug}/${p.path}`);
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Seleccionar contenido del CMS" wide>
+      <div className={styles.body}>
+        <div className={styles.controls}>
+          <select
+            className={styles.select}
+            value={slug}
+            onChange={(e) => {
+              setSlug(e.target.value);
+              setQ('');
+            }}
+          >
+            <option value="">— Elige una colección —</option>
+            {colecciones.map((c) => (
+              <option key={c.id} value={c.slug}>
+                {c.clave ? `${c.clave} — ${c.nombre}` : c.nombre}
+              </option>
+            ))}
+          </select>
+          <input
+            className={styles.search}
+            type="text"
+            placeholder="Buscar página…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            disabled={!slug}
+          />
+        </div>
+
+        {error && <p className={styles.error}>{error}</p>}
+        {loading && <p className={styles.hint}>Cargando…</p>}
+        {!loading && !slug && <p className={styles.hint}>Elige una colección para ver sus páginas publicadas.</p>}
+        {!loading && slug && filtradas.length === 0 && !error && (
+          <p className={styles.hint}>No hay páginas publicadas que coincidan.</p>
+        )}
+
+        <ul className={styles.list}>
+          {filtradas.map((p) => (
+            <li key={p.path}>
+              <button
+                type="button"
+                className={styles.item}
+                onClick={() => elegir(p)}
+                title={`/contenidos/${slug}/${p.path}`}
+              >
+                <span className="material-icons">description</span>
+                <span className={styles.itemLabel}>{p.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </Modal>
+  );
+}

--- a/packages/web/src/data/labs/lab1.ts
+++ b/packages/web/src/data/labs/lab1.ts
@@ -75,7 +75,7 @@ const lab1: Lab = {
   entrega: 'Una vez que termines, registra la actividad en tu plan de aprendizaje. Guarda tu trabajo en tu computadora personal. En el laboratorio 2 se dar\u00e1n las instrucciones para la entrega de este laboratorio y de todos los siguientes.',
   practica: {
     titulo: "Pr\u00e1ctica: Intro a Desarrollo Web con HTML",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab1HTML/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab1html/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab1.ts
+++ b/packages/web/src/data/labs/lab1.ts
@@ -76,7 +76,7 @@ const lab1: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Intro a Desarrollo Web con HTML",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab1HTML/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab10.ts
+++ b/packages/web/src/data/labs/lab10.ts
@@ -40,7 +40,7 @@ const lab10: Lab = {
   entrega: 'A traves de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Rutas y Formas",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab10RutasYFormas/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab10rutasyformas/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab10.ts
+++ b/packages/web/src/data/labs/lab10.ts
@@ -41,7 +41,7 @@ const lab10: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Rutas y Formas",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab10RutasYFormas/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab11.ts
+++ b/packages/web/src/data/labs/lab11.ts
@@ -91,7 +91,7 @@ const lab11: Lab = {
         '<ul>' +
           '<li>La aplicacion debe poder responder al menos a 5 rutas diferentes, distribuidas en al menos 2 modulos, y mandar una respuesta HTTP 404 cuando la ruta no existe.</li>' +
           '<li>En alguna de las rutas, la aplicacion debe contener al menos 1 forma que debe enviar datos al servidor por POST. El servidor debe reaccionar ante este envio y guardar los datos en un archivo de texto dentro del mismo servidor.</li>' +
-          '<li>Deberas separar las rutas creadas en un archivo diferente y seguir lo visto en la practica del <a href="https://meeplab2015.github.io/tc2005b-docusaurus/docs/backend/node/tutorials/intro_web/Lab11Express/#separando-en-clases">Docusaurus.</a> La seccion que dice separando en clases.</li>' +
+          '<li>Deberas separar las rutas creadas en un archivo diferente y seguir lo visto en la practica de la <a href="/contenidos/tc2005b/backend/node/tutorials/intro-web/lab11express/readme#separando-en-clases">documentaci\u00f3n.</a> La seccion que dice separando en clases.</li>' +
         '</ul>' +
       '</li>' +
     '</ol>',
@@ -109,7 +109,7 @@ const lab11: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Express",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab11Express/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab11.ts
+++ b/packages/web/src/data/labs/lab11.ts
@@ -108,7 +108,7 @@ const lab11: Lab = {
   entrega: 'A traves de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Express",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab11Express/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab11express/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab12.ts
+++ b/packages/web/src/data/labs/lab12.ts
@@ -97,7 +97,7 @@ const lab12: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: EJS",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab12EJS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab12ejs/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab12.ts
+++ b/packages/web/src/data/labs/lab12.ts
@@ -98,7 +98,7 @@ const lab12: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: EJS",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab12EJS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab13.ts
+++ b/packages/web/src/data/labs/lab13.ts
@@ -88,7 +88,7 @@ const lab13: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: MVC",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB13MVC/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab13.ts
+++ b/packages/web/src/data/labs/lab13.ts
@@ -87,7 +87,7 @@ const lab13: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: MVC",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB13MVC/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab13mvc/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab14.ts
+++ b/packages/web/src/data/labs/lab14.ts
@@ -85,7 +85,7 @@ const lab14: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Sesiones",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB14Sesiones/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab14sesiones/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab14.ts
+++ b/packages/web/src/data/labs/lab14.ts
@@ -86,7 +86,7 @@ const lab14: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Sesiones",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/LAB14Sesiones/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab17.ts
+++ b/packages/web/src/data/labs/lab17.ts
@@ -124,7 +124,7 @@ const lab17: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Interacci\u00f3n con Base de Datos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab17BD/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab17bd/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab17.ts
+++ b/packages/web/src/data/labs/lab17.ts
@@ -125,7 +125,7 @@ const lab17: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Interacci\u00f3n con Base de Datos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab17BD/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab18.ts
+++ b/packages/web/src/data/labs/lab18.ts
@@ -116,7 +116,7 @@ const lab18: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Autenticaci\u00f3n",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab18AutenticacionSupabase/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab18autenticacionsupabase/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab18.ts
+++ b/packages/web/src/data/labs/lab18.ts
@@ -117,7 +117,7 @@ const lab18: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Autenticaci\u00f3n",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab18AutenticacionSupabase/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab19.ts
+++ b/packages/web/src/data/labs/lab19.ts
@@ -44,7 +44,7 @@ const lab19: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: RBAC",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab19RBAC/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab19.ts
+++ b/packages/web/src/data/labs/lab19.ts
@@ -43,7 +43,7 @@ const lab19: Lab = {
   entrega: 'A trav\u00e9s de Bitbucket o GitHub (Repositorio de Equipo).',
   practica: {
     titulo: "Pr\u00e1ctica: RBAC",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab19RBAC/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab19rbac/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab2.ts
+++ b/packages/web/src/data/labs/lab2.ts
@@ -32,7 +32,7 @@ const lab2: Lab = {
   entrega: 'En tu malla de evaluaci\u00f3n individual en la secci\u00f3n correspondiente',
   practica: {
     titulo: "Pr\u00e1ctica: Git",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab2Git/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab2git/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab2.ts
+++ b/packages/web/src/data/labs/lab2.ts
@@ -33,7 +33,7 @@ const lab2: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Git",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab2Git/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab22.ts
+++ b/packages/web/src/data/labs/lab22.ts
@@ -87,7 +87,7 @@ const lab22: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub).',
   practica: {
     titulo: "Pr\u00e1ctica: Archivos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab22Archivos/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab22archivos/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab22.ts
+++ b/packages/web/src/data/labs/lab22.ts
@@ -88,7 +88,7 @@ const lab22: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Archivos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab22Archivos/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab24.ts
+++ b/packages/web/src/data/labs/lab24.ts
@@ -89,7 +89,7 @@ const lab24: Lab = {
   entrega: 'A traves de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: AJAX",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab24AJAX/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab24ajax/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab24.ts
+++ b/packages/web/src/data/labs/lab24.ts
@@ -90,7 +90,7 @@ const lab24: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: AJAX",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab24AJAX/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab3.ts
+++ b/packages/web/src/data/labs/lab3.ts
@@ -58,7 +58,7 @@ const lab3: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: CSS",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab3CSS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab3.ts
+++ b/packages/web/src/data/labs/lab3.ts
@@ -57,7 +57,7 @@ const lab3: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: CSS",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab3CSS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab3css/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab4.ts
+++ b/packages/web/src/data/labs/lab4.ts
@@ -116,7 +116,7 @@ const lab4: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal',
   practica: {
     titulo: "Pr\u00e1ctica: JavaScript",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab4JS/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab4js/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab4.ts
+++ b/packages/web/src/data/labs/lab4.ts
@@ -117,7 +117,7 @@ const lab4: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: JavaScript",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab4JS/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab5.ts
+++ b/packages/web/src/data/labs/lab5.ts
@@ -328,7 +328,7 @@ const lab5: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Frameworks de estilo",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab5StyleFramework/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab5.ts
+++ b/packages/web/src/data/labs/lab5.ts
@@ -327,7 +327,7 @@ const lab5: Lab = {
   entrega: 'A trav\u00e9s de tu repositorio personal.',
   practica: {
     titulo: "Pr\u00e1ctica: Frameworks de estilo",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab5StyleFramework/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab5styleframework/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab6.ts
+++ b/packages/web/src/data/labs/lab6.ts
@@ -45,7 +45,7 @@ const lab6: Lab = {
   entrega: 'A traves de tu repositorio personal (Bitbucket o GitHub)',
   practica: {
     titulo: "Pr\u00e1ctica: Programaci\u00f3n Orientada a Eventos",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab6POE/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab6poe/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab6.ts
+++ b/packages/web/src/data/labs/lab6.ts
@@ -46,7 +46,7 @@ const lab6: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Programaci\u00f3n Orientada a Eventos",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab6POE/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab7.ts
+++ b/packages/web/src/data/labs/lab7.ts
@@ -55,7 +55,7 @@ const lab7: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Ramas en Git",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab7Branches/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/data/labs/lab7.ts
+++ b/packages/web/src/data/labs/lab7.ts
@@ -54,7 +54,7 @@ const lab7: Lab = {
   entrega: 'En el canal de discord del equipo',
   practica: {
     titulo: "Pr\u00e1ctica: Ramas en Git",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab7Branches/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab7branches/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab8.ts
+++ b/packages/web/src/data/labs/lab8.ts
@@ -41,7 +41,7 @@ const lab8: Lab = {
   entrega: 'A traves de tu repositorio personal',
   practica: {
     titulo: "Pr\u00e1ctica: Intro al Backend",
-    enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab8IntroBackend/",
+    enlace: "/contenidos/tc2005b/backend/node/tutorials/intro-web/lab8introbackend/readme",
     descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };

--- a/packages/web/src/data/labs/lab8.ts
+++ b/packages/web/src/data/labs/lab8.ts
@@ -42,7 +42,7 @@ const lab8: Lab = {
   practica: {
     titulo: "Pr\u00e1ctica: Intro al Backend",
     enlace: "/docs/tc2005b/backend/node/tutorials/intro_web/Lab8IntroBackend/",
-    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en el Docusaurus del curso"
+    descripcion: "Consulta la gu\u00eda pr\u00e1ctica completa en la documentaci\u00f3n del curso"
   }
 };
 

--- a/packages/web/src/styles/contenido-render.css
+++ b/packages/web/src/styles/contenido-render.css
@@ -65,6 +65,12 @@
 .contenido-copy-btn:focus-visible {
   opacity: 1;
 }
+/* En dispositivos táctiles (sin hover) el botón queda siempre visible. */
+@media (hover: none) {
+  .contenido-copy-btn {
+    opacity: 1;
+  }
+}
 .contenido-copy-btn:hover {
   background: rgba(255, 255, 255, 0.16);
 }

--- a/packages/web/src/styles/contenido-render.css
+++ b/packages/web/src/styles/contenido-render.css
@@ -40,6 +40,41 @@
   padding: 12px 14px;
   border-radius: 10px;
   overflow-x: auto;
+  position: relative;
+}
+/* Botón "copiar" inyectado por el visor en cada bloque de código. */
+.contenido-copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #dbe4f0;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.contenido-render pre:hover .contenido-copy-btn,
+.contenido-copy-btn:focus-visible {
+  opacity: 1;
+}
+.contenido-copy-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+.contenido-copy-btn.copiado {
+  color: #86efac;
+  border-color: rgba(134, 239, 172, 0.5);
+  opacity: 1;
+}
+.contenido-copy-btn .material-icons {
+  font-size: 17px;
 }
 .contenido-render pre code {
   background: none;


### PR DESCRIPTION
## Descripción

Conjunto de ajustes al CMS "Contenidos" tras el retiro de Docusaurus, más mejoras de UX para autoría y lectura. En orden:

1. **Sidebar admin** — el menú del grupo pasa de "Docusaurus" a "Contenidos" (era el único rótulo visible que aún nombraba Docusaurus).
2. **Referencias en labs** — 18 descripciones que decían "guía práctica completa en el Docusaurus del curso" → "en la documentación del curso"; el enlace muerto de lab11 (`meeplab2015.github.io/tc2005b-docusaurus`) se reapunta al visor. Actualizado en las dos copias (`data-source/labs` y el migrado).
3. **Migración de enlaces en BD** — script idempotente que reescribe los `/docs/...` de las Páginas al visor `/contenidos/...` usando el mapa de redirects (con fallback al formato viejo sin `/tc2005b`). Solo toca claves del mapa, así los `/docs/...` externos (MDN, Node, Tailwind, Bootstrap, Chrome) quedan intactos. **Aplicado a producción: 21 páginas, 22 enlaces.**
4. **Selector de contenido del CMS** — el bloque "Práctica" del editor de Páginas tiene un botón "Seleccionar del CMS": eliges colección → página publicada (con búsqueda y breadcrumb) y rellena el enlace con `/contenidos/<slug>/<ruta>`, sin investigar la ruta. El campo sigue editable para URLs externas. Reusa endpoints existentes; sin cambios en el backend.
5. **Visor: árbol colapsable + scrollbars ocultas** — botón show/hide del árbol lateral (útil al presentar con alumnos; estado recordado en `localStorage`) y se ocultan las barras de scroll del árbol y el TOC (el scroll sigue activo).
6. **Visor: copiar código** — cada bloque de código recibe un botón "copiar" (aparece al hover) con feedback de confirmación. Inyectado tras el render sin `innerHTML` (íconos por `textContent`) para evitar XSS.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)
- [x] `fix` — corrección (enlaces rotos, rótulos obsoletos)
- [x] `docs` — CHANGELOG

## ¿Cómo se probó?

- `cd packages/web && npx tsc --noEmit` sin errores en cada paso.
- **Migración de enlaces**: `--dry-run` + verificación de contexto de cada enlace "sin resolver" (confirmado que los 12 restantes son URLs externas precedidas por su dominio); tras aplicar, verificado en BD que lab1/lab11 apuntan a `/contenidos/...`.
- **Selector del CMS**: probado el flujo real contra la BD (login → 34 páginas aplanadas → `lab1html/readme` resuelve exactamente al enlace migrado, con breadcrumb legible).
- **Visor (árbol colapsable, scrollbars, copiar código)**: verificado por `tsc` y siguiendo los patrones del visor. No se probó en navegador automatizado porque la sesión del visor es gated y no procede teclear credenciales; **pendiente de verificación visual en una sesión autenticada**.
- [x] `cd packages/web && npx tsc --noEmit` sin errores

## Checklist

- [x] La rama sigue Conventional Branch (`fix/cms-contenidos-mejoras`)
- [x] Los commits siguen Conventional Commits
- [x] Actualicé `CHANGELOG.md` (Changed + Added, Unreleased)
- [x] Actualicé documentación relevante donde aplica
- [x] No hay commits directos a `main`; este cambio entra vía PR revisado