### PR TITLE
feat(paginas): las páginas pertenecen a una colección (materia)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,42 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Páginas por colección (materia)**: `Pagina` ahora apunta a una `Coleccion`
+  del CMS "Contenidos" (pointer `Pagina.coleccion`), de modo que cada página
+  pertenece a una materia. Al agregar una actividad al calendario, el picker de
+  páginas solo ofrece las de las colecciones asignadas al grupo
+  (`Grupo.colecciones`); si el grupo tiene varias, ofrece las de todas. Si no
+  tiene ninguna, muestra todas con un aviso en lugar de quedarse vacío.
+  - `GET /api/paginas?grupoId=` — listado público acotado a las colecciones del
+    grupo; responde `filtrado: false` cuando no pudo acotar. Sin el parámetro, el
+    comportamiento es el de siempre.
+  - `GET /api/admin/paginas?coleccionId=` — filtro para la tabla del admin
+    (`sin-coleccion` lista las que no tienen colección asignada).
+  - `scripts/migrate-paginas-coleccion.ts` — backfill idempotente de las páginas
+    existentes hacia una colección (`--coleccion <slug>`, `--dry-run`).
+  - `scripts/seed-paginas.ts` acepta `--coleccion <slug>` para no volver a crear
+    páginas huérfanas.
+
+### Changed
+- **La URL pública de las páginas no cambia** (`/paginas/:slug`) y el slug sigue
+  siendo único global: las actividades del calendario enlazan a las páginas por
+  string (`Actividad.enlace`), sin integridad referencial, y cambiar la forma de
+  la URL las habría roto en silencio.
+- Las páginas **siguen siendo públicas**: la colección organiza y filtra, no
+  restringe el acceso. El gating del CMS "Contenidos" no se extiende a `/paginas`.
+- `PaginaForm`: el campo "Grupo", que era un input de texto donde se tecleaba a
+  mano el objectId del grupo, se sustituye por un `<select>` de colecciones. El
+  admin ya no puede escribir un id inexistente: el API valida que la colección
+  exista (antes creaba el pointer a ciegas con `createWithoutData`).
+- `PaginasPage`: la columna "Alcance" (que solo derivaba de si había grupo o no)
+  se sustituye por "Colección", con filtro por colección.
+
 ### Removed
+- **`Pagina.grupo`**: el pointer a `Grupo` y la noción de "alcance Global/Grupo"
+  derivada de él. No filtraba nada en ninguna capa —toda página publicada era
+  visible para cualquiera con el slug— y ninguna de las 47 páginas en producción
+  lo tenía asignado.
 - **Docusaurus retirado (US-7)**: se elimina `packages/docusaurus`, el gate
   `/docs` por materia y el campo `Grupo.docusaurus[]`. `/docs/*` responde
   301 permanente hacia `/contenidos/*` (mapa del importador + heurística).

--- a/packages/api/scripts/migrate-paginas-coleccion.ts
+++ b/packages/api/scripts/migrate-paginas-coleccion.ts
@@ -1,0 +1,82 @@
+/**
+ * Backfill: asigna `Pagina.coleccion` a las páginas que no la tienen.
+ *
+ * Contexto: las páginas nacieron sin noción de materia (el seed las creó con
+ * `grupoId: null`). Al atar Pagina -> Coleccion, las existentes quedan huérfanas
+ * y desaparecerían del picker del calendario, que ahora filtra por las
+ * colecciones del grupo. Este script las adopta en la colección indicada.
+ *
+ * Idempotente: solo toca las páginas SIN colección. Correrlo dos veces no hace
+ * nada la segunda vez.
+ *
+ *   ./node_modules/.bin/tsx scripts/migrate-paginas-coleccion.ts --coleccion tc2005b --dry-run
+ *   ./node_modules/.bin/tsx scripts/migrate-paginas-coleccion.ts --coleccion tc2005b
+ *
+ * ⚠️ Dev comparte la BD de PRODUCCIÓN. Corre --dry-run primero.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const i = argv.indexOf('--coleccion');
+  const slug = i >= 0 ? argv[i + 1] : undefined;
+  if (!slug) {
+    console.error('Uso: migrate-paginas-coleccion.ts --coleccion <slug> [--dry-run]');
+    process.exit(1);
+  }
+  return { slug, dryRun };
+}
+
+async function main() {
+  const { slug, dryRun } = parseArgs();
+
+  const qc = new Parse.Query('Coleccion');
+  qc.equalTo('slug', slug);
+  qc.equalTo('exists', true);
+  const coleccion = await qc.first({ useMasterKey: true });
+  if (!coleccion) {
+    console.error(`✗ No existe la colección con slug "${slug}". Abortado.`);
+    process.exit(1);
+  }
+  console.log(`Colección destino: ${coleccion.get('nombre')} (${coleccion.get('clave')}) id=${coleccion.id}\n`);
+
+  const qp = new Parse.Query('Pagina');
+  qp.equalTo('exists', true);
+  qp.doesNotExist('coleccion');
+  qp.ascending('slug');
+  qp.limit(1000);
+  const huerfanas = await qp.find({ useMasterKey: true });
+
+  if (huerfanas.length === 0) {
+    console.log('✓ No hay páginas sin colección. Nada que hacer.');
+    return;
+  }
+
+  console.log(`${huerfanas.length} página(s) sin colección:`);
+  for (const p of huerfanas) {
+    console.log(`  ${dryRun ? '[dry-run]' : '[migrar] '} /paginas/${p.get('slug')}  "${p.get('titulo')}"`);
+  }
+
+  if (dryRun) {
+    console.log(`\n--dry-run: no se escribió nada. Quita la bandera para aplicar.`);
+    return;
+  }
+
+  for (const p of huerfanas) {
+    p.set('coleccion', coleccion);
+  }
+  await Parse.Object.saveAll(huerfanas, { useMasterKey: true });
+  console.log(`\n✓ ${huerfanas.length} página(s) asignadas a "${slug}".`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/scripts/seed-paginas.ts
+++ b/packages/api/scripts/seed-paginas.ts
@@ -5,6 +5,11 @@
  * Uso: cd packages/api && npx tsx scripts/seed-paginas.ts
  *      cd packages/api && npx tsx scripts/seed-paginas.ts --dry-run
  *      cd packages/api && npx tsx scripts/seed-paginas.ts --file avances-data.json
+ *      cd packages/api && npx tsx scripts/seed-paginas.ts --coleccion tc2005b
+ *
+ * Sin --coleccion las páginas nacen sin colección y NO aparecen en el picker del
+ * calendario (que filtra por las colecciones del grupo). Pásala salvo que quieras
+ * asignarlas después con migrate-paginas-coleccion.ts.
  */
 
 import { readFileSync } from 'fs';
@@ -23,6 +28,8 @@ const fileArgIndex = process.argv.indexOf('--file');
 const dataFilename = fileArgIndex !== -1 && process.argv[fileArgIndex + 1]
   ? process.argv[fileArgIndex + 1]
   : 'paginas-data.json';
+const coleccionArgIndex = process.argv.indexOf('--coleccion');
+const coleccionSlug = coleccionArgIndex !== -1 ? process.argv[coleccionArgIndex + 1] : undefined;
 
 interface ContentBlock {
   id: string;
@@ -35,7 +42,6 @@ interface PaginaInput {
   slug: string;
   descripcion?: string;
   icono: string;
-  grupoId: null;
   bloques: ContentBlock[];
   publicado: boolean;
   orden: number;
@@ -52,6 +58,21 @@ async function main() {
   }
 
   console.log(`Connecting to Parse Server at ${config.serverURL}...`);
+
+  let coleccion: Parse.Object | undefined;
+  if (coleccionSlug) {
+    const q = new Parse.Query('Coleccion');
+    q.equalTo('slug', coleccionSlug);
+    q.equalTo('exists', true);
+    coleccion = await q.first({ useMasterKey: true });
+    if (!coleccion) {
+      console.error(`✗ No existe la colección con slug "${coleccionSlug}". Abortado.`);
+      process.exit(1);
+    }
+    console.log(`Colección destino: ${coleccion.get('nombre')} (${coleccion.get('clave')})`);
+  } else {
+    console.warn('⚠ Sin --coleccion: las páginas quedarán sin colección y no saldrán en el picker del calendario.');
+  }
 
   // Read the generated JSON
   const dataPath = resolve(__dirname, dataFilename);
@@ -90,7 +111,7 @@ async function main() {
     pagina.setBloques(data.bloques);
     pagina.setPublicado(data.publicado);
     pagina.setOrden(data.orden);
-    // No grupo = global page
+    if (coleccion) pagina.setColeccion(coleccion);
 
     await pagina.save(null, { useMasterKey: true });
     console.log(`  ✓ ${data.slug}: "${data.titulo}" (${data.bloques.length} bloques) → id: ${pagina.id}`);

--- a/packages/api/src/controllers/paginas.controller.ts
+++ b/packages/api/src/controllers/paginas.controller.ts
@@ -22,15 +22,62 @@ function validateBloques(bloques: unknown): boolean {
   );
 }
 
+/**
+ * Resuelve un coleccionId a un pointer, verificando que la colección exista y
+ * no esté soft-deleted. Devuelve `null` si el id no corresponde a ninguna.
+ */
+async function resolverColeccion(coleccionId: string): Promise<Parse.Object | null> {
+  const query = new Parse.Query('Coleccion');
+  query.equalTo('exists' as any, true as any);
+  try {
+    return await query.get(coleccionId, { useMasterKey: true });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Colecciones (pointers) asignadas a un grupo. Vacío si el grupo no existe o no
+ * tiene ninguna: el llamador decide qué hacer con ese caso.
+ */
+async function coleccionesDeGrupo(grupoId: string): Promise<Parse.Object[]> {
+  const query = new Parse.Query('Grupo');
+  query.equalTo('exists' as any, true as any);
+  query.include('colecciones' as any);
+  try {
+    const grupo = await query.get(grupoId, { useMasterKey: true });
+    const colecciones = (grupo.get('colecciones') ?? []) as Parse.Object[];
+    return colecciones.filter((c) => c && c.get('exists') !== false);
+  } catch {
+    return [];
+  }
+}
+
 // ─── Admin endpoints ────────────────────────────────────────────
 
-export async function listPaginas(_req: Request, res: Response): Promise<void> {
+export async function listPaginas(req: Request, res: Response): Promise<void> {
+  const { coleccionId } = req.query;
+
   try {
     const query = new Parse.Query<Pagina>('Pagina');
     query.equalTo('exists' as any, true as any);
     query.ascending('slug');
-    query.include('grupo' as any);
+    query.include('coleccion' as any);
     query.limit(1000);
+
+    if (typeof coleccionId === 'string' && coleccionId) {
+      if (coleccionId === 'sin-coleccion') {
+        query.doesNotExist('coleccion' as any);
+      } else {
+        const coleccion = await resolverColeccion(coleccionId);
+        if (!coleccion) {
+          res.status(404).json({ status: 'error', message: 'Colección no encontrada' });
+          return;
+        }
+        query.equalTo('coleccion' as any, coleccion as any);
+      }
+    }
+
     const paginas = await query.find({ useMasterKey: true });
 
     res.json({
@@ -47,7 +94,7 @@ export async function getPagina(req: Request, res: Response): Promise<void> {
 
   try {
     const query = BaseModel.queryActive<Pagina>('Pagina');
-    query.include('grupo' as any);
+    query.include('coleccion' as any);
     const pagina = await query.get(id, { useMasterKey: true });
 
     res.json({ status: 'ok', pagina: pagina.toSafeJSON() });
@@ -61,7 +108,7 @@ export async function getPagina(req: Request, res: Response): Promise<void> {
 }
 
 export async function createPagina(req: Request, res: Response): Promise<void> {
-  const { titulo, slug, descripcion, icono, grupoId, bloques, publicado, orden, etiquetas } = req.body;
+  const { titulo, slug, descripcion, icono, coleccionId, bloques, publicado, orden, etiquetas } = req.body;
 
   if (!titulo || typeof titulo !== 'string' || titulo.trim() === '') {
     res.status(400).json({ status: 'error', message: 'El título es requerido' });
@@ -88,9 +135,13 @@ export async function createPagina(req: Request, res: Response): Promise<void> {
     pagina.setSlug(slug);
     if (descripcion) pagina.setDescripcion(descripcion.trim());
     if (icono) pagina.setIcono(icono.trim());
-    if (grupoId) {
-      const grupoPointer = Parse.Object.extend('Grupo').createWithoutData(grupoId);
-      pagina.setGrupo(grupoPointer);
+    if (coleccionId) {
+      const coleccion = await resolverColeccion(coleccionId);
+      if (!coleccion) {
+        res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+        return;
+      }
+      pagina.setColeccion(coleccion);
     }
     if (bloques && validateBloques(bloques)) {
       pagina.setBloques(bloques);
@@ -113,10 +164,13 @@ export async function createPagina(req: Request, res: Response): Promise<void> {
 
 export async function updatePagina(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { titulo, slug, descripcion, icono, grupoId, bloques, publicado, orden, etiquetas } = req.body;
+  const { titulo, slug, descripcion, icono, coleccionId, bloques, publicado, orden, etiquetas } = req.body;
 
   try {
     const query = BaseModel.queryActive<Pagina>('Pagina');
+    // include: sin esto, una página que no cambia de colección devolvería el
+    // pointer sin datos y `toSafeJSON()` la expondría con nombre/slug en null.
+    query.include('coleccion' as any);
     const pagina = await query.get(id, { useMasterKey: true });
 
     if (titulo !== undefined) {
@@ -150,12 +204,16 @@ export async function updatePagina(req: Request, res: Response): Promise<void> {
     if (descripcion !== undefined) pagina.setDescripcion((descripcion ?? '').trim());
     if (icono !== undefined) pagina.setIcono((icono ?? 'article').trim());
 
-    if (grupoId !== undefined) {
-      if (grupoId === null || grupoId === '') {
-        pagina.unset('grupo');
+    if (coleccionId !== undefined) {
+      if (coleccionId === null || coleccionId === '') {
+        pagina.unset('coleccion');
       } else {
-        const grupoPointer = Parse.Object.extend('Grupo').createWithoutData(grupoId);
-        pagina.setGrupo(grupoPointer);
+        const coleccion = await resolverColeccion(coleccionId);
+        if (!coleccion) {
+          res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+          return;
+        }
+        pagina.setColeccion(coleccion);
       }
     }
 
@@ -218,6 +276,9 @@ export async function getPaginaPublica(req: Request, res: Response): Promise<voi
     const query = BaseModel.queryActive<Pagina>('Pagina');
     query.equalTo('slug' as any, slug as any);
     query.equalTo('publicado' as any, true as any);
+    // Sin include, el pointer llega sin datos y `toSafeJSON()` expondría la
+    // colección con nombre/slug/clave en null.
+    query.include('coleccion' as any);
     const pagina = await query.first({ useMasterKey: true });
 
     if (!pagina) {
@@ -231,16 +292,40 @@ export async function getPaginaPublica(req: Request, res: Response): Promise<voi
   }
 }
 
-export async function listPaginasPublicas(_req: Request, res: Response): Promise<void> {
+/**
+ * Listado público de páginas publicadas.
+ *
+ * Con `?grupoId=`, acota a las páginas de las colecciones asignadas a ese grupo
+ * (`Grupo.colecciones`) — es lo que consume el picker del calendario, para que
+ * al armar una actividad solo se ofrezcan páginas de la materia del grupo. Si el
+ * grupo no tiene colecciones asignadas, se devuelven **todas** y se avisa con
+ * `filtrado: false`, para no dejar el picker vacío sin explicación.
+ *
+ * Sin `grupoId` el comportamiento es el de siempre: todas las publicadas.
+ */
+export async function listPaginasPublicas(req: Request, res: Response): Promise<void> {
+  const { grupoId } = req.query;
+
   try {
     const query = BaseModel.queryActive<Pagina>('Pagina');
     query.equalTo('publicado' as any, true as any);
     query.ascending('orden');
     query.select('titulo' as any, 'slug' as any);
+
+    let filtrado = false;
+    if (typeof grupoId === 'string' && grupoId) {
+      const colecciones = await coleccionesDeGrupo(grupoId);
+      if (colecciones.length > 0) {
+        query.containedIn('coleccion' as any, colecciones as any);
+        filtrado = true;
+      }
+    }
+
     const paginas = await query.find({ useMasterKey: true });
 
     res.json({
       status: 'ok',
+      filtrado,
       paginas: paginas.map((p) => ({
         id: p.id,
         slug: p.getSlug(),

--- a/packages/api/src/models/Pagina.ts
+++ b/packages/api/src/models/Pagina.ts
@@ -40,11 +40,18 @@ export class Pagina extends BaseModel {
     this.set('icono', icono);
   }
 
-  getGrupo(): Parse.Object | undefined {
-    return this.get('grupo');
+  /**
+   * Colección del CMS "Contenidos" a la que pertenece la página (pointer, nunca
+   * string). Determina de qué materia es la página: el picker del calendario
+   * solo ofrece las páginas de las colecciones asignadas al grupo
+   * (`Grupo.colecciones`). No restringe el acceso — `/paginas/:slug` sigue
+   * siendo público.
+   */
+  getColeccion(): Parse.Object | undefined {
+    return this.get('coleccion');
   }
-  setGrupo(grupo: Parse.Object): void {
-    this.set('grupo', grupo);
+  setColeccion(coleccion: Parse.Object): void {
+    this.set('coleccion', coleccion);
   }
 
   getBloques(): ContentBlock[] {
@@ -76,13 +83,25 @@ export class Pagina extends BaseModel {
   }
 
   toSafeJSON(): Record<string, unknown> {
+    const coleccion = this.getColeccion();
+    // Si la colección (incluida) fue soft-deleted, no la exponemos.
+    const coleccionActiva = coleccion && coleccion.get('exists') !== false ? coleccion : null;
     return {
       id: this.id,
       titulo: this.getTitulo(),
       slug: this.getSlug(),
       descripcion: this.getDescripcion(),
       icono: this.getIcono(),
-      grupoId: this.getGrupo()?.id ?? null,
+      coleccionId: coleccionActiva?.id ?? null,
+      // Requiere query.include('coleccion') para traer nombre/slug/clave.
+      coleccion: coleccionActiva
+        ? {
+            id: coleccionActiva.id,
+            nombre: coleccionActiva.get('nombre') ?? null,
+            slug: coleccionActiva.get('slug') ?? null,
+            clave: coleccionActiva.get('clave') ?? null,
+          }
+        : null,
       bloques: this.getBloques(),
       publicado: this.getPublicado(),
       orden: this.getOrden(),

--- a/packages/web/scripts/generate-paginas-json.ts
+++ b/packages/web/scripts/generate-paginas-json.ts
@@ -53,7 +53,6 @@ interface PaginaExport {
   slug: string;
   descripcion?: string;
   icono: string;
-  grupoId: null;
   bloques: ContentBlock[];
   publicado: boolean;
   orden: number;
@@ -152,7 +151,6 @@ function labToPagina(lab: Lab, orden: number): PaginaExport {
     slug: lab.id,
     descripcion: lab.descripcion,
     icono: 'science',
-    grupoId: null,
     bloques,
     publicado: true,
     orden,

--- a/packages/web/src/components/calendar/ActivityForm.module.css
+++ b/packages/web/src/components/calendar/ActivityForm.module.css
@@ -268,6 +268,15 @@
   font-size: 0.8125rem;
 }
 
+.pickerNotice {
+  padding: 8px 12px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  border-bottom: 1px solid var(--border-color, #e5e7eb);
+}
+
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/web/src/components/calendar/ActivityForm.tsx
+++ b/packages/web/src/components/calendar/ActivityForm.tsx
@@ -51,9 +51,15 @@ interface ActivityFormProps {
   loading?: boolean;
   initialData?: Partial<ActivityFormData>;
   mode?: 'create' | 'edit';
+  /**
+   * Grupo del calendario que se está editando. Acota el picker de páginas a las
+   * colecciones asignadas a ese grupo (su materia). Sin él, el picker ofrece
+   * todas las páginas publicadas del sitio.
+   */
+  grupoId?: string;
 }
 
-export default function ActivityForm({ onSave, onCancel, loading, initialData, mode = 'create' }: ActivityFormProps) {
+export default function ActivityForm({ onSave, onCancel, loading, initialData, mode = 'create', grupoId }: ActivityFormProps) {
   const [tipo, setTipo] = useState<ActividadTipo>(initialData?.tipo ?? 'lab');
   const [titulo, setTitulo] = useState(initialData?.titulo ?? '');
   const [descripcion, setDescripcion] = useState(initialData?.descripcion ?? '');
@@ -67,6 +73,9 @@ export default function ActivityForm({ onSave, onCancel, loading, initialData, m
   const [showPicker, setShowPicker] = useState(false);
   const [pickerFilter, setPickerFilter] = useState('');
   const [paginasLoaded, setPaginasLoaded] = useState(false);
+  // false = el grupo no tiene colecciones asignadas y el API devolvió todas las
+  // páginas del sitio en vez de dejar el picker vacío.
+  const [paginasFiltradas, setPaginasFiltradas] = useState(true);
   const pickerRef = useRef<HTMLDivElement>(null);
 
   // Document picker state
@@ -125,10 +134,14 @@ export default function ActivityForm({ onSave, onCancel, loading, initialData, m
       return;
     }
     try {
-      const res = await fetch(`${API_BASE}/paginas`);
+      const url = grupoId
+        ? `${API_BASE}/paginas?grupoId=${encodeURIComponent(grupoId)}`
+        : `${API_BASE}/paginas`;
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setPaginas(data.paginas ?? []);
+        setPaginasFiltradas(data.filtrado !== false);
         setPaginasLoaded(true);
       }
     } catch {
@@ -402,9 +415,21 @@ export default function ActivityForm({ onSave, onCancel, loading, initialData, m
                 placeholder="Buscar página..."
                 autoFocus
               />
+              {/* Solo si pedimos acotar y el API no pudo: sin grupoId el API
+                  responde filtrado:false sin que eso sea una anomalía. */}
+              {grupoId && !paginasFiltradas && (
+                <div className={styles.pickerNotice}>
+                  Este grupo no tiene colecciones asignadas: se muestran todas las
+                  páginas del sitio.
+                </div>
+              )}
               {filteredPaginas.length === 0 ? (
                 <div className={styles.pickerEmpty}>
-                  {paginas.length === 0 ? 'No hay páginas publicadas' : 'Sin resultados'}
+                  {paginas.length > 0
+                    ? 'Sin resultados'
+                    : paginasFiltradas
+                      ? 'No hay páginas publicadas en las colecciones de este grupo'
+                      : 'No hay páginas publicadas'}
                 </div>
               ) : (
                 <ul className={styles.pickerList}>

--- a/packages/web/src/components/calendar/CalendarContent.tsx
+++ b/packages/web/src/components/calendar/CalendarContent.tsx
@@ -593,6 +593,7 @@ export default function CalendarContent({ grupoId, stickyTop = 'var(--navbar-hei
             onSave={handleSaveActivity}
             onCancel={() => setAddModalState(null)}
             loading={isCreating}
+            grupoId={calendario?.grupoId}
           />
         </Modal>
       )}
@@ -605,6 +606,7 @@ export default function CalendarContent({ grupoId, stickyTop = 'var(--navbar-hei
             loading={isUpdating}
             initialData={editModalState.initialData}
             mode="edit"
+            grupoId={calendario?.grupoId}
           />
         </Modal>
       )}

--- a/packages/web/src/components/dashboard/organisms/PaginaForm/PaginaForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/PaginaForm/PaginaForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { PaginaData, ContentBlock, EtiquetaData } from '../../../../types/pagina';
+import type { PaginaData, ContentBlock, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
 import BlockEditor from '../BlockEditor/BlockEditor';
 import PaginaContent from '../../../paginas/PaginaContent';
 import DashButton from '../../atoms/DashButton/DashButton';
@@ -9,13 +9,14 @@ import styles from './PaginaForm.module.css';
 interface PaginaFormProps {
   pagina?: PaginaData;
   etiquetas?: EtiquetaData[];
+  colecciones?: ColeccionRef[];
   onSave: (data: Omit<PaginaData, 'id' | 'createdAt' | 'updatedAt'>) => void;
   onCancel: () => void;
   loading?: boolean;
   previewMode?: boolean;
 }
 
-export default function PaginaForm({ pagina, etiquetas: availableTags = [], onSave, onCancel, loading, previewMode }: PaginaFormProps) {
+export default function PaginaForm({ pagina, etiquetas: availableTags = [], colecciones = [], onSave, onCancel, loading, previewMode }: PaginaFormProps) {
   const [activeTab, setActiveTab] = useState<'editar' | 'preview'>(previewMode ? 'preview' : 'editar');
 
   const [titulo, setTitulo] = useState(pagina?.titulo ?? '');
@@ -23,7 +24,7 @@ export default function PaginaForm({ pagina, etiquetas: availableTags = [], onSa
   const [slugManual, setSlugManual] = useState(!!pagina?.slug);
   const [descripcion, setDescripcion] = useState(pagina?.descripcion ?? '');
   const [icono, setIcono] = useState(pagina?.icono ?? 'article');
-  const [grupoId, setGrupoId] = useState(pagina?.grupoId ?? '');
+  const [coleccionId, setColeccionId] = useState(pagina?.coleccionId ?? '');
   const [publicado, setPublicado] = useState(pagina?.publicado ?? false);
   const [bloques, setBloques] = useState<ContentBlock[]>(pagina?.bloques ?? []);
   const [selectedTags, setSelectedTags] = useState<string[]>(pagina?.etiquetas ?? []);
@@ -53,7 +54,7 @@ export default function PaginaForm({ pagina, etiquetas: availableTags = [], onSa
       slug: slug.trim(),
       descripcion: descripcion.trim() || undefined,
       icono: icono.trim() || 'article',
-      grupoId: grupoId || null,
+      coleccionId: coleccionId || null,
       bloques,
       publicado,
       etiquetas: selectedTags,
@@ -66,7 +67,7 @@ export default function PaginaForm({ pagina, etiquetas: availableTags = [], onSa
     slug,
     descripcion: descripcion || undefined,
     icono,
-    grupoId: grupoId || null,
+    coleccionId: coleccionId || null,
     bloques,
     publicado,
   };
@@ -160,15 +161,20 @@ export default function PaginaForm({ pagina, etiquetas: availableTags = [], onSa
             </div>
 
             <div className={styles.field}>
-              <label>Grupo (opcional)</label>
-              <input
-                type="text"
-                value={grupoId}
-                onChange={(e) => setGrupoId(e.target.value)}
-                placeholder="Dejar vacío = Global"
-              />
+              <label>Colección (materia)</label>
+              <select
+                value={coleccionId ?? ''}
+                onChange={(e) => setColeccionId(e.target.value)}
+              >
+                <option value="">Sin asignar</option>
+                {colecciones.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.clave ? `${c.clave} — ${c.nombre}` : c.nombre}
+                  </option>
+                ))}
+              </select>
               <span className={styles.slugPreview}>
-                ID del grupo o vacío para página global
+                Sin asignar, la página no aparece al agregar actividades al calendario
               </span>
             </div>
 

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
@@ -5,7 +5,7 @@ import AdminTable from '../../organisms/AdminTable/AdminTable';
 import Modal from '../../atoms/Modal/Modal';
 import PaginaForm from '../../organisms/PaginaForm/PaginaForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
-import type { PaginaData, EtiquetaData } from '../../../../types/pagina';
+import type { PaginaData, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
 import { randomUUID } from '../../../../utils/uuid';
 import styles from './PaginasPage.module.css';
 
@@ -27,6 +27,7 @@ export default function PaginasPage() {
 
   const [paginas, setPaginas] = useState<PaginaData[]>([]);
   const [etiquetas, setEtiquetas] = useState<EtiquetaData[]>([]);
+  const [colecciones, setColecciones] = useState<ColeccionRef[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -35,6 +36,7 @@ export default function PaginasPage() {
   const [editPagina, setEditPagina] = useState<PaginaData | undefined>();
   const [previewPagina, setPreviewPagina] = useState<PaginaData | undefined>();
   const [filtroEtiqueta, setFiltroEtiqueta] = useState<string | null>(null);
+  const [filtroColeccion, setFiltroColeccion] = useState<string>('');
 
   // Etiquetas CRUD state
   const [etiquetasOpen, setEtiquetasOpen] = useState(false);
@@ -51,9 +53,19 @@ export default function PaginasPage() {
   }, [etiquetas]);
 
   const paginasFiltradas = useMemo(() => {
-    if (!filtroEtiqueta) return paginas;
-    return paginas.filter((p) => p.etiquetas?.includes(filtroEtiqueta));
-  }, [paginas, filtroEtiqueta]);
+    let out = paginas;
+    if (filtroColeccion === 'sin-coleccion') {
+      out = out.filter((p) => !p.coleccionId);
+    } else if (filtroColeccion) {
+      out = out.filter((p) => p.coleccionId === filtroColeccion);
+    }
+    if (filtroEtiqueta) {
+      out = out.filter((p) => p.etiquetas?.includes(filtroEtiqueta));
+    }
+    return out;
+  }, [paginas, filtroEtiqueta, filtroColeccion]);
+
+  const sinColeccion = useMemo(() => paginas.filter((p) => !p.coleccionId).length, [paginas]);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -89,10 +101,24 @@ export default function PaginasPage() {
     }
   }, [sessionToken]);
 
+  const fetchColecciones = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/admin/colecciones`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) throw new Error('Error al cargar colecciones');
+      const data = await res.json();
+      setColecciones(data.colecciones);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  }, [sessionToken]);
+
   useEffect(() => {
     fetchPaginas();
     fetchEtiquetas();
-  }, [fetchPaginas, fetchEtiquetas]);
+    fetchColecciones();
+  }, [fetchPaginas, fetchEtiquetas, fetchColecciones]);
 
   // ── Page handlers ──────────────────────────────────────────────
 
@@ -176,7 +202,7 @@ export default function PaginasPage() {
           slug: newSlug,
           descripcion: pagina.descripcion ?? '',
           icono: pagina.icono ?? 'article',
-          grupoId: pagina.grupoId ?? null,
+          coleccionId: pagina.coleccionId ?? null,
           bloques: newBloques,
           publicado: false,
           etiquetas: pagina.etiquetas ?? [],
@@ -289,11 +315,15 @@ export default function PaginasPage() {
         ? <span className={`${styles.badge} ${styles.badgePublicado}`}>Publicado</span>
         : <span className={`${styles.badge} ${styles.badgeBorrador}`}>Borrador</span>,
     }),
-    columnHelper.accessor('grupoId', {
-      header: 'Alcance',
-      cell: (info) => info.getValue()
-        ? <span>Grupo</span>
-        : <span className={`${styles.badge} ${styles.badgeGlobal}`}>Global</span>,
+    columnHelper.accessor('coleccion', {
+      header: 'Colección',
+      cell: (info) => {
+        const col = info.getValue();
+        if (!col) {
+          return <span className={`${styles.badge} ${styles.badgeBorrador}`}>Sin asignar</span>;
+        }
+        return <span className={`${styles.badge} ${styles.badgeGlobal}`}>{col.clave ?? col.slug}</span>;
+      },
     }),
     columnHelper.accessor('etiquetas', {
       header: 'Etiquetas',
@@ -447,6 +477,31 @@ export default function PaginasPage() {
         )}
       </div>
 
+      {/* ── Colección filter ── */}
+      {colecciones.length > 0 && (
+        <div className={styles.tagFilter}>
+          <span className={styles.tagFilterLabel}>
+            <span className="material-icons">menu_book</span>
+            Colección:
+          </span>
+          <select
+            value={filtroColeccion}
+            onChange={(e) => setFiltroColeccion(e.target.value)}
+            className={styles.tagInput}
+          >
+            <option value="">Todas</option>
+            {colecciones.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.clave ? `${c.clave} — ${c.nombre}` : c.nombre}
+              </option>
+            ))}
+            {sinColeccion > 0 && (
+              <option value="sin-coleccion">Sin asignar ({sinColeccion})</option>
+            )}
+          </select>
+        </div>
+      )}
+
       {/* ── Tag filter bar ── */}
       {etiquetas.length > 0 && (
         <div className={styles.tagFilter}>
@@ -511,6 +566,7 @@ export default function PaginasPage() {
         <PaginaForm
           pagina={editPagina ?? previewPagina}
           etiquetas={etiquetas}
+          colecciones={colecciones}
           onSave={handleSave}
           onCancel={closeModal}
           loading={saving}

--- a/packages/web/src/types/pagina.ts
+++ b/packages/web/src/types/pagina.ts
@@ -14,13 +14,24 @@ export interface ContentBlock {
   datos: Record<string, unknown>;
 }
 
+/** Colección del CMS "Contenidos" tal como la expone `Pagina.toSafeJSON()`. */
+export interface ColeccionRef {
+  id: string;
+  nombre: string | null;
+  slug: string | null;
+  clave: string | null;
+}
+
 export interface PaginaData {
   id: string;
   titulo: string;
   slug: string;
   descripcion?: string;
   icono?: string;
-  grupoId?: string | null;
+  /** Colección (materia) a la que pertenece. `null` = sin asignar. */
+  coleccionId?: string | null;
+  /** Datos de la colección; solo viene en los endpoints admin (con include). */
+  coleccion?: ColeccionRef | null;
   bloques: ContentBlock[];
   publicado: boolean;
   orden?: number;


### PR DESCRIPTION
## Descripción

Las **Páginas** pasan a pertenecer a una **Colección** del CMS "Contenidos" (`Pagina.coleccion` → pointer). Así cada página queda asociada a una materia, y al agregar una actividad al calendario el picker **solo ofrece las páginas de las colecciones asignadas al grupo** (`Grupo.colecciones`). Si el grupo tiene varias colecciones, ofrece las de todas.

Tres decisiones que acotan el riesgo:

1. **La URL pública no cambia** (`/paginas/:slug`) y el slug sigue siendo único global. `Actividad.enlace` es un **string sin integridad referencial**, y hoy **38 actividades** apuntan a `/paginas/*`: cambiar la forma de la URL las habría roto en silencio y sin forma de enumerarlas.
2. **Las páginas siguen siendo públicas.** La colección organiza y filtra; no otorga ni restringe acceso. El gating del CMS "Contenidos" no se extiende a `/paginas`.
3. Se **retira `Pagina.grupo`** y el "alcance" Global/Grupo derivado de él: no filtraba nada en ninguna capa (toda página publicada era visible para cualquiera con el slug) y **ninguna de las 47 páginas en producción lo tenía asignado**, así que no hubo dato que migrar.

De paso: el API ahora **valida que la colección exista** (antes construía el pointer a ciegas con `createWithoutData`, aceptando ids inexistentes), y el campo del form deja de ser un input donde se tecleaba a mano el objectId.

### Cambios de API

| Endpoint | Cambio |
|---|---|
| `GET /api/paginas?grupoId=` | Acota a las colecciones del grupo. Responde `filtrado: false` si no pudo acotar (grupo sin colecciones) → el picker muestra todas con un aviso en vez de quedarse vacío. Sin el parámetro, comportamiento idéntico al actual. |
| `GET /api/admin/paginas?coleccionId=` | Filtro para la tabla del admin (`sin-coleccion` lista las huérfanas). |
| `GET /api/paginas/:slug` | Sin cambios de contrato; ahora incluye la colección en el payload. |

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` pasa — 175 tests. (1 archivo falla en `deprecated/archived/unused_folders/…`; **falla igual en `main`**, es preexistente y no lo toca este PR.)
- [x] `npx tsc --noEmit` sin errores en `web` y en `api`.
- [x] `yarn build` OK.

Verificación end-to-end contra una instancia del API (puerto aparte, BD real):

| Caso | Resultado |
|---|---|
| `GET /paginas` (sin `grupoId`) | 200 · 46 páginas · comportamiento legacy intacto |
| `GET /paginas?grupoId=<FebJun26>` (colecciones = `[tc2005b]`) | 200 · `filtrado: true` · acotado a su colección |
| `GET /paginas?grupoId=<Prueba 2>` (0 colecciones) | 200 · `filtrado: false` · fallback a todas + aviso en la UI |
| `GET /paginas?grupoId=<id inexistente>` | 200 · no revienta |
| `GET /paginas/lab1`, `/av1`, `/lab_seguridad` | 200 · las 38 actividades siguen resolviendo |

Que el filtro **discrimina de verdad** (y no es un no-op que devuelve todo) se verificó en solo lectura sobre la query real: `containedIn([tc2005b])` → 46, `containedIn([tc2007b])` → **0**, `containedIn([tc2005b, tc2007b])` → 46.

### Migración

`packages/api/scripts/migrate-paginas-coleccion.ts` — idempotente, con `--dry-run`.

Ya ejecutada: **47 páginas → `tc2005b`** (labs, avances y talleres; todas eran de esa materia). Segunda corrida: *"No hay páginas sin colección. Nada que hacer."*

`seed-paginas.ts` acepta ahora `--coleccion <slug>` para no volver a crear páginas huérfanas.

## Checklist

- [x] La rama sigue Conventional Branch (`feature/paginas-por-coleccion`)
- [x] Los commits siguen Conventional Commits
- [x] Actualicé `CHANGELOG.md`
- [x] No hay commits directos a `main`

## Pendiente (fuera de alcance, para otro PR)

- **`Grupo.curso` está vacío en los 3 grupos de producción** y el calendario público lo lee (`calendario.controller.ts:116-117`): `createGrupo` dejó de escribirlo cuando se migró a `Grupo.materia`, pero el lector no se actualizó. Es un bug **ya activo**, independiente de este PR.
- `Coleccion.materia` sigue siendo código muerto (declarado, nunca leído ni escrito).