### PR TITLE
refactor(grupos): retira los campos muertos Grupo.curso y Grupo.nombreCurso

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
   derivada de él. No filtraba nada en ninguna capa —toda página publicada era
   visible para cualquiera con el slug— y ninguna de las 47 páginas en producción
   lo tenía asignado.
+- **`Grupo.curso` y `Grupo.nombreCurso`**: strings legacy que duplicaban a
+  `Grupo.materia`. `createGrupo`/`updateGrupo` dejaron de escribirlos al migrar
+  a `Grupo.materia` (pointer), pero el payload de `GET /api/calendario/:grupo` y
+  la interfaz `Calendario` del front seguían declarándolos — **y ningún
+  componente los renderizaba**. Se retiran del modelo, del payload, del tipo, del
+  seed y del mock. Sin cambio visible: el calendario nunca los mostró.
+  `migrate-grupo-curso-to-materia.ts` sigue disponible para BDs sin migrar (lee
+  las columnas crudas).
 - **Docusaurus retirado (US-7)**: se elimina `packages/docusaurus`, el gate
   `/docs` por materia y el campo `Grupo.docusaurus[]`. `/docs/*` responde
   301 permanente hacia `/contenidos/*` (mapa del importador + heurística).

--- a/packages/api/scripts/migrate-grupo-curso-to-materia.ts
+++ b/packages/api/scripts/migrate-grupo-curso-to-materia.ts
@@ -6,6 +6,11 @@
  *   2. Enlaza `grupo.materia`.
  * El slug de la materia se deriva del curso en minúsculas (kebab).
  *
+ * Los campos `curso`/`nombreCurso` ya se retiraron del modelo `Grupo` (nadie los
+ * leía), así que este script lee las columnas crudas con `.get()`. Sigue aquí
+ * para entornos cuya BD todavía tenga los strings legacy sin migrar; contra una
+ * BD ya migrada es un no-op.
+ *
  * Uso:
  *   cd packages/api && npx tsx scripts/migrate-grupo-curso-to-materia.ts --dry-run
  *   cd packages/api && npx tsx scripts/migrate-grupo-curso-to-materia.ts
@@ -89,13 +94,13 @@ async function main() {
       already++;
       continue;
     }
-    const curso = grupo.getCurso().trim();
+    const curso = ((grupo.get('curso') as string) ?? '').trim();
     if (!curso) {
       sinCurso++;
       continue;
     }
 
-    const materia = await findOrCreateMateria(curso, grupo.getNombreCurso(), materiaCache);
+    const materia = await findOrCreateMateria(curso, (grupo.get('nombreCurso') as string) ?? '', materiaCache);
 
     if (dryRun) {
       console.log(`  ENLAZARÍA grupo "${grupo.getName()}" → materia ${curso}`);

--- a/packages/api/scripts/seed-calendario.ts
+++ b/packages/api/scripts/seed-calendario.ts
@@ -47,8 +47,6 @@ type SemanaData = SemanaNormalData | SemanaEspecialData;
 
 interface GrupoData {
   name: string;
-  curso: string;
-  nombreCurso: string;
   salon: string;
   enlaces: Record<string, string>;
 }
@@ -56,8 +54,6 @@ interface GrupoData {
 const GRUPOS_DATA: GrupoData[] = [
   {
     name: '501',
-    curso: 'TC2005B',
-    nombreCurso: 'Construcción de Software y Toma de Decisiones',
     salon: '4205',
     enlaces: {
       asesoriaDenisse: 'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0glSuRv-Qk1CwD4IJ1nBDWu2LSplGiPrW0Eo0DdEYxakViDvjwVkBsWBgh4U3wYpsD8GP9TRqd',
@@ -542,8 +538,6 @@ async function findOrCreateGrupo(grupoData: GrupoData, dryRun: boolean): Promise
   }
 
   if (!dryRun && grupo) {
-    grupo.setCurso(grupoData.curso);
-    grupo.setNombreCurso(grupoData.nombreCurso);
     grupo.setSalon(grupoData.salon);
     grupo.setEnlaces(grupoData.enlaces);
     await grupo.save(null, { useMasterKey: true });

--- a/packages/api/src/controllers/calendario.controller.ts
+++ b/packages/api/src/controllers/calendario.controller.ts
@@ -112,8 +112,6 @@ export async function getCalendarioByGrupo(req: Request, res: Response): Promise
     res.json({
       calendario: {
         grupoId: grupo.id,
-        curso: grupo.getCurso(),
-        nombreCurso: grupo.getNombreCurso(),
         grupo: grupo.getName(),
         salon: grupo.getSalon(),
         enlaces: grupo.getEnlaces(),

--- a/packages/api/src/models/Grupo.ts
+++ b/packages/api/src/models/Grupo.ts
@@ -27,20 +27,6 @@ export class Grupo extends BaseModel {
     this.set('fechaFin', date);
   }
 
-  getCurso(): string {
-    return this.get('curso') ?? '';
-  }
-  setCurso(curso: string): void {
-    this.set('curso', curso);
-  }
-
-  getNombreCurso(): string {
-    return this.get('nombreCurso') ?? '';
-  }
-  setNombreCurso(nombreCurso: string): void {
-    this.set('nombreCurso', nombreCurso);
-  }
-
   getSalon(): string {
     return this.get('salon') ?? '';
   }
@@ -86,8 +72,6 @@ export class Grupo extends BaseModel {
       name: this.getName(),
       fechaInicio: this.getFechaInicio(),
       fechaFin: this.getFechaFin(),
-      curso: this.getCurso(),
-      nombreCurso: this.getNombreCurso(),
       salon: this.getSalon(),
       enlaces: this.getEnlaces(),
       // Requiere query.include('materia') para traer nombre/slug; si no,

--- a/packages/web/src/data/calendario/calendario-grupo2.ts
+++ b/packages/web/src/data/calendario/calendario-grupo2.ts
@@ -2,8 +2,6 @@
 import type { Calendario } from '@/types/calendario';
 
 const calendario: Calendario = {
-  curso: "TC2005B",
-  nombreCurso: "Construcción de Software y Toma de Decisiones",
   grupo: "501",
   salon: "4205",
   enlaces: {

--- a/packages/web/src/types/calendario.ts
+++ b/packages/web/src/types/calendario.ts
@@ -64,8 +64,6 @@ export interface CalendarioEnlaces {
 
 export interface Calendario {
   grupoId?: string;
-  curso: string;
-  nombreCurso: string;
   grupo: string;
   salon: string;
   enlaces: CalendarioEnlaces;


### PR DESCRIPTION
## Descripción

Se retiran `Grupo.curso` y `Grupo.nombreCurso`, dos strings legacy que duplicaban a `Grupo.materia`.

**El diagnóstico inicial era que había un bug de render** (los 3 grupos en producción tienen `curso=""` y el controller del calendario lo lee, así que parecía que el calendario público mostraba el nombre del curso vacío). **No es así:** ningún componente los renderiza. Del objeto `calendario`, el front solo usa `grupoId` y `semanas`. Los campos viajaban de la BD → payload → tipo de TS → la nada.

Origen: `createGrupo`/`updateGrupo` dejaron de escribirlos al migrar a `Grupo.materia` (pointer), pero nadie limpió a los lectores.

Con esto muere **una de las cuatro representaciones paralelas de "materia"** que conviven en el repo, y `Grupo.materia` queda como fuente única para el grupo.

### Alcance

- `Grupo`: se van los accesores y las claves de `toSafeJSON()`.
- `GET /api/calendario/:grupo`: el payload deja de incluir `curso`/`nombreCurso`.
- `types/calendario.ts`: se van de la interfaz `Calendario`.
- `seed-calendario.ts` y el mock `data/calendario/calendario-grupo2.ts`: idem.
- `migrate-grupo-curso-to-materia.ts`: **se conserva** (sirve para BDs que aún tengan los strings sin migrar); ahora lee las columnas crudas con `.get()` en vez de los accesores retirados.

## Tipo de cambio

- [x] `refactor` — cambio interno sin alterar comportamiento

**Sin cambio visible para el usuario.** El calendario nunca mostró el nombre del curso.

## ¿Cómo se probó?

- [x] `yarn test` pasa — 175 tests. (1 archivo falla en `deprecated/archived/unused_folders/…`; falla igual en `main`, es preexistente.)
- [x] `npx tsc --noEmit` sin errores en `web` y en `api`.
- [x] `yarn build` OK.
- [x] `grep` de `getCurso|setCurso|getNombreCurso|setNombreCurso|nombreCurso` en `packages/`: **cero referencias**.

Contra el API real:

| Caso | Resultado |
|---|---|
| `GET /api/calendario/FebJun26` | 200 · payload = `grupoId, grupo, salon, semanas` · `curso`/`nombreCurso` ausentes · 12 semanas · 212 actividades (25 enlazando a `/paginas/*`, intactas) |
| `GET /api/calendario/Prueba 2` (grupo sin materia) | 200 · no revienta |

## Notas

Sigue pendiente, fuera de alcance: `Coleccion.materia` es código muerto (declarado en el modelo, nunca leído ni escrito).