### PR TITLE
fix(paginas): etiquetas como pointers — reparadas las que no se veían ni filtraban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Etiquetas de páginas que no se veían ni filtraban.** `Pagina.etiquetas`
+  guardaba objectIds como **strings sueltos**, sin validar nada, así que se
+  colaron NOMBRES de etiqueta (`"eval"`) donde debía ir el id. El render los
+  descartaba en silencio (`if (!tag) return null`), de modo que **av2 y av3
+  estaban etiquetadas como `eval` y aun así salían sin chip y no aparecían al
+  filtrar** por esa etiqueta; av1 tenía la etiqueta duplicada (el nombre y el id).
+  - `Pagina.etiquetas` pasa a ser un **array de pointers** a `Etiqueta`. Un
+    pointer no admite un nombre suelto: la clase de bug queda cerrada de raíz.
+  - El API **valida** los ids contra `Etiqueta` (400 si alguno no existe) y
+    devuelve las etiquetas **hidratadas** (`{id, nombre, color, textColor}`),
+    omitiendo las borradas. El cliente ya no resuelve ids contra un mapa, así que
+    no puede volver a descartar referencias sin avisar.
+  - `scripts/migrate-paginas-etiquetas-pointers.ts` — migración idempotente con
+    `--dry-run`: convierte strings→pointers, **repara** las entradas que eran
+    nombres (busca la `Etiqueta` por nombre) y deduplica. Ejecutada: 3 páginas,
+    3 referencias reparadas, 0 descartadas.
+
 ### Added
 - **Páginas por colección (materia)**: `Pagina` ahora apunta a una `Coleccion`
   del CMS "Contenidos" (pointer `Pagina.coleccion`), de modo que cada página

--- a/packages/api/scripts/migrate-paginas-etiquetas-pointers.ts
+++ b/packages/api/scripts/migrate-paginas-etiquetas-pointers.ts
@@ -1,0 +1,133 @@
+/**
+ * Migración: `Pagina.etiquetas` pasa de array de strings a array de pointers.
+ *
+ * El campo guardaba objectIds sueltos como strings, sin validación alguna. En
+ * producción eso permitió que se colaran NOMBRES de etiqueta ("eval") donde
+ * debía ir el objectId: el visor los descartaba en silencio, así que esas
+ * páginas se veían sin etiqueta y no salían al filtrar.
+ *
+ * Para cada entrada del array, en este orden:
+ *   1. ¿Es el objectId de una Etiqueta viva?  → pointer.
+ *   2. ¿Coincide con el NOMBRE de una Etiqueta viva? → pointer (repara el bug).
+ *   3. Ni una cosa ni la otra → se descarta y se reporta.
+ * Al final se deduplica (av1 tenía el id bueno Y el string "eval": la misma
+ * etiqueta dos veces).
+ *
+ * Idempotente: las páginas cuyo array ya sean pointers se saltan.
+ *
+ *   ./node_modules/.bin/tsx scripts/migrate-paginas-etiquetas-pointers.ts --dry-run
+ *   ./node_modules/.bin/tsx scripts/migrate-paginas-etiquetas-pointers.ts
+ *
+ * ⚠️ Dev comparte la BD de PRODUCCIÓN. Corre --dry-run primero.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+const dryRun = process.argv.includes('--dry-run');
+
+function esPointer(x: unknown): boolean {
+  return !!x && typeof x === 'object' && typeof (x as any).id === 'string';
+}
+
+async function main() {
+  const qe = new Parse.Query('Etiqueta');
+  qe.equalTo('exists', true);
+  qe.equalTo('active', true);
+  qe.limit(500);
+  const etiquetas = await qe.find({ useMasterKey: true });
+
+  const porId = new Map(etiquetas.map((e) => [e.id!, e]));
+  const porNombre = new Map(etiquetas.map((e) => [String(e.get('nombre')).toLowerCase(), e]));
+  console.log(`Etiquetas vivas: ${etiquetas.length} (${etiquetas.map((e) => e.get('nombre')).join(', ')})\n`);
+
+  const qp = new Parse.Query('Pagina');
+  qp.equalTo('exists', true);
+  qp.ascending('slug');
+  qp.limit(1000);
+  const paginas = await qp.find({ useMasterKey: true });
+
+  const aGuardar: Parse.Object[] = [];
+  let yaPointers = 0;
+  let reparadas = 0;
+  let descartadas = 0;
+
+  for (const p of paginas) {
+    const actual = (p.get('etiquetas') ?? []) as unknown[];
+    if (actual.length === 0) continue;
+
+    if (actual.every(esPointer)) {
+      yaPointers++;
+      continue;
+    }
+
+    const resueltas: Parse.Object[] = [];
+    const notas: string[] = [];
+
+    for (const entrada of actual) {
+      if (esPointer(entrada)) {
+        const e = porId.get((entrada as any).id);
+        if (e) resueltas.push(e);
+        continue;
+      }
+      if (typeof entrada !== 'string') {
+        notas.push(`descarta ${JSON.stringify(entrada)} (tipo inesperado)`);
+        descartadas++;
+        continue;
+      }
+      const porIdHit = porId.get(entrada);
+      if (porIdHit) {
+        resueltas.push(porIdHit);
+        continue;
+      }
+      const porNombreHit = porNombre.get(entrada.toLowerCase());
+      if (porNombreHit) {
+        resueltas.push(porNombreHit);
+        notas.push(`REPARA "${entrada}" (era el nombre) → ${porNombreHit.id}`);
+        reparadas++;
+        continue;
+      }
+      notas.push(`DESCARTA "${entrada}" (no es id ni nombre de ninguna etiqueta)`);
+      descartadas++;
+    }
+
+    // Deduplicar por id: av1 traía el id bueno y además el string "eval".
+    const unicas = [...new Map(resueltas.map((e) => [e.id!, e])).values()];
+
+    const antes = actual.map((x) => (esPointer(x) ? `→${(x as any).id}` : JSON.stringify(x))).join(', ');
+    const despues = unicas.map((e) => `→${e.id}(${e.get('nombre')})`).join(', ') || '(ninguna)';
+    console.log(`${dryRun ? '[dry-run]' : '[migrar] '} /paginas/${p.get('slug')}`);
+    console.log(`     antes:   [${antes}]`);
+    console.log(`     después: [${despues}]`);
+    for (const n of notas) console.log(`     · ${n}`);
+
+    p.set('etiquetas', unicas);
+    aGuardar.push(p);
+  }
+
+  console.log(`\nPáginas ya con pointers (saltadas): ${yaPointers}`);
+  console.log(`Páginas a migrar:                   ${aGuardar.length}`);
+  console.log(`Referencias reparadas (nombre→id):  ${reparadas}`);
+  console.log(`Referencias descartadas:            ${descartadas}`);
+
+  if (aGuardar.length === 0) {
+    console.log('\n✓ Nada que migrar.');
+    return;
+  }
+  if (dryRun) {
+    console.log('\n--dry-run: no se escribió nada. Quita la bandera para aplicar.');
+    return;
+  }
+
+  await Parse.Object.saveAll(aGuardar, { useMasterKey: true });
+  console.log(`\n✓ ${aGuardar.length} página(s) migradas a pointers.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/paginas.controller.ts
+++ b/packages/api/src/controllers/paginas.controller.ts
@@ -37,6 +37,25 @@ async function resolverColeccion(coleccionId: string): Promise<Parse.Object | nu
 }
 
 /**
+ * ids de etiquetas → pointers VALIDADOS. `null` = payload no-array (se ignora);
+ * `'invalido'` = algún id no corresponde a una Etiqueta viva (400).
+ *
+ * Antes se guardaba el array de strings tal cual, sin comprobar nada: por eso en
+ * producción acabaron páginas con el literal `"eval"` (el nombre de la etiqueta)
+ * en vez de su objectId, y el visor las descartaba en silencio.
+ */
+async function resolverEtiquetas(value: unknown): Promise<Parse.Object[] | 'invalido' | null> {
+  if (!Array.isArray(value)) return null;
+  const ids = [...new Set(value.filter((s): s is string => typeof s === 'string' && s.trim() !== ''))];
+  if (ids.length === 0) return [];
+  const q = BaseModel.queryActive('Etiqueta');
+  q.containedIn('objectId' as any, ids as any);
+  const encontradas = await q.find({ useMasterKey: true });
+  if (encontradas.length !== ids.length) return 'invalido';
+  return encontradas;
+}
+
+/**
  * Colecciones (pointers) asignadas a un grupo. Vacío si el grupo no existe o no
  * tiene ninguna: el llamador decide qué hacer con ese caso.
  */
@@ -62,7 +81,7 @@ export async function listPaginas(req: Request, res: Response): Promise<void> {
     const query = new Parse.Query<Pagina>('Pagina');
     query.equalTo('exists' as any, true as any);
     query.ascending('slug');
-    query.include('coleccion' as any);
+    query.include(['coleccion', 'etiquetas'] as any);
     query.limit(1000);
 
     if (typeof coleccionId === 'string' && coleccionId) {
@@ -94,7 +113,7 @@ export async function getPagina(req: Request, res: Response): Promise<void> {
 
   try {
     const query = BaseModel.queryActive<Pagina>('Pagina');
-    query.include('coleccion' as any);
+    query.include(['coleccion', 'etiquetas'] as any);
     const pagina = await query.get(id, { useMasterKey: true });
 
     res.json({ status: 'ok', pagina: pagina.toSafeJSON() });
@@ -150,9 +169,12 @@ export async function createPagina(req: Request, res: Response): Promise<void> {
     }
     pagina.setPublicado(publicado === true);
     if (orden !== undefined) pagina.setOrden(Number(orden));
-    if (Array.isArray(etiquetas) && etiquetas.every((e: any) => typeof e === 'string')) {
-      pagina.setEtiquetas(etiquetas);
+    const etiquetasPtrs = await resolverEtiquetas(etiquetas);
+    if (etiquetasPtrs === 'invalido') {
+      res.status(400).json({ status: 'error', message: 'Alguna etiqueta indicada no existe' });
+      return;
     }
+    if (etiquetasPtrs) pagina.setEtiquetas(etiquetasPtrs);
 
     await pagina.save(null, { useMasterKey: true });
 
@@ -170,7 +192,7 @@ export async function updatePagina(req: Request, res: Response): Promise<void> {
     const query = BaseModel.queryActive<Pagina>('Pagina');
     // include: sin esto, una página que no cambia de colección devolvería el
     // pointer sin datos y `toSafeJSON()` la expondría con nombre/slug en null.
-    query.include('coleccion' as any);
+    query.include(['coleccion', 'etiquetas'] as any);
     const pagina = await query.get(id, { useMasterKey: true });
 
     if (titulo !== undefined) {
@@ -229,9 +251,12 @@ export async function updatePagina(req: Request, res: Response): Promise<void> {
     if (publicado !== undefined) pagina.setPublicado(publicado === true);
     if (orden !== undefined) pagina.setOrden(Number(orden));
     if (etiquetas !== undefined) {
-      if (Array.isArray(etiquetas) && etiquetas.every((e: any) => typeof e === 'string')) {
-        pagina.setEtiquetas(etiquetas);
+      const etiquetasPtrs = await resolverEtiquetas(etiquetas);
+      if (etiquetasPtrs === 'invalido') {
+        res.status(400).json({ status: 'error', message: 'Alguna etiqueta indicada no existe' });
+        return;
       }
+      if (etiquetasPtrs) pagina.setEtiquetas(etiquetasPtrs);
     }
 
     await pagina.save(null, { useMasterKey: true });
@@ -278,7 +303,7 @@ export async function getPaginaPublica(req: Request, res: Response): Promise<voi
     query.equalTo('publicado' as any, true as any);
     // Sin include, el pointer llega sin datos y `toSafeJSON()` expondría la
     // colección con nombre/slug/clave en null.
-    query.include('coleccion' as any);
+    query.include(['coleccion', 'etiquetas'] as any);
     const pagina = await query.first({ useMasterKey: true });
 
     if (!pagina) {

--- a/packages/api/src/models/Pagina.ts
+++ b/packages/api/src/models/Pagina.ts
@@ -75,10 +75,18 @@ export class Pagina extends BaseModel {
     this.set('orden', orden);
   }
 
-  getEtiquetas(): string[] {
+  /**
+   * Etiquetas de la página (array de pointers a `Etiqueta`, nunca strings).
+   *
+   * Antes esto guardaba objectIds sueltos como strings, y nada impedía escribir
+   * cualquier cosa: en producción había páginas con el literal `"eval"` (el
+   * NOMBRE de la etiqueta) en vez del id, que el visor descartaba en silencio.
+   * Un pointer no admite eso.
+   */
+  getEtiquetas(): Parse.Object[] {
     return this.get('etiquetas') ?? [];
   }
-  setEtiquetas(etiquetas: string[]): void {
+  setEtiquetas(etiquetas: Parse.Object[]): void {
     this.set('etiquetas', etiquetas);
   }
 
@@ -105,7 +113,18 @@ export class Pagina extends BaseModel {
       bloques: this.getBloques(),
       publicado: this.getPublicado(),
       orden: this.getOrden(),
-      etiquetas: this.getEtiquetas(),
+      // Requiere query.include('etiquetas'). Se devuelven hidratadas —no ids
+      // sueltos— para que el cliente no tenga que resolverlas contra un mapa y
+      // acabe descartando en silencio las que no encuentre. Las soft-deleted no
+      // se exponen.
+      etiquetas: this.getEtiquetas()
+        .filter((e) => e && e.get('exists') !== false && e.get('active') !== false)
+        .map((e) => ({
+          id: e.id,
+          nombre: e.get('nombre') ?? null,
+          color: e.get('color') ?? null,
+          textColor: e.get('textColor') ?? null,
+        })),
       active: this.get('active'),
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/packages/web/src/components/dashboard/organisms/PaginaForm/PaginaForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/PaginaForm/PaginaForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { PaginaData, ContentBlock, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
+import type { PaginaData, PaginaSavePayload, ContentBlock, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
 import BlockEditor from '../BlockEditor/BlockEditor';
 import PaginaContent from '../../../paginas/PaginaContent';
 import DashButton from '../../atoms/DashButton/DashButton';
@@ -10,7 +10,7 @@ interface PaginaFormProps {
   pagina?: PaginaData;
   etiquetas?: EtiquetaData[];
   colecciones?: ColeccionRef[];
-  onSave: (data: Omit<PaginaData, 'id' | 'createdAt' | 'updatedAt'>) => void;
+  onSave: (data: PaginaSavePayload) => void;
   onCancel: () => void;
   loading?: boolean;
   previewMode?: boolean;
@@ -27,7 +27,10 @@ export default function PaginaForm({ pagina, etiquetas: availableTags = [], cole
   const [coleccionId, setColeccionId] = useState(pagina?.coleccionId ?? '');
   const [publicado, setPublicado] = useState(pagina?.publicado ?? false);
   const [bloques, setBloques] = useState<ContentBlock[]>(pagina?.bloques ?? []);
-  const [selectedTags, setSelectedTags] = useState<string[]>(pagina?.etiquetas ?? []);
+  // El API devuelve las etiquetas hidratadas; el form trabaja con sus ids.
+  const [selectedTags, setSelectedTags] = useState<string[]>(
+    (pagina?.etiquetas ?? []).map((e) => e.id),
+  );
 
   // Auto-generate slug from title if not manually edited
   useEffect(() => {

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
@@ -5,7 +5,7 @@ import AdminTable from '../../organisms/AdminTable/AdminTable';
 import Modal from '../../atoms/Modal/Modal';
 import PaginaForm from '../../organisms/PaginaForm/PaginaForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
-import type { PaginaData, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
+import type { PaginaData, PaginaSavePayload, EtiquetaData, ColeccionRef } from '../../../../types/pagina';
 import { randomUUID } from '../../../../utils/uuid';
 import styles from './PaginasPage.module.css';
 
@@ -46,11 +46,6 @@ export default function PaginasPage() {
   const [editTagNombre, setEditTagNombre] = useState('');
   const [editTagColorIdx, setEditTagColorIdx] = useState(0);
 
-  const etiquetaMap = useMemo(() => {
-    const map = new Map<string, EtiquetaData>();
-    etiquetas.forEach((e) => map.set(e.id, e));
-    return map;
-  }, [etiquetas]);
 
   const paginasFiltradas = useMemo(() => {
     let out = paginas;
@@ -60,7 +55,7 @@ export default function PaginasPage() {
       out = out.filter((p) => p.coleccionId === filtroColeccion);
     }
     if (filtroEtiqueta) {
-      out = out.filter((p) => p.etiquetas?.includes(filtroEtiqueta));
+      out = out.filter((p) => p.etiquetas?.some((e) => e.id === filtroEtiqueta));
     }
     return out;
   }, [paginas, filtroEtiqueta, filtroColeccion]);
@@ -146,7 +141,7 @@ export default function PaginasPage() {
     setPreviewPagina(undefined);
   }
 
-  async function handleSave(data: Omit<PaginaData, 'id' | 'createdAt' | 'updatedAt'>) {
+  async function handleSave(data: PaginaSavePayload) {
     setSaving(true);
     setError('');
     try {
@@ -205,7 +200,8 @@ export default function PaginasPage() {
           coleccionId: pagina.coleccionId ?? null,
           bloques: newBloques,
           publicado: false,
-          etiquetas: pagina.etiquetas ?? [],
+          // El API recibe ids, aunque las devuelva hidratadas.
+          etiquetas: (pagina.etiquetas ?? []).map((e) => e.id),
         }),
       });
       if (!res.ok) {
@@ -327,24 +323,23 @@ export default function PaginasPage() {
     }),
     columnHelper.accessor('etiquetas', {
       header: 'Etiquetas',
+      // El API ya las manda resueltas (y sin las borradas), así que no hay nada
+      // que buscar en un mapa ni referencias que descartar en silencio: si el
+      // array viene vacío es que la página no tiene etiquetas, punto.
       cell: (info) => {
-        const tagIds = info.getValue() ?? [];
-        if (tagIds.length === 0) return <span style={{ color: 'var(--text-muted)' }}>—</span>;
+        const tags = info.getValue() ?? [];
+        if (tags.length === 0) return <span style={{ color: 'var(--text-muted)' }}>—</span>;
         return (
           <div className={styles.tagCell}>
-            {tagIds.map((tagId) => {
-              const tag = etiquetaMap.get(tagId);
-              if (!tag) return null;
-              return (
-                <span
-                  key={tagId}
-                  className={styles.tagBadge}
-                  style={{ background: tag.color, color: tag.textColor }}
-                >
-                  {tag.nombre}
-                </span>
-              );
-            })}
+            {tags.map((tag) => (
+              <span
+                key={tag.id}
+                className={styles.tagBadge}
+                style={{ background: tag.color, color: tag.textColor }}
+              >
+                {tag.nombre}
+              </span>
+            ))}
           </div>
         );
       },

--- a/packages/web/src/types/pagina.ts
+++ b/packages/web/src/types/pagina.ts
@@ -35,10 +35,19 @@ export interface PaginaData {
   bloques: ContentBlock[];
   publicado: boolean;
   orden?: number;
-  etiquetas?: string[];
+  /**
+   * Etiquetas ya hidratadas (el API las resuelve y omite las borradas). Al
+   * guardar, en cambio, se mandan solo los ids: ver `PaginaSavePayload`.
+   */
+  etiquetas?: EtiquetaData[];
   createdAt?: string;
   updatedAt?: string;
 }
+
+/** Lo que el form manda al API: las etiquetas viajan como ids. */
+export type PaginaSavePayload = Omit<PaginaData, 'id' | 'coleccion' | 'etiquetas' | 'createdAt' | 'updatedAt'> & {
+  etiquetas?: string[];
+};
 
 export interface PaginaResumen {
   id: string;


### PR DESCRIPTION
## Descripción

Esto empezó como higiene de código (`Pagina.etiquetas` guardaba strings en vez de Pointers, contra la convención del repo) y resultó ser **un bug real que ya estaba visible en el admin**.

`Pagina.etiquetas` era un array de strings sin ninguna validación: para Mongo, `"eval"` y `"7a8QGeliAl"` son igual de válidos. Así se colaron **nombres** de etiqueta donde debía ir el **objectId**. Estado que encontré en producción:

```
/paginas/av1   ["eval", "7a8QGeliAl"]   ← el nombre Y el id: etiqueta duplicada
/paginas/av2   ["eval"]                 ← solo el nombre: no resuelve
/paginas/av3   ["eval"]                 ← solo el nombre: no resuelve
```

El render lo tapaba en silencio — `PaginasPage.tsx`: `const tag = etiquetaMap.get(tagId); if (!tag) return null;`. Si el id no resolvía, no pintaba nada **y no avisaba**.

**Impacto real:** av2 y av3 estaban etiquetadas como `eval`, salían **sin chip**, y **no aparecían al filtrar** por esa etiqueta. El único indicio era sutilísimo: su celda salía en blanco en vez del `—` que sí pintan las páginas sin etiquetas.

## La corrección

Dos frentes, porque arreglar solo los datos dejaba la puerta abierta:

1. **Esquema** — `Pagina.etiquetas` pasa a **array de pointers** a `Etiqueta`. Un pointer no admite un nombre suelto: la clase de bug queda cerrada de raíz.
2. **Contrato** — el API valida los ids contra `Etiqueta` (400 si alguno no existe) y devuelve las etiquetas **hidratadas** (`{id, nombre, color, textColor}`), omitiendo las soft-deleted. El cliente ya no resuelve ids contra un mapa, así que **no puede volver a descartar referencias sin avisar**. Efecto colateral: borrar una etiqueta deja de producir ids colgantes en las páginas.

## Migración — **ya ejecutada** contra producción

`scripts/migrate-paginas-etiquetas-pointers.ts`, idempotente y con `--dry-run`. Convierte strings→pointers, **repara** las entradas que eran nombres (busca la `Etiqueta` por nombre) y deduplica:

```
[migrar] /paginas/av1
     antes:   ["eval", "7a8QGeliAl"]
     después: [→7a8QGeliAl(eval)]
     · REPARA "eval" (era el nombre) → 7a8QGeliAl
[migrar] /paginas/av2   antes: ["eval"]  →  después: [→7a8QGeliAl(eval)]
[migrar] /paginas/av3   antes: ["eval"]  →  después: [→7a8QGeliAl(eval)]

Páginas a migrar: 3 | Referencias reparadas: 3 | Referencias descartadas: 0
```

**0 descartadas**: no se perdió ninguna etiqueta. Segunda corrida: *"Nada que migrar"*.

## Tipo de cambio

- [x] `fix` — corrección de bug (SemVer: PATCH)

## ¿Cómo se probó?

- [x] `yarn test` pasa — 175 tests (el fallo en `deprecated/archived/…` es preexistente, falla igual en `main`).
- [x] `npx tsc --noEmit` sin errores en `web` y `api`.
- [x] `yarn build` OK.

Contra la BD real, después de migrar:

```
=== payload que ve el admin ===
  /paginas/av1   etiquetas=[eval(#fef3c7)]     ← ya sin duplicado
  /paginas/av2   etiquetas=[eval(#fef3c7)]     ← ANTES: vacío
  /paginas/av3   etiquetas=[eval(#fef3c7)]     ← ANTES: vacío
  /paginas/av4   etiquetas=[(ninguna)]

=== query por pointer: páginas con etiqueta "eval" ===
   av1, av2, av3 (3)                            ← ANTES: solo av1
```

Esa última query —filtrar páginas por un pointer de etiqueta— **era imposible con el esquema anterior**; con strings había que traerse todo y filtrar en cliente.