### PR TITLE
feat(cms): el editor a un clic — árbol en el sidebar, edición inline y drag & drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,46 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **CMS "Contenidos" — el editor a un clic.** El árbol de páginas se muda al
+  sidebar (modo contextual, como `/admin/grupos/:id`) y seleccionar una página
+  abre el editor **inline**, sin el paso intermedio de "Abrir editor". La página
+  seleccionada viaja en la URL (`?doc=<id>`), así que recargar o compartir el
+  enlace conserva lo que estabas editando. La ruta a pantalla completa
+  (`/admin/contenidos/:id/editar/:docId`) sigue viva como modo enfocado.
+  - **El árbol se maneja como un explorador de archivos**: arrastrar mueve
+    (vertical reordena, horizontal cambia de nivel), doble clic renombra en
+    línea, y al pasar el cursor aparecen las acciones de cambiar slug y eliminar.
+  - **Renombrar cambia SOLO el título; el slug (la URL) no se toca.** 82 de los
+    120 documentos tienen un slug que no deriva de su título (`readme`, herencia
+    de Docusaurus) y hay ~59 enlaces internos apuntando a esas rutas sin ningún
+    redirect: regenerar el slug al renombrar los habría roto en silencio. Al
+    **crear**, en cambio, el slug sí se genera del título (nada apunta aún a la
+    página), y el campo desaparece del formulario.
+  - Cambiar el slug a propósito es una acción aparte, con un diálogo que muestra
+    **la ruta actual y cómo quedará** antes de guardar.
+  - Desaparece el panel de metadatos: todo se movió a donde se usa (la plantilla
+    baja a la toolbar del editor).
+  - El editor puede **colapsar el código o la vista previa** (código / ambos /
+    preview; por defecto ambos, y se recuerda). El panel oculto no se desmonta,
+    para no perder el historial de deshacer de CodeMirror.
+- **Los diálogos del admin usan SweetAlert2** (`utils/dialogos.ts`). Se
+  sustituyen los **25 `confirm()`/`prompt()`/`alert()` nativos** de todo el web:
+  además de verse mejor, los nativos **bloquean el hilo del navegador** mientras
+  están abiertos. Los borrados van en rojo y con el botón etiquetado ("Eliminar"),
+  no con un "OK" genérico; la contraseña generada de un alumno se muestra en un
+  diálogo copiable en vez de un `alert()` del sistema.
+
 ### Fixed
+- **Pérdida de borrador al cambiar de página en el editor.** El autosave
+  (debounce de 1.5 s) se **cancelaba** al cambiar de documento o desmontar, así
+  que lo escrito en el último segundo y medio se perdía sin aviso. Ahora se
+  vuelca antes de salir, con los valores del documento que se deja, encadenado al
+  PUT en vuelo para no romper el single-flight.
+- **El sidebar se colapsaba solo y no se dejaba abrir** en pantallas ≤1024 px: el
+  handler de `resize` forzaba el colapso en **cada evento**, no solo al cruzar el
+  umbral, y nunca lo revertía al ensanchar. Con el árbol dentro, eso dejaba al
+  admin sin navegación.
 - **Etiquetas de páginas que no se veían ni filtraban.** `Pagina.etiquetas`
   guardaba objectIds como **strings sueltos**, sin validar nada, así que se
   colaron NOMBRES de etiqueta (`"eval"`) donde debía ir el id. El render los

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,8 @@
     "react-apexcharts": "^2.1.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.1.0",
-    "recharts": "^3.8.0"
+    "recharts": "^3.8.0",
+    "sweetalert2": "^11.26.25"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/packages/web/src/components/calendar/CalendarContent.tsx
+++ b/packages/web/src/components/calendar/CalendarContent.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useLayoutEffect } from 'react';
+import { confirmar } from '@/utils/dialogos';
 import {
   DndContext,
   PointerSensor,
@@ -279,7 +280,13 @@ export default function CalendarContent({ grupoId, stickyTop = 'var(--navbar-hei
   }, [editModalState, updateActividad]);
 
   const handleDeleteActivity = useCallback(async (semanaId: string, actividadId: string) => {
-    if (!window.confirm('¿Eliminar esta actividad?')) return;
+    const confirmado = await confirmar({
+      titulo: '¿Eliminar esta actividad?',
+      texto: 'Esta acción no se puede deshacer.',
+      confirmar: 'Eliminar',
+      peligro: true,
+    });
+    if (!confirmado) return;
     const ok = await deleteActividad(actividadId);
     if (!ok) return;
 

--- a/packages/web/src/components/calendar/WeekCard.tsx
+++ b/packages/web/src/components/calendar/WeekCard.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import { confirmar } from '@/utils/dialogos';
 import {
   DndContext,
   DragOverlay,
@@ -456,11 +457,15 @@ export default function WeekCard({
           <span
             className={styles.weekDeleteBtn}
             title="Eliminar semana vacía"
-            onClick={(e) => {
+            onClick={async (e) => {
               e.stopPropagation();
-              if (window.confirm('¿Eliminar esta semana?')) {
-                onDeleteWeek(semana.id!);
-              }
+              const ok = await confirmar({
+                titulo: '¿Eliminar esta semana?',
+                texto: 'La semana está vacía; esta acción no se puede deshacer.',
+                confirmar: 'Eliminar',
+                peligro: true,
+              });
+              if (ok) onDeleteWeek(semana.id!);
             }}
           >
             <i className="material-icons">delete_outline</i>

--- a/packages/web/src/components/dashboard/organisms/DocumentoForm/DocumentoForm.module.css
+++ b/packages/web/src/components/dashboard/organisms/DocumentoForm/DocumentoForm.module.css
@@ -46,3 +46,16 @@
   border-radius: 8px;
   font-size: 13.5px;
 }
+
+/* Vista previa del slug generado (no editable: cambiarlo después es la acción
+   del árbol, que avisa de que mueve la URL pública). */
+.slugPreview {
+  margin: -4px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.slugPreview code {
+  background: var(--bg-page);
+  padding: 1px 5px;
+  border-radius: 4px;
+}

--- a/packages/web/src/components/dashboard/organisms/DocumentoForm/DocumentoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/DocumentoForm/DocumentoForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import TextInput from '../../atoms/TextInput/TextInput';
 import DashButton from '../../atoms/DashButton/DashButton';
-import { slugify, slugifyInput } from '../../../../utils/slug';
+import { slugify } from '../../../../utils/slug';
 import styles from './DocumentoForm.module.css';
 import type { DocumentoNodo, DocumentoTipo, DocumentoPlantilla } from '../../../../types/contenidos';
 
@@ -38,33 +38,35 @@ export function aplanarCategorias(nodos: DocumentoNodo[], nivel = 0): { id: stri
 
 export default function DocumentoForm({ categorias, padreInicial, errorExterno, onSave, onCancel, loading }: DocumentoFormProps) {
   const [titulo, setTitulo] = useState('');
-  const [slug, setSlug] = useState('');
-  const [slugTocado, setSlugTocado] = useState(false);
   const [tipo, setTipo] = useState<DocumentoTipo>('md');
   const [plantilla, setPlantilla] = useState<'' | DocumentoPlantilla>('');
   const [padreId, setPadreId] = useState(padreInicial ?? '');
   const [error, setError] = useState('');
 
+  // El slug se deriva del título y ya no se edita aquí: al crear no hay nada
+  // que apunte a la página todavía, así que generarlo es gratis. Cambiarlo
+  // después sí mueve la URL pública, y para eso está la acción del árbol
+  // (con su aviso).
+  const slug = slugify(titulo);
+
   function handleTitulo(v: string) {
     setTitulo(v);
-    if (!slugTocado) setSlug(slugify(v));
     setError('');
   }
 
   function doSave() {
-    const slugFinal = slugify(slug);
     if (!titulo.trim()) {
       setError('El título es requerido');
       return;
     }
-    if (!slugFinal) {
-      setError('El slug es requerido');
+    if (!slug) {
+      setError('El título debe tener al menos una letra o número');
       return;
     }
     setError('');
     onSave({
       titulo: titulo.trim(),
-      slug: slugFinal,
+      slug,
       tipo,
       plantilla: tipo === 'md' && plantilla ? plantilla : undefined,
       padreId: padreId || undefined,
@@ -88,14 +90,10 @@ export default function DocumentoForm({ categorias, padreInicial, errorExterno, 
         error={error}
         disabled={loading}
       />
-      <TextInput
-        label="Slug"
-        placeholder="lab1-html"
-        icon="link"
-        value={slug}
-        onChange={(v) => { setSlug(slugifyInput(v)); setSlugTocado(true); setError(''); }}
-        disabled={loading}
-      />
+      {/* El slug no se edita: se muestra para que se vea qué URL va a quedar. */}
+      <p className={styles.slugPreview}>
+        URL: <code>/{slug || '…'}</code>
+      </p>
       <div className={styles.field}>
         <label className={styles.label}>Tipo</label>
         <select className={styles.select} value={tipo} onChange={(e) => setTipo(e.target.value as DocumentoTipo)} disabled={loading}>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.module.css
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.module.css
@@ -1,0 +1,185 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+
+/* Scroll propio: con 120 páginas no puede empujar al footer ni crecer sin fin. */
+.arbol {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 4px 6px 12px;
+  scrollbar-width: thin;
+}
+.arbol::-webkit-scrollbar {
+  width: 6px;
+}
+.arbol::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.18);
+  border-radius: 3px;
+}
+
+.nodo {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--sidebar-color, #334155);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  user-select: none;
+  touch-action: manipulation;
+}
+
+.nodo:hover {
+  background: var(--sidebar-hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+.nodoActivo,
+.nodoActivo:hover {
+  background: var(--sidebar-active-bg, #eef2ff);
+  color: var(--sidebar-active-color, #4f46e5);
+  font-weight: 600;
+}
+
+/* El nodo que se arrastra se atenúa: el que "viaja" es el DragOverlay. */
+.nodoArrastrando {
+  opacity: 0.35;
+}
+
+.overlay {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--dash-primary, #4f46e5);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.16);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: grabbing;
+}
+
+.chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.chevron:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.chevronHueco {
+  width: 18px;
+  flex-shrink: 0;
+}
+
+.titulo {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Renombrar en línea (doble clic) ── */
+.renameInput {
+  flex: 1;
+  min-width: 0;
+  padding: 1px 4px;
+  border: 1px solid var(--dash-primary, #4f46e5);
+  border-radius: 4px;
+  font: inherit;
+  font-weight: 400;
+  color: var(--text-primary);
+  background: var(--bg-card, #fff);
+  outline: none;
+}
+
+/* ── Acciones (aparecen al pasar el cursor) ── */
+.acciones {
+  display: none;
+  align-items: center;
+  gap: 1px;
+  flex-shrink: 0;
+}
+.nodo:hover .acciones {
+  display: flex;
+}
+
+.accion {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted, #64748b);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.accion:hover {
+  background: rgba(0, 0, 0, 0.08);
+  color: var(--text-primary);
+}
+.accionPeligro:hover {
+  background: #fdecea;
+  color: var(--dash-danger, #c0392b);
+}
+
+/* El punto de estado cede el sitio a las acciones al hacer hover: en 270px no
+   caben los dos sin comerse el título. */
+.dotPub,
+.dotBorr {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.nodo:hover .dotPub,
+.nodo:hover .dotBorr {
+  display: none;
+}
+
+.dotPub {
+  background: #2e7d32;
+}
+.dotBorr {
+  background: #e65100;
+}
+
+.error {
+  margin: 6px 8px;
+  padding: 8px 10px;
+  background: #fdecea;
+  color: var(--dash-danger, #c0392b);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  cursor: pointer;
+}
+
+.vacio {
+  padding: 12px 14px;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-muted, #64748b);
+}

--- a/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
@@ -1,0 +1,401 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragStartEvent,
+  type DragMoveEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import Icon from '../../atoms/Icon/Icon';
+import { useColeccionArbol } from '../../../../context/ColeccionArbolContext';
+import { confirmar, pedirTexto, escapar } from '../../../../utils/dialogos';
+import { slugify } from '../../../../utils/slug';
+import { aplanar, idsDeSubarbol, proyectar, ordenDestino, type NodoPlano } from './arbol-dnd';
+import type { DocumentoTipo } from '../../../../types/contenidos';
+import styles from './ArbolContenidos.module.css';
+
+const SANGRIA = 14;
+
+const ICONO_TIPO: Record<DocumentoTipo, string> = {
+  md: 'article',
+  html: 'code',
+  categoria: 'folder',
+};
+
+interface NodoProps {
+  nodo: NodoPlano;
+  activo: boolean;
+  expandido: boolean;
+  profundidadProyectada: number | null;
+  editando: boolean;
+  onSeleccionar: (id: string) => void;
+  onToggle: (id: string) => void;
+  onEmpezarRename: (id: string) => void;
+  onRenombrar: (id: string, titulo: string) => void;
+  onCancelarRename: () => void;
+  onCambiarSlug: (nodo: NodoPlano) => void;
+  onEliminar: (nodo: NodoPlano) => void;
+}
+
+function Nodo({
+  nodo, activo, expandido, profundidadProyectada, editando,
+  onSeleccionar, onToggle, onEmpezarRename, onRenombrar, onCancelarRename,
+  onCambiarSlug, onEliminar,
+}: NodoProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: nodo.id,
+    // Renombrando no se arrastra: el ratón tiene que poder seleccionar texto.
+    disabled: editando,
+  });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (editando) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editando]);
+
+  const profundidad = profundidadProyectada ?? nodo.profundidad;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+        paddingLeft: 6 + profundidad * SANGRIA,
+      }}
+      className={`${styles.nodo} ${activo ? styles.nodoActivo : ''} ${isDragging ? styles.nodoArrastrando : ''}`}
+      onClick={() => !editando && onSeleccionar(nodo.id)}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onEmpezarRename(nodo.id);
+      }}
+      title={editando ? undefined : `${nodo.titulo}  ·  /${nodo.slug}`}
+      {...attributes}
+      {...(editando ? {} : listeners)}
+    >
+      {nodo.esCategoria ? (
+        <button
+          type="button"
+          className={styles.chevron}
+          onClick={(e) => { e.stopPropagation(); onToggle(nodo.id); }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={expandido ? 'Contraer' : 'Expandir'}
+        >
+          <Icon name={expandido ? 'expand_more' : 'chevron_right'} size="sm" />
+        </button>
+      ) : (
+        <span className={styles.chevronHueco} />
+      )}
+
+      <Icon name={ICONO_TIPO[nodo.tipo]} size="sm" />
+
+      {editando ? (
+        <input
+          ref={inputRef}
+          className={styles.renameInput}
+          defaultValue={nodo.titulo}
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') onRenombrar(nodo.id, (e.target as HTMLInputElement).value);
+            if (e.key === 'Escape') onCancelarRename();
+          }}
+          onBlur={(e) => onRenombrar(nodo.id, e.target.value)}
+        />
+      ) : (
+        <>
+          <span className={styles.titulo}>{nodo.titulo}</span>
+
+          <span className={styles.acciones}>
+            <button
+              type="button"
+              className={styles.accion}
+              title={`Cambiar slug (cambia la URL) — ahora: /${nodo.slug}`}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); onCambiarSlug(nodo); }}
+            >
+              <Icon name="link" size="sm" />
+            </button>
+            <button
+              type="button"
+              className={`${styles.accion} ${styles.accionPeligro}`}
+              title="Eliminar"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); onEliminar(nodo); }}
+            >
+              <Icon name="delete" size="sm" />
+            </button>
+          </span>
+
+          {!nodo.esCategoria && (
+            <span
+              className={nodo.publicado ? styles.dotPub : styles.dotBorr}
+              title={nodo.publicado ? 'Publicada' : 'Borrador'}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Árbol de páginas de la colección, en el sidebar.
+ *
+ * - La selección vive en la URL (`?doc=<id>`): recargar o compartir el enlace
+ *   devuelve la misma página abierta.
+ * - Doble clic = renombrar (solo el título; el slug NO se toca, porque es la URL
+ *   pública y hay enlaces internos apuntando a ella).
+ * - Arrastrar = mover: en vertical reordena, en horizontal cambia de nivel. Solo
+ *   se puede colgar de una categoría.
+ */
+export default function ArbolContenidos({ coleccionId }: { coleccionId: string }) {
+  const { arbol, documentos, coleccion, cargando, mover, renombrar, cambiarSlug, eliminar } = useColeccionArbol();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const seleccionadoId = searchParams.get('doc');
+
+  const [expandidos, setExpandidos] = useState<Set<string>>(new Set());
+  const [editandoId, setEditandoId] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [offsetX, setOffsetX] = useState(0);
+  const [overId, setOverId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  // Arrastrar debe poder empezar sin bloquear el clic simple ni el doble clic.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  );
+
+  // Al entrar por enlace directo, abrir las categorías que llevan a la página:
+  // si no, el nodo seleccionado quedaría escondido en una rama cerrada.
+  useEffect(() => {
+    if (!seleccionadoId || documentos.length === 0) return;
+    const porId = new Map(documentos.map((d) => [d.id, d]));
+    const ancestros = new Set<string>();
+    let actual = porId.get(seleccionadoId);
+    while (actual?.padreId) {
+      ancestros.add(actual.padreId);
+      actual = porId.get(actual.padreId);
+    }
+    if (ancestros.size > 0) setExpandidos((prev) => new Set([...prev, ...ancestros]));
+  }, [seleccionadoId, documentos]);
+
+  const planos = useMemo(() => aplanar(arbol, expandidos), [arbol, expandidos]);
+
+  // Mientras arrastras, la descendencia del nodo desaparece de la lista: no
+  // tiene sentido soltar una categoría dentro de sí misma.
+  const visibles = useMemo(() => {
+    if (!activeId) return planos;
+    const excluir = idsDeSubarbol(planos, activeId);
+    excluir.delete(activeId);
+    return planos.filter((n) => !excluir.has(n.id));
+  }, [planos, activeId]);
+
+  const proyeccion = useMemo(() => {
+    if (!activeId || !overId) return null;
+    return proyectar(visibles, activeId, overId, offsetX, SANGRIA);
+  }, [visibles, activeId, overId, offsetX]);
+
+  function toggle(id: string) {
+    setExpandidos((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function seleccionar(id: string) {
+    navigate(`/admin/contenidos/${coleccionId}?doc=${id}`);
+  }
+
+  async function handleRenombrar(id: string, titulo: string) {
+    setEditandoId(null);
+    const limpio = titulo.trim();
+    const original = documentos.find((d) => d.id === id)?.titulo;
+    if (!limpio || limpio === original) return;
+    const err = await renombrar(id, limpio);
+    if (err) setError(err);
+  }
+
+  /** Ruta pública de los ANCESTROS del nodo (sin su propio slug ni el dominio). */
+  function rutaAncestros(nodoId: string): string {
+    const porId = new Map(documentos.map((d) => [d.id, d]));
+    const segmentos: string[] = [];
+    let actual = porId.get(nodoId);
+    while (actual?.padreId) {
+      const padre = porId.get(actual.padreId);
+      if (!padre) break;
+      segmentos.unshift(padre.slug);
+      actual = padre;
+    }
+    return `/contenidos/${coleccion?.slug ?? '…'}${segmentos.length ? '/' + segmentos.join('/') : ''}`;
+  }
+
+  async function handleCambiarSlug(nodo: NodoPlano) {
+    const base = rutaAncestros(nodo.id);
+    // slugify ya deja solo [a-z0-9-]; se escapa igual, por si el día de mañana
+    // se relaja la normalización.
+    const seg = (s: string) => `<span class="swal-seg">${escapar(s)}</span>`;
+    const cola = nodo.esCategoria && nodo.tieneHijos ? '<span class="swal-ruta-cola">/…</span>' : '';
+
+    const nuevo = await pedirTexto({
+      titulo: 'Cambiar slug',
+      html:
+        `Slug de <b>${escapar(nodo.titulo)}</b> — el segmento de la URL pública.` +
+        '<span class="swal-aviso">⚠️ Cambia la URL de esta página' +
+        (nodo.esCategoria && nodo.tieneHijos ? ' <b>y la de todo lo que cuelga de ella</b>' : '') +
+        '. Los enlaces que ya apunten a la ruta actual dejarán de funcionar: no hay redirects.</span>',
+      valor: nodo.slug,
+      confirmar: 'Cambiar la URL',
+      normalizar: slugify,
+      validar: (v) => (v ? null : 'El slug no puede quedar vacío'),
+      vistaPrevia: (v) => {
+        const antes =
+          `<div class="swal-ruta"><span class="swal-ruta-label">Ahora</span>` +
+          `<code>${escapar(base)}/${seg(nodo.slug)}${cola}</code></div>`;
+        if (!v) {
+          return antes;
+        }
+        if (v === nodo.slug) {
+          return antes + '<div class="swal-ruta-nota">Sin cambios.</div>';
+        }
+        const despues =
+          `<div class="swal-ruta swal-ruta-nueva"><span class="swal-ruta-label">Quedará</span>` +
+          `<code>${escapar(base)}/${seg(v)}${cola}</code></div>`;
+        return antes + despues;
+      },
+    });
+    if (nuevo === null || nuevo === nodo.slug) return;
+    const err = await cambiarSlug(nodo.id, nuevo);
+    if (err) setError(err);
+  }
+
+  async function handleEliminar(nodo: NodoPlano) {
+    if (nodo.tieneHijos) {
+      setError(`"${nodo.titulo}" tiene páginas dentro. Muévelas o elimínalas primero.`);
+      return;
+    }
+    const ok = await confirmar({
+      titulo: `¿Eliminar «${nodo.titulo}»?`,
+      texto: 'Esta acción no se puede deshacer.',
+      confirmar: 'Eliminar',
+      peligro: true,
+    });
+    if (!ok) return;
+    const err = await eliminar(nodo.id);
+    if (err) {
+      setError(err);
+      return;
+    }
+    if (seleccionadoId === nodo.id) navigate(`/admin/contenidos/${coleccionId}`);
+  }
+
+  function onDragStart(e: DragStartEvent) {
+    setActiveId(String(e.active.id));
+    setOverId(String(e.active.id));
+    setError('');
+  }
+
+  function onDragMove(e: DragMoveEvent) {
+    setOffsetX(e.delta.x);
+    if (e.over) setOverId(String(e.over.id));
+  }
+
+  async function onDragEnd(e: DragEndEvent) {
+    const active = activeId;
+    const proj = proyeccion;
+    setActiveId(null);
+    setOverId(null);
+    setOffsetX(0);
+    if (!active || !e.over || !proj) return;
+
+    const nodo = planos.find((n) => n.id === active);
+    if (!nodo) return;
+
+    const orden = ordenDestino(visibles, active, String(e.over.id), proj.padreId);
+    // Sin cambios reales: no molestamos al servidor.
+    if ((nodo.padreId ?? null) === proj.padreId && String(e.over.id) === active) return;
+
+    const err = await mover(active, proj.padreId, orden);
+    if (err) {
+      // El servidor rechaza mover a una categoría donde ya hay un hermano con el
+      // mismo slug — y aquí abundan los `readme`, así que pasará. El árbol se
+      // repinta solo desde el refetch; basta con explicar por qué no se movió.
+      setError(err);
+      return;
+    }
+    if (proj.padreId) setExpandidos((prev) => new Set(prev).add(proj.padreId!));
+  }
+
+  const nodoArrastrado = activeId ? planos.find((n) => n.id === activeId) : null;
+
+  if (cargando && documentos.length === 0) {
+    return <p className={styles.vacio}>Cargando árbol…</p>;
+  }
+  if (documentos.length === 0) {
+    return <p className={styles.vacio}>Esta colección no tiene páginas todavía.</p>;
+  }
+
+  return (
+    <div className={styles.wrap}>
+      {error && (
+        <div className={styles.error} onClick={() => setError('')} title="Descartar">
+          {error}
+        </div>
+      )}
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={onDragStart}
+        onDragMove={onDragMove}
+        onDragEnd={onDragEnd}
+        onDragCancel={() => { setActiveId(null); setOverId(null); setOffsetX(0); }}
+      >
+        <SortableContext items={visibles.map((n) => n.id)} strategy={verticalListSortingStrategy}>
+          <div className={styles.arbol}>
+            {visibles.map((n) => (
+              <Nodo
+                key={n.id}
+                nodo={n}
+                activo={n.id === seleccionadoId}
+                expandido={expandidos.has(n.id)}
+                profundidadProyectada={activeId === n.id && proyeccion ? proyeccion.profundidad : null}
+                editando={editandoId === n.id}
+                onSeleccionar={seleccionar}
+                onToggle={toggle}
+                onEmpezarRename={setEditandoId}
+                onRenombrar={handleRenombrar}
+                onCancelarRename={() => setEditandoId(null)}
+                onCambiarSlug={handleCambiarSlug}
+                onEliminar={handleEliminar}
+              />
+            ))}
+          </div>
+        </SortableContext>
+
+        <DragOverlay>
+          {nodoArrastrado && (
+            <div className={styles.overlay}>
+              <Icon name={ICONO_TIPO[nodoArrastrado.tipo]} size="sm" />
+              <span>{nodoArrastrado.titulo}</span>
+            </div>
+          )}
+        </DragOverlay>
+      </DndContext>
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.module.css
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.module.css
@@ -98,6 +98,15 @@
   gap: 4px;
   overflow-y: auto;
 }
+
+/* Con el árbol dentro, el scroll lo gestiona el propio árbol (necesita
+   min-height:0 para que su overflow funcione dentro del flex). El padding
+   lateral se reduce: cada nivel de indentación cuesta ancho. */
+.navArbol {
+  padding: 8px 4px;
+  overflow: hidden;
+  min-height: 0;
+}
 .footer {
   padding: 16px;
   border-top: 1px solid var(--sidebar-border);

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -3,10 +3,12 @@ import { Link, useMatch } from 'react-router';
 import NavItem from '../../molecules/NavItem/NavItem';
 import DocusMenu, { type DocusLink } from '../../molecules/DocusMenu/DocusMenu';
 import Icon from '../../atoms/Icon/Icon';
+import ArbolContenidos from './ArbolContenidos';
 import { getSidebarItems, getGrupoDetailItems } from './sidebarConfig';
 import styles from './Sidebar.module.css';
 import type { DashboardRole } from '../../../../types/dashboard';
 import { useAuth } from '../../../../context/AuthContext';
+import { useColeccionArbol } from '../../../../context/ColeccionArbolContext';
 import { APP_NAME } from '../../../../config/app';
 
 interface SidebarProps {
@@ -22,6 +24,13 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
   const grupoMatch = grupoMatchExact || grupoMatchSub;
   const isGrupoDetail = !!grupoMatch;
   const grupoId = grupoMatch?.params.id;
+
+  // Colección abierta: el sidebar se vuelve el árbol de páginas (mismo patrón
+  // contextual que el detalle de grupo). Los datos vienen del provider, que los
+  // comparte con la página para que una mutación se refleje aquí.
+  const { coleccionId, coleccion } = useColeccionArbol();
+  const isColeccionDetail = !!coleccionId;
+
   const { sessionToken, user, updateUser } = useAuth();
   const [grupoName, setGrupoName] = useState('');
   const [selectedGrupoId, setSelectedGrupoId] = useState<string>('');
@@ -100,7 +109,19 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
       <aside
         className={`${styles.sidebar} ${collapsed ? styles.collapsed : ''} ${mobileOpen ? styles.mobileOpen : ''}`}
       >
-        {isGrupoDetail ? (
+        {isColeccionDetail ? (
+          <div className={styles.backHeader}>
+            <Link to="/admin/contenidos" className={styles.backButton} onClick={onCloseMobile}>
+              <Icon name="arrow_back" size="sm" />
+              {!collapsed && <span>Volver a Contenidos</span>}
+            </Link>
+            {!collapsed && (
+              <span className={styles.grupoLabel} title={coleccion?.nombre ?? ''}>
+                {coleccion?.clave ?? coleccion?.slug ?? '…'}
+              </span>
+            )}
+          </div>
+        ) : isGrupoDetail ? (
           <div className={styles.backHeader}>
             <Link to="/admin/grupos" className={styles.backButton} onClick={onCloseMobile}>
               <Icon name="arrow_back" size="sm" />
@@ -134,21 +155,29 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
             </select>
           </div>
         )}
-        <nav className={styles.nav}>
-          {items.map(item => (
-            <NavItem
-              key={item.path}
-              icon={item.icon}
-              label={item.label}
-              path={item.path}
-              badge={item.badge}
-              disabled={item.disabled}
-              external={item.external}
-              collapsed={collapsed}
-              onClick={onCloseMobile}
-            />
-          ))}
-          {isGrupoDetail && <DocusMenu items={docusLinks} collapsed={collapsed} />}
+        <nav className={`${styles.nav} ${isColeccionDetail && !collapsed ? styles.navArbol : ''}`}>
+          {isColeccionDetail ? (
+            // Colapsado (70px) el árbol es ilegible: se oculta y queda solo el
+            // botón de volver, que es la salida.
+            !collapsed && <ArbolContenidos coleccionId={coleccionId} />
+          ) : (
+            <>
+              {items.map(item => (
+                <NavItem
+                  key={item.path}
+                  icon={item.icon}
+                  label={item.label}
+                  path={item.path}
+                  badge={item.badge}
+                  disabled={item.disabled}
+                  external={item.external}
+                  collapsed={collapsed}
+                  onClick={onCloseMobile}
+                />
+              ))}
+              {isGrupoDetail && <DocusMenu items={docusLinks} collapsed={collapsed} />}
+            </>
+          )}
         </nav>
         <div className={styles.footer}>
           {!collapsed && (

--- a/packages/web/src/components/dashboard/organisms/Sidebar/arbol-dnd.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/arbol-dnd.ts
@@ -1,0 +1,147 @@
+import type { DocumentoData, DocumentoNodo } from '../../../../types/contenidos';
+
+/** Nodo del árbol aplanado a lista: es lo que consume dnd-kit. */
+export interface NodoPlano {
+  id: string;
+  titulo: string;
+  slug: string;
+  tipo: DocumentoData['tipo'];
+  publicado: boolean;
+  padreId: string | null;
+  profundidad: number;
+  /** Solo las categorías admiten hijos (lo valida también el servidor). */
+  esCategoria: boolean;
+  tieneHijos: boolean;
+}
+
+/** Aplana el árbol respetando qué categorías están expandidas. */
+export function aplanar(
+  nodos: DocumentoNodo[],
+  expandidos: Set<string>,
+  profundidad = 0,
+  padreId: string | null = null,
+): NodoPlano[] {
+  const out: NodoPlano[] = [];
+  for (const n of nodos) {
+    const esCategoria = n.tipo === 'categoria';
+    out.push({
+      id: n.id,
+      titulo: n.titulo,
+      slug: n.slug,
+      tipo: n.tipo,
+      publicado: n.publicado,
+      padreId,
+      profundidad,
+      esCategoria,
+      tieneHijos: n.hijos.length > 0,
+    });
+    if (esCategoria && expandidos.has(n.id)) {
+      out.push(...aplanar(n.hijos, expandidos, profundidad + 1, n.id));
+    }
+  }
+  return out;
+}
+
+/** ids del nodo y de toda su descendencia (no puedes soltar algo dentro de sí mismo). */
+export function idsDeSubarbol(items: NodoPlano[], id: string): Set<string> {
+  const out = new Set<string>([id]);
+  const idx = items.findIndex((i) => i.id === id);
+  if (idx === -1) return out;
+  const base = items[idx].profundidad;
+  for (let i = idx + 1; i < items.length; i++) {
+    if (items[i].profundidad <= base) break;
+    out.add(items[i].id);
+  }
+  return out;
+}
+
+export interface Proyeccion {
+  profundidad: number;
+  padreId: string | null;
+}
+
+/**
+ * A qué padre y profundidad va a caer el nodo arrastrado.
+ *
+ * La profundidad sale del desplazamiento HORIZONTAL del ratón (como en un
+ * explorador de archivos: arrastras a la derecha para meterlo dentro), acotada
+ * por lo que el árbol permite: solo se puede colgar de una CATEGORÍA, así que si
+ * el vecino de arriba es una página, no se puede anidar más.
+ */
+export function proyectar(
+  items: NodoPlano[],
+  activeId: string,
+  overId: string,
+  offsetX: number,
+  sangria: number,
+): Proyeccion {
+  const idxOver = items.findIndex((i) => i.id === overId);
+  const idxActive = items.findIndex((i) => i.id === activeId);
+  if (idxOver === -1 || idxActive === -1) return { profundidad: 0, padreId: null };
+
+  // Lista tal como quedaría tras el movimiento, para mirar a los vecinos reales.
+  const movidos = [...items];
+  const [arrastrado] = movidos.splice(idxActive, 1);
+  movidos.splice(idxOver, 0, arrastrado);
+
+  const anterior = movidos[idxOver - 1];
+  const siguiente = movidos[idxOver + 1];
+
+  const deseada = items[idxActive].profundidad + Math.round(offsetX / sangria);
+
+  // Máximo: un nivel más que el de arriba, y solo si el de arriba es categoría.
+  const maxima = anterior
+    ? anterior.esCategoria
+      ? anterior.profundidad + 1
+      : anterior.profundidad
+    : 0;
+  // Mínimo: no puede quedar por encima del de abajo, o lo dejaría huérfano.
+  const minima = siguiente ? siguiente.profundidad : 0;
+
+  const profundidad = Math.max(minima, Math.min(deseada, maxima));
+
+  // El padre es el ancestro más cercano por encima con profundidad = profundidad-1.
+  let padreId: string | null = null;
+  if (profundidad > 0 && anterior) {
+    if (anterior.profundidad === profundidad - 1) {
+      padreId = anterior.id;
+    } else {
+      // Subir por la lista hasta encontrar el nodo del nivel padre.
+      const candidato = movidos
+        .slice(0, idxOver)
+        .reverse()
+        .find((i) => i.profundidad === profundidad - 1);
+      padreId = candidato?.id ?? null;
+    }
+  }
+
+  return { profundidad, padreId };
+}
+
+/**
+ * Posición (orden) que ocupará entre sus nuevos hermanos.
+ *
+ * El servidor compacta los órdenes de los hermanos, así que basta con el índice
+ * dentro del nuevo padre.
+ */
+export function ordenDestino(
+  items: NodoPlano[],
+  activeId: string,
+  overId: string,
+  padreId: string | null,
+): number {
+  const idxOver = items.findIndex((i) => i.id === overId);
+  const idxActive = items.findIndex((i) => i.id === activeId);
+  const movidos = [...items];
+  const [arrastrado] = movidos.splice(idxActive, 1);
+  movidos.splice(idxOver, 0, arrastrado);
+
+  const hermanos = movidos.filter((i) => i.padreId === padreId && i.id !== activeId);
+  // Cuántos hermanos quedan por encima de la posición de caída.
+  const posicionFinal = movidos.findIndex((i) => i.id === activeId);
+  let orden = 0;
+  for (const h of hermanos) {
+    if (movidos.findIndex((i) => i.id === h.id) < posicionFinal) orden++;
+  }
+  return orden;
+}

--- a/packages/web/src/components/dashboard/pages/ActividadesGrupoPage/ActividadesGrupoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ActividadesGrupoPage/ActividadesGrupoPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useParams, useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -227,7 +228,7 @@ export default function ActividadesGrupoPage() {
   }
 
   async function handleDelete(item: ActividadEvaluacionData) {
-    if (!confirm(`¿Eliminar "${item.nombre}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar "${item.nombre}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${baseUrl}/${item.id}`, {
         method: 'DELETE',

--- a/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
@@ -139,7 +140,7 @@ export default function ActividadesPage() {
   }
 
   async function handleDelete(item: ActividadEvaluacionData) {
-    if (!confirm(`¿Eliminar "${item.nombre}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar "${item.nombre}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/actividades-evaluacion/${item.id}`, {
         method: 'DELETE',

--- a/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.module.css
+++ b/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.module.css
@@ -1,7 +1,11 @@
+/* Alto fijo al viewport: el editor embebido crece hasta el fondo y scrollea por
+   dentro, en vez de estirar la página y dejar el código fuera de la vista. */
 .page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 14px;
+  height: calc(100vh - var(--dashboard-header-height) - 48px);
+  min-height: 0;
 }
 
 .header {
@@ -48,22 +52,75 @@
   font-size: 14px;
 }
 
-.split {
-  display: grid;
-  grid-template-columns: minmax(280px, 380px) 1fr;
-  gap: 16px;
-  align-items: start;
-}
-@media (max-width: 900px) {
-  .split { grid-template-columns: 1fr; }
-}
-
-.arbolPanel,
-.detallePanel {
+/* ── Panel de metadatos (colapsable) ── */
+.metaPanel {
   background: var(--bg-card, #fff);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  padding: 16px;
+  padding: 12px 16px;
+  flex-shrink: 0;
+}
+
+.metaSummary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  user-select: none;
+}
+.metaSummary::-webkit-details-marker {
+  display: none;
+}
+.metaSummary::after {
+  content: '▾';
+  margin-left: auto;
+  font-size: 14px;
+  transition: transform 0.15s;
+}
+.metaPanel[open] .metaSummary::after {
+  transform: rotate(180deg);
+}
+
+/* El título de la página seleccionada, visible aun con el panel plegado. */
+.metaSummaryTitulo {
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metaPanel[open] .metaGrid {
+  margin-top: 14px;
+}
+
+/* ── Editor embebido: ocupa el alto restante ── */
+.editorWrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Sin selección ── */
+.vacio {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .panelTitulo {

--- a/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ColeccionDetailPage/ColeccionDetailPage.tsx
@@ -1,256 +1,76 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useParams, Link } from 'react-router';
+import { useState, useMemo, Suspense, lazy } from 'react';
+import { useParams, useSearchParams, Link } from 'react-router';
 import { useAuth } from '../../../../context/AuthContext';
+import { useColeccionArbol } from '../../../../context/ColeccionArbolContext';
 import Modal from '../../atoms/Modal/Modal';
 import Icon from '../../atoms/Icon/Icon';
 import DashButton from '../../atoms/DashButton/DashButton';
 import DocumentoForm, { aplanarCategorias, type DocumentoSavePayload } from '../../organisms/DocumentoForm/DocumentoForm';
-import { slugify, slugifyInput } from '../../../../utils/slug';
-import { buildArbol } from '../../../../types/contenidos';
-import type { ColeccionData, DocumentoData, DocumentoNodo, DocumentoPlantilla } from '../../../../types/contenidos';
 import styles from './ColeccionDetailPage.module.css';
+
+// CodeMirror + el pipeline de render pesan: solo se cargan cuando hay una página
+// seleccionada (al mirar una categoría no se descarga nada).
+const EditorContenido = lazy(() => import('../EditorContenidoPage/EditorContenidoPage'));
 
 const API_BASE = '/api';
 
-const ICONO_TIPO: Record<string, string> = {
-  md: 'article',
-  html: 'code',
-  categoria: 'folder',
-};
-
-/** Admin del CMS "Contenidos": árbol de páginas de una colección (design §5.2). */
+/**
+ * Admin del CMS "Contenidos": el editor de la página seleccionada.
+ *
+ * Aquí ya no hay panel de metadatos. Todo lo que había se movió a donde se usa:
+ * el título se renombra con doble clic en el árbol, el orden y el padre se
+ * cambian arrastrando, el slug y el borrado son acciones del nodo, y la
+ * plantilla vive en la toolbar del editor. El árbol lo pinta el sidebar
+ * (ArbolContenidos) y comparte datos con esta página vía ColeccionArbolContext.
+ *
+ * La selección viaja en la URL (`?doc=<id>`).
+ */
 export default function ColeccionDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const { sessionToken } = useAuth();
+  const { coleccion, documentos, arbol, cargando, refetch } = useColeccionArbol();
 
-  const [coleccion, setColeccion] = useState<ColeccionData | null>(null);
-  const [documentos, setDocumentos] = useState<DocumentoData[]>([]);
-  const [loading, setLoading] = useState(true);
+  const seleccionadoId = searchParams.get('doc');
+
   const [error, setError] = useState('');
-  const [seleccionadoId, setSeleccionadoId] = useState<string | null>(null);
-  const [expandidos, setExpandidos] = useState<Set<string>>(new Set());
   const [modalOpen, setModalOpen] = useState(false);
   const [modalError, setModalError] = useState('');
   const [saving, setSaving] = useState(false);
 
-  // Metadatos del documento seleccionado (edición en panel)
-  const [metaTitulo, setMetaTitulo] = useState('');
-  const [metaSlug, setMetaSlug] = useState('');
-  const [metaPlantilla, setMetaPlantilla] = useState<'' | DocumentoPlantilla>('');
-  const [moverA, setMoverA] = useState('');
-
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-    'x-session-token': sessionToken ?? '',
-  };
-
-  const fetchDatos = useCallback(async () => {
-    if (!id) return;
-    try {
-      setLoading(true);
-      const auth = { 'x-session-token': sessionToken ?? '' };
-      const [colRes, docsRes] = await Promise.all([
-        fetch(`${API_BASE}/admin/colecciones`, { headers: auth }),
-        fetch(`${API_BASE}/admin/colecciones/${id}/documentos`, { headers: auth }),
-      ]);
-      if (!colRes.ok || !docsRes.ok) throw new Error('Error al cargar la colección');
-      const colJson = await colRes.json();
-      const docsJson = await docsRes.json();
-      const encontrada = (colJson.colecciones ?? []).find((c: ColeccionData) => c.id === id) ?? null;
-      if (!encontrada) throw new Error('Colección no encontrada');
-      setColeccion(encontrada);
-      setDocumentos(docsJson.documentos ?? []);
-    } catch (err: any) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [id, sessionToken]);
-
-  useEffect(() => {
-    fetchDatos();
-  }, [fetchDatos]);
-
-  const arbol = useMemo(() => buildArbol(documentos), [documentos]);
   const categorias = useMemo(() => aplanarCategorias(arbol), [arbol]);
   const seleccionado = useMemo(
     () => documentos.find((d) => d.id === seleccionadoId) ?? null,
     [documentos, seleccionadoId],
   );
 
-  // Descendientes del seleccionado: destinos inválidos de "Mover a"
-  // (el server los rechazaría con el anti-ciclo; mejor ni ofrecerlos).
-  const descendientesSeleccionado = useMemo(() => {
-    const out = new Set<string>();
-    if (!seleccionadoId) return out;
-    const hijosPor = new Map<string | null, DocumentoData[]>();
-    for (const d of documentos) {
-      const key = d.padreId ?? null;
-      if (!hijosPor.has(key)) hijosPor.set(key, []);
-      hijosPor.get(key)!.push(d);
-    }
-    const pila = [seleccionadoId];
-    while (pila.length) {
-      const actual = pila.pop()!;
-      for (const hijo of hijosPor.get(actual) ?? []) {
-        if (!out.has(hijo.id)) {
-          out.add(hijo.id);
-          pila.push(hijo.id);
-        }
-      }
-    }
-    return out;
-  }, [documentos, seleccionadoId]);
-
-  // Sincronizar el panel de metadatos al seleccionar (el cuerpo se edita en
-  // la página del editor: /admin/contenidos/:id/editar/:docId).
-  useEffect(() => {
-    if (!seleccionado) return;
-    setMetaTitulo(seleccionado.titulo);
-    setMetaSlug(seleccionado.slug);
-    setMetaPlantilla(seleccionado.plantilla ?? '');
-    setMoverA(seleccionado.padreId ?? '');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seleccionadoId]);
-
-  function toggleExpandido(docId: string) {
-    setExpandidos((prev) => {
-      const next = new Set(prev);
-      if (next.has(docId)) next.delete(docId);
-      else next.add(docId);
-      return next;
-    });
-  }
-
-  /** Ejecuta la petición y devuelve el mensaje de error (o null si fue bien). */
-  async function llamada(url: string, method: string, body?: unknown): Promise<string | null> {
-    try {
-      const res = await fetch(url, { method, headers, body: body === undefined ? undefined : JSON.stringify(body) });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        return err.message || 'Error en la operación';
-      }
-      return null;
-    } catch (err: any) {
-      return err.message || 'Error en la operación';
-    }
-  }
-
   async function handleCrear(data: DocumentoSavePayload) {
     setSaving(true);
-    const err = await llamada(`${API_BASE}/admin/colecciones/${id}/documentos`, 'POST', data);
-    setSaving(false);
-    if (err) {
-      // Dentro del modal: un error en la página quedaría oculto tras el overlay.
-      setModalError(err);
-      return;
+    try {
+      const res = await fetch(`${API_BASE}/admin/colecciones/${id}/documentos`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-session-token': sessionToken ?? '' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        // Dentro del modal: un error en la página quedaría oculto tras el overlay.
+        setModalError(err.message || 'Error al crear');
+        return;
+      }
+      setModalError('');
+      setModalOpen(false);
+      await refetch();
+    } catch (err: any) {
+      setModalError(err.message || 'Error al crear');
+    } finally {
+      setSaving(false);
     }
-    setModalError('');
-    setModalOpen(false);
-    if (data.padreId) setExpandidos((prev) => new Set(prev).add(data.padreId!));
-    await fetchDatos();
   }
 
-  async function handleGuardarMeta() {
-    if (!seleccionado) return;
-    setError('');
-    const err = await llamada(`${API_BASE}/admin/documentos/${seleccionado.id}`, 'PUT', {
-      titulo: metaTitulo,
-      slug: slugify(metaSlug),
-      plantilla: metaPlantilla || null,
-    });
-    if (err) setError(err);
-    else await fetchDatos();
+  if (cargando && documentos.length === 0) {
+    return <div className={styles.page}><p>Cargando...</p></div>;
   }
-
-  /** Hermanos del seleccionado (mismo padre), ordenados. */
-  function hermanosDe(doc: DocumentoData): DocumentoData[] {
-    return documentos
-      .filter((d) => (d.padreId ?? null) === (doc.padreId ?? null))
-      .sort((a, b) => a.orden - b.orden);
-  }
-
-  async function handleReordenar(direccion: -1 | 1) {
-    if (!seleccionado) return;
-    const hermanos = hermanosDe(seleccionado);
-    const idx = hermanos.findIndex((h) => h.id === seleccionado.id);
-    const destino = idx + direccion;
-    if (destino < 0 || destino >= hermanos.length) return;
-    setError('');
-    const err = await llamada(`${API_BASE}/admin/documentos/${seleccionado.id}/mover`, 'PUT', {
-      padreId: seleccionado.padreId,
-      orden: destino,
-    });
-    if (err) setError(err);
-    else await fetchDatos();
-  }
-
-  async function handleMoverA() {
-    if (!seleccionado) return;
-    const nuevoPadre = moverA || null;
-    if ((seleccionado.padreId ?? null) === nuevoPadre) return;
-    setError('');
-    const err = await llamada(`${API_BASE}/admin/documentos/${seleccionado.id}/mover`, 'PUT', {
-      padreId: nuevoPadre,
-      orden: documentos.length, // al final; el server lo acota a los hermanos reales
-    });
-    if (err) {
-      setError(err);
-      return;
-    }
-    if (nuevoPadre) setExpandidos((prev) => new Set(prev).add(nuevoPadre));
-    await fetchDatos();
-  }
-
-  async function handleEliminar() {
-    if (!seleccionado) return;
-    if (!confirm(`¿Eliminar "${seleccionado.titulo}"? Esta acción no se puede deshacer.`)) return;
-    setError('');
-    const err = await llamada(`${API_BASE}/admin/documentos/${seleccionado.id}`, 'DELETE');
-    if (err) {
-      setError(err);
-      return;
-    }
-    setSeleccionadoId(null);
-    await fetchDatos();
-  }
-
-  function renderNodo(nodo: DocumentoNodo, nivel: number) {
-    const esCategoria = nodo.tipo === 'categoria';
-    const abierto = expandidos.has(nodo.id);
-    return (
-      <div key={nodo.id}>
-        <div
-          className={`${styles.nodo} ${seleccionadoId === nodo.id ? styles.nodoActivo : ''}`}
-          style={{ paddingLeft: 8 + nivel * 18 }}
-          onClick={() => setSeleccionadoId(nodo.id)}
-        >
-          {esCategoria ? (
-            <button
-              type="button"
-              className={styles.chevron}
-              onClick={(e) => { e.stopPropagation(); toggleExpandido(nodo.id); }}
-              aria-label={abierto ? 'Colapsar' : 'Expandir'}
-            >
-              <Icon name={abierto ? 'expand_more' : 'chevron_right'} size="sm" />
-            </button>
-          ) : (
-            <span className={styles.chevronHueco} />
-          )}
-          <Icon name={ICONO_TIPO[nodo.tipo]} size="sm" />
-          <span className={styles.nodoTitulo} title={nodo.titulo}>{nodo.titulo}</span>
-          {!esCategoria && (
-            <span className={`${styles.estado} ${nodo.publicado ? styles.estadoPub : styles.estadoBorr}`}>
-              {nodo.publicado ? 'publicada' : 'borrador'}
-            </span>
-          )}
-        </div>
-        {esCategoria && abierto && nodo.hijos.map((h) => renderNodo(h, nivel + 1))}
-      </div>
-    );
-  }
-
-  if (loading) return <div className={styles.page}><p>Cargando...</p></div>;
 
   return (
     <div className={styles.page}>
@@ -267,92 +87,39 @@ export default function ColeccionDetailPage() {
         </div>
       </div>
 
-      {error && <div className={styles.error}>{error}</div>}
+      {error && <div className={styles.error} onClick={() => setError('')}>{error}</div>}
 
-      <div className={styles.split}>
-        <div className={styles.arbolPanel}>
-          <div className={styles.panelTitulo}>Árbol de páginas</div>
-          {arbol.length === 0 ? (
-            <p className={styles.hint}>Aún no hay páginas. Crea la primera con "+ Página / Categoría".</p>
-          ) : (
-            arbol.map((n) => renderNodo(n, 0))
-          )}
+      {!seleccionado ? (
+        <div className={styles.vacio}>
+          <Icon name="menu_book" size="lg" />
+          <p>Selecciona una página en el árbol para editarla.</p>
+          <p className={styles.hint}>
+            {documentos.length === 0
+              ? 'Esta colección aún no tiene páginas. Crea la primera con "+ Página / Categoría".'
+              : 'Doble clic para renombrar · arrastra para mover o cambiar de nivel.'}
+          </p>
         </div>
-
-        <div className={styles.detallePanel}>
-          {!seleccionado ? (
-            <p className={styles.hint}>Selecciona una página del árbol para editarla.</p>
-          ) : (
-            <>
-              <div className={styles.panelTitulo}>
-                {seleccionado.tipo === 'categoria' ? 'Categoría' : `Página (${seleccionado.tipo})`}
-              </div>
-
-              <div className={styles.metaGrid}>
-                <label className={styles.campo}>
-                  <span>Título</span>
-                  <input className={styles.input} value={metaTitulo} onChange={(e) => setMetaTitulo(e.target.value)} />
-                </label>
-                <label className={styles.campo}>
-                  <span>Slug</span>
-                  <input className={styles.input} value={metaSlug} onChange={(e) => setMetaSlug(slugifyInput(e.target.value))} />
-                </label>
-                {seleccionado.tipo === 'md' && (
-                  <label className={styles.campo}>
-                    <span>Plantilla</span>
-                    <select className={styles.input} value={metaPlantilla} onChange={(e) => setMetaPlantilla(e.target.value as '' | DocumentoPlantilla)}>
-                      <option value="">Sin plantilla</option>
-                      <option value="laboratorio">Laboratorio</option>
-                      <option value="lectura">Lectura</option>
-                      <option value="temario">Temario</option>
-                    </select>
-                  </label>
-                )}
-              </div>
-
-              <div className={styles.accionesFila}>
-                <DashButton variant="outline" onClick={handleGuardarMeta}>Guardar cambios</DashButton>
-                <DashButton variant="outline" onClick={() => handleReordenar(-1)}>↑ Subir</DashButton>
-                <DashButton variant="outline" onClick={() => handleReordenar(1)}>↓ Bajar</DashButton>
-                <DashButton variant="outline" onClick={handleEliminar}>Eliminar</DashButton>
-              </div>
-
-              <div className={styles.moverFila}>
-                <span className={styles.moverLabel}>Mover a</span>
-                <select className={styles.input} value={moverA} onChange={(e) => setMoverA(e.target.value)}>
-                  <option value="">Raíz de la colección</option>
-                  {categorias
-                    .filter((c) => c.id !== seleccionado.id && !descendientesSeleccionado.has(c.id))
-                    .map((c) => (
-                      <option key={c.id} value={c.id}>{c.label}</option>
-                    ))}
-                </select>
-                <DashButton variant="outline" onClick={handleMoverA}>Mover</DashButton>
-              </div>
-
-              {seleccionado.tipo !== 'categoria' && (
-                <div className={styles.editor}>
-                  <div className={styles.editorBarra}>
-                    <span className={styles.panelTitulo}>
-                      Cuerpo ({seleccionado.tipo === 'md' ? 'Markdown' : 'HTML'})
-                    </span>
-                    <span className={styles.editorEstado}>
-                      {seleccionado.borradorId ? 'Borrador en curso' : seleccionado.publicado ? 'Publicada' : 'Sin contenido publicado'}
-                    </span>
-                    <Link to={`/admin/contenidos/${id}/editar/${seleccionado.id}`} className={styles.abrirEditor}>
-                      <Icon name="edit_note" size="sm" />
-                      <span>Abrir editor</span>
-                    </Link>
-                  </div>
-                  <p className={styles.hint}>
-                    El contenido se edita en el editor (resaltado, preview en vivo, publicar e historial).
-                  </p>
-                </div>
-              )}
-            </>
-          )}
+      ) : seleccionado.tipo === 'categoria' ? (
+        <div className={styles.vacio}>
+          <Icon name="folder" size="lg" />
+          <p>«{seleccionado.titulo}» es una categoría: solo agrupa páginas, no tiene contenido.</p>
+          <p className={styles.hint}>Doble clic en el árbol para renombrarla · arrástrala para moverla.</p>
         </div>
-      </div>
+      ) : (
+        <div className={styles.editorWrap}>
+          <Suspense fallback={<p className={styles.hint}>Cargando editor…</p>}>
+            {/* key: al cambiar de página se remonta el editor. Sin esto, su estado
+                interno (cuerpo, historial de deshacer) se arrastraría de un
+                documento al siguiente. El desmontaje vacía el autosave pendiente. */}
+            <EditorContenido
+              key={seleccionado.id}
+              coleccionId={id}
+              docId={seleccionado.id}
+              embebido
+            />
+          </Suspense>
+        </div>
+      )}
 
       <Modal isOpen={modalOpen} onClose={() => { setModalOpen(false); setModalError(''); }} title="Nueva página o categoría">
         <DocumentoForm

--- a/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
@@ -132,7 +133,7 @@ export default function CompetenciasPage() {
   }
 
   async function handleDeleteInd(ind: IndicacionData) {
-    if (!confirm(`¿Eliminar esta indicación? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar esta indicación?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/indicaciones-malla/${ind.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');
@@ -184,7 +185,7 @@ export default function CompetenciasPage() {
   }
 
   async function handleDeleteComp(comp: CompetenciaData) {
-    if (!confirm(`¿Eliminar la competencia "${comp.competencia}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar la competencia "${comp.competencia}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/competencias/${comp.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -87,7 +88,7 @@ export default function ContenidosPage() {
   }
 
   async function handleDelete(coleccion: ColeccionData) {
-    if (!confirm(`¿Eliminar la colección "${coleccion.nombre}"? Sus páginas dejarán de ser accesibles.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar la colección "${coleccion.nombre}"?`, texto: `Sus páginas dejarán de ser accesibles.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/colecciones/${coleccion.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.module.css
@@ -5,6 +5,14 @@
   height: calc(100vh - var(--dashboard-header-height) - 48px);
 }
 
+/* Embebido en la página de la colección, el alto ya no puede calcularse contra
+   el viewport (el editor no es el único hijo del <main>): lo pone el contenedor
+   anfitrión. */
+.embebido {
+  height: 100%;
+  min-height: 0;
+}
+
 /* ── Header ── */
 .header {
   display: flex;
@@ -108,6 +116,41 @@
   color: var(--text-muted);
 }
 
+.plantillaSelect {
+  padding: 4px 6px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-card, #fff);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+/* ── Selector de vista (código / ambos / preview) ── */
+.vistaGrupo {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 8px;
+  padding: 2px;
+  background: var(--bg-page);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+.vistaGrupo button {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.vistaActiva,
+.vistaGrupo button.vistaActiva:hover {
+  background: var(--bg-card, #fff);
+  color: var(--dash-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+
 /* ── Split fuente/preview ── */
 .split {
   display: grid;
@@ -116,6 +159,23 @@
   flex: 1;
   min-height: 0;
 }
+
+/* Al colapsar una mitad, la otra ocupa todo. El panel oculto se esconde con
+   `display:none` (ver .oculto) pero NO se desmonta: así CodeMirror conserva el
+   deshacer y el cursor al alternar. */
+.split-codigo,
+.split-preview {
+  grid-template-columns: 1fr;
+}
+
+/* Compuesto a propósito: `.fuente` y `.preview` declaran su propio `display`
+   más abajo en este archivo. Con un `.oculto` suelto (misma especificidad)
+   ganaría el que va después y el panel seguiría visible. */
+.fuente.oculto,
+.preview.oculto {
+  display: none;
+}
+
 @media (max-width: 900px) {
   .split { grid-template-columns: 1fr; }
 }

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useParams, Link } from 'react-router';
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { markdown } from '@codemirror/lang-markdown';
@@ -19,6 +20,15 @@ const AUTOSAVE_MS = 1500;
 const PREVIEW_MS = 300;
 
 type EstadoGuardado = 'cargando' | 'guardado' | 'dirty' | 'guardando' | 'error';
+
+/** Qué mitades del split se ven. 'ambos' es el comportamiento de siempre. */
+type Vista = 'codigo' | 'ambos' | 'preview';
+const VISTA_KEY = 'cms:editor:vista';
+
+function leerVista(): Vista {
+  const v = localStorage.getItem(VISTA_KEY);
+  return v === 'codigo' || v === 'preview' ? v : 'ambos';
+}
 
 interface VersionInfo {
   id: string;
@@ -44,13 +54,31 @@ function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
+interface EditorProps {
+  /**
+   * Cuando el editor va embebido (dentro de la página de la colección) recibe
+   * los ids por props; como ruta propia los saca de useParams. Embebido, además,
+   * no pinta su cabecera de página completa ni calcula su alto contra el
+   * viewport: se adapta al contenedor.
+   */
+  coleccionId?: string;
+  docId?: string;
+  embebido?: boolean;
+}
+
 /**
  * Editor del CMS "Contenidos" (design §3): CodeMirror + preview en vivo con
  * el MISMO pipeline unified que renderiza al publicar — WYSIWYG real.
  * Autosave a borrador único; publicar congela una versión; historial/restaurar.
  */
-export default function EditorContenidoPage() {
-  const { id, docId } = useParams<{ id: string; docId: string }>();
+export default function EditorContenidoPage({
+  coleccionId: propColeccionId,
+  docId: propDocId,
+  embebido = false,
+}: EditorProps = {}) {
+  const params = useParams<{ id: string; docId: string }>();
+  const id = propColeccionId ?? params.id;
+  const docId = propDocId ?? params.docId;
   const { sessionToken } = useAuth();
   const editorRef = useRef<ReactCodeMirrorRef>(null);
 
@@ -59,6 +87,14 @@ export default function EditorContenidoPage() {
   const [estado, setEstado] = useState<EstadoGuardado>('cargando');
   const [error, setError] = useState('');
   const [previewHtml, setPreviewHtml] = useState('');
+  // Se recuerda entre sesiones: quien escribe en una pantalla chica no quiere
+  // volver a colapsar el preview cada vez que entra.
+  const [vista, setVistaState] = useState<Vista>(leerVista);
+
+  function setVista(v: Vista) {
+    setVistaState(v);
+    localStorage.setItem(VISTA_KEY, v);
+  }
 
   const [publicarOpen, setPublicarOpen] = useState(false);
   const [mensajePublicar, setMensajePublicar] = useState('');
@@ -129,10 +165,37 @@ export default function EditorContenidoPage() {
 
   useEffect(() => {
     cargar();
-    // Al cambiar de documento (o desmontar), un timer pendiente del documento
-    // ANTERIOR escribiría el cuerpo del nuevo en el borrador equivocado.
-    return () => cancelarAutosave();
-  }, [cargar]);
+    // Al cambiar de documento (o desmontar) hay que resolver un autosave que
+    // siga en el debounce. Cancelarlo a secas —como se hacía— PERDÍA hasta
+    // AUTOSAVE_MS de escritura. Pero dejar correr el timer tampoco vale: para
+    // cuando dispare, `cuerpoRef` ya apunta al cuerpo del documento NUEVO y lo
+    // escribiría en el borrador del viejo.
+    //
+    // Así que se vacía a mano, con los valores del documento que dejamos: el
+    // cleanup cierra sobre el `docId` de este efecto, y `cuerpoRef.current`
+    // todavía no ha sido reemplazado (`cargar()` del nuevo documento es async y
+    // corre después). Se encadena al PUT en vuelo para no romper el
+    // single-flight.
+    return () => {
+      const habiaPendiente = autosaveTimer.current !== null;
+      cancelarAutosave();
+      if (!habiaPendiente || !docId || !documentoRef.current) return;
+
+      const cuerpoPendiente = cuerpoRef.current;
+      const enVuelo = saveEnVuelo.current;
+      const flush = (enVuelo ? enVuelo.catch(() => {}) : Promise.resolve()).then(() =>
+        fetch(`${API_BASE}/admin/documentos/${docId}/borrador`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', 'x-session-token': sessionToken ?? '' },
+          body: JSON.stringify({ cuerpo: cuerpoPendiente }),
+        }).then(() => undefined),
+      );
+      // No se puede await en un cleanup: se deja en vuelo, pero registrado, para
+      // que el siguiente guardado del MISMO documento no adelante a éste.
+      saveEnVuelo.current = flush.then(() => true).catch(() => false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cargar, docId, sessionToken]);
 
   /* ── Autosave debounced a borrador único ── */
   const guardar = useCallback(async (): Promise<boolean> => {
@@ -184,6 +247,27 @@ export default function EditorContenidoPage() {
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, []);
+
+  /* ── Plantilla ──
+     Vive en la toolbar (y no en un panel de metadatos aparte) porque es una
+     propiedad del contenido: se decide mientras se escribe. */
+  async function cambiarPlantilla(valor: string) {
+    if (!docId || !documento) return;
+    const plantilla = (valor || null) as DocumentoData['plantilla'];
+    const previo = documento.plantilla;
+    setDocumento({ ...documento, plantilla }); // optimista
+    try {
+      const res = await fetch(`${API_BASE}/admin/documentos/${docId}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ plantilla }),
+      });
+      if (!res.ok) throw new Error();
+    } catch {
+      setDocumento((d) => (d ? { ...d, plantilla: previo } : d)); // revertir
+      setError('No se pudo cambiar la plantilla.');
+    }
+  }
 
   /* ── Preview en vivo (solo Markdown; el HTML crudo se sirve sandboxeado en US-5) ── */
   const esMd = documento?.tipo === 'md';
@@ -297,7 +381,7 @@ export default function EditorContenidoPage() {
   }
 
   async function eliminarRecurso(r: RecursoInfo) {
-    if (!confirm(`¿Eliminar "${r.nombre}"? Las páginas que lo referencien mostrarán un enlace roto.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar "${r.nombre}"?`, texto: `Las páginas que lo referencien mostrarán un enlace roto.`, confirmar: 'Eliminar', peligro: true }))) return;
     setRecursosError('');
     try {
       const res = await fetch(`${API_BASE}/admin/recursos/${r.id}`, { method: 'DELETE', headers });
@@ -378,7 +462,7 @@ export default function EditorContenidoPage() {
   }
 
   async function restaurarVersion(v: VersionInfo) {
-    if (!confirm(`¿Restaurar la v${v.numero} al borrador? El contenido actual del borrador se reemplaza.`)) return;
+    if (!(await confirmar({ titulo: `¿Restaurar la v${v.numero} al borrador?`, texto: `El contenido actual del borrador se reemplaza.` }))) return;
     // Un autosave pendiente (timer) o en vuelo (PUT) aterrizaría DESPUÉS del
     // restore y pisaría el borrador restaurado.
     cancelarAutosave();
@@ -415,11 +499,21 @@ export default function EditorContenidoPage() {
   }
 
   return (
-    <div className={styles.page} onKeyDown={onKeyDown}>
+    <div className={`${styles.page} ${embebido ? styles.embebido : ''}`} onKeyDown={onKeyDown}>
       <div className={styles.header}>
-        <Link to={`/admin/contenidos/${id}`} className={styles.volver}>
-          <Icon name="arrow_back" size="sm" />
-        </Link>
+        {embebido ? (
+          <Link
+            to={`/admin/contenidos/${id}/editar/${docId}`}
+            className={styles.volver}
+            title="Abrir a pantalla completa"
+          >
+            <Icon name="open_in_full" size="sm" />
+          </Link>
+        ) : (
+          <Link to={`/admin/contenidos/${id}`} className={styles.volver} title="Volver a la colección">
+            <Icon name="arrow_back" size="sm" />
+          </Link>
+        )}
         <div className={styles.tituloWrap}>
           <span className={styles.titulo} title={documento?.titulo}>{documento?.titulo ?? '…'}</span>
           <span className={styles.subtitulo}>
@@ -462,6 +556,53 @@ export default function EditorContenidoPage() {
             {subiendo ? '⏳ Subiendo…' : '🖼️ Subir'}
           </button>
           <button type="button" title="Recursos del documento" onClick={abrirRecursos}>📎 Recursos</button>
+
+          <span className={styles.sep} />
+          <select
+            className={styles.plantillaSelect}
+            value={documento?.plantilla ?? ''}
+            onChange={(e) => cambiarPlantilla(e.target.value)}
+            disabled={!documento}
+            title="Plantilla de la página"
+          >
+            <option value="">Sin plantilla</option>
+            <option value="laboratorio">Laboratorio</option>
+            <option value="lectura">Lectura</option>
+            <option value="temario">Temario</option>
+          </select>
+
+          {/* Colapsar código o preview. Solo en Markdown: el HTML crudo no tiene
+              preview en vivo, así que no hay nada entre lo que elegir. */}
+          <div className={styles.vistaGrupo} role="group" aria-label="Vista del editor">
+            <button
+              type="button"
+              className={vista === 'codigo' ? styles.vistaActiva : ''}
+              onClick={() => setVista('codigo')}
+              title="Solo código"
+              aria-pressed={vista === 'codigo'}
+            >
+              <Icon name="code" size="sm" />
+            </button>
+            <button
+              type="button"
+              className={vista === 'ambos' ? styles.vistaActiva : ''}
+              onClick={() => setVista('ambos')}
+              title="Código y vista previa"
+              aria-pressed={vista === 'ambos'}
+            >
+              <Icon name="vertical_split" size="sm" />
+            </button>
+            <button
+              type="button"
+              className={vista === 'preview' ? styles.vistaActiva : ''}
+              onClick={() => setVista('preview')}
+              title="Solo vista previa"
+              aria-pressed={vista === 'preview'}
+            >
+              <Icon name="visibility" size="sm" />
+            </button>
+          </div>
+
           <span className={styles.atajos}>⌘S guardar · ⌘⇧P publicar</span>
         </div>
       )}
@@ -476,34 +617,51 @@ export default function EditorContenidoPage() {
         }}
       />
 
-      <div className={styles.split}>
-        <div className={styles.fuente} onPaste={onPasteFuente}>
-          <CodeMirror
-            ref={editorRef}
-            value={cuerpo}
-            onChange={onCambio}
-            editable={documento !== null && estado !== 'cargando'}
-            theme={oneDark}
-            extensions={[esMd ? markdown() : html(), EditorView.lineWrapping]}
-            basicSetup={{ foldGutter: true, highlightActiveLine: true }}
-            className={styles.codemirror}
-          />
-        </div>
-        {esMd ? (
-          <div className={styles.preview}>
-            {/* Seguro: previewHtml SIEMPRE sale de renderMarkdown(), cuyo pipeline
-                aplica rehype-sanitize (allowlist) — scripts/handlers/iframes se
-                eliminan. Es el mismo HTML que servirá producción (design §3). */}
-            <div className="contenido-render" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+      {/* El HTML crudo no tiene preview: se fuerza 'ambos' para que el hint siga
+          apareciendo y el usuario no acabe con un panel vacío por una preferencia
+          que eligió en un documento Markdown. */}
+      {(() => {
+        const vistaEfectiva: Vista = esMd ? vista : 'ambos';
+        const verCodigo = vistaEfectiva !== 'preview';
+        const verPreview = vistaEfectiva !== 'codigo';
+        return (
+          <div className={`${styles.split} ${styles[`split-${vistaEfectiva}`]}`}>
+            {/* El editor se mantiene MONTADO aunque esté oculto: desmontarlo
+                tiraría el historial de deshacer de CodeMirror y la posición del
+                cursor cada vez que alternas de vista. */}
+            <div
+              className={`${styles.fuente} ${!verCodigo ? styles.oculto : ''}`}
+              onPaste={onPasteFuente}
+              aria-hidden={!verCodigo}
+            >
+              <CodeMirror
+                ref={editorRef}
+                value={cuerpo}
+                onChange={onCambio}
+                editable={documento !== null && estado !== 'cargando'}
+                theme={oneDark}
+                extensions={[esMd ? markdown() : html(), EditorView.lineWrapping]}
+                basicSetup={{ foldGutter: true, highlightActiveLine: true }}
+                className={styles.codemirror}
+              />
+            </div>
+            {esMd ? (
+              <div className={`${styles.preview} ${!verPreview ? styles.oculto : ''}`} aria-hidden={!verPreview}>
+                {/* Seguro: previewHtml SIEMPRE sale de renderMarkdown(), cuyo pipeline
+                    aplica rehype-sanitize (allowlist) — scripts/handlers/iframes se
+                    eliminan. Es el mismo HTML que servirá producción (design §3). */}
+                <div className="contenido-render" dangerouslySetInnerHTML={{ __html: previewHtml }} />
+              </div>
+            ) : (
+              <div className={styles.preview}>
+                <p className={styles.hint}>
+                  Las páginas HTML se muestran sandboxeadas en el visor (iframe aislado, US-5) — sin preview en vivo aquí.
+                </p>
+              </div>
+            )}
           </div>
-        ) : (
-          <div className={styles.preview}>
-            <p className={styles.hint}>
-              Las páginas HTML se muestran sandboxeadas en el visor (iframe aislado, US-5) — sin preview en vivo aquí.
-            </p>
-          </div>
-        )}
-      </div>
+        );
+      })()}
 
       {/* ── Modal publicar ── */}
       <Modal isOpen={publicarOpen} onClose={() => setPublicarOpen(false)} title="Publicar versión">

--- a/packages/web/src/components/dashboard/pages/EntrevistasPage/EntrevistasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EntrevistasPage/EntrevistasPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useParams, useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -164,7 +165,7 @@ export default function EntrevistasPage() {
   }
 
   async function handleDelete(entrevista: EntrevistaData) {
-    if (!confirm(`¿Eliminar la entrevista del equipo "${entrevista.equipo.nombre}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar la entrevista del equipo "${entrevista.equipo.nombre}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${grupoId}/entrevistas/${entrevista.id}`, {
         method: 'DELETE',

--- a/packages/web/src/components/dashboard/pages/EquiposPage/EquiposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EquiposPage/EquiposPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useParams, useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -120,7 +121,7 @@ export default function EquiposPage() {
   }
 
   async function handleDelete(equipo: EquipoData) {
-    if (!confirm(`¿Eliminar el equipo "${equipo.nombre}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar el equipo "${equipo.nombre}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${grupoId}/equipos/${equipo.id}`, {
         method: 'DELETE',

--- a/packages/web/src/components/dashboard/pages/GrupoDetailPage/GrupoDetailPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GrupoDetailPage/GrupoDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { confirmar, avisar, escapar } from '../../../../utils/dialogos';
 import { useParams, useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -257,7 +258,7 @@ export default function GrupoDetailPage() {
   }, [fetchCalificaciones]);
 
   async function handleCrearCompetencias() {
-    if (!confirm('¿Crear competencias para los alumnos pendientes?')) return;
+    if (!(await confirmar({ titulo: '¿Crear competencias para los alumnos pendientes?', confirmar: 'Crear' }))) return;
     setCreatingCompetencias(true);
     setError('');
     try {
@@ -325,7 +326,7 @@ export default function GrupoDetailPage() {
   }
 
   async function handleCrearMallas() {
-    if (!confirm('¿Crear mallas de evaluación para los alumnos pendientes?')) return;
+    if (!(await confirmar({ titulo: '¿Crear mallas de evaluación para los alumnos pendientes?', confirmar: 'Crear' }))) return;
     setCreatingMallas(true);
     setError('');
     try {
@@ -380,7 +381,14 @@ export default function GrupoDetailPage() {
 
       if (!editAlumno && result.generatedPassword) {
         setCreatedPassword(result.generatedPassword);
-        alert(`Alumno creado. Contraseña generada: ${result.generatedPassword}`);
+        await avisar({
+          titulo: 'Alumno creado',
+          html:
+            'Contraseña generada:<br><code class="swal-codigo">' +
+            escapar(result.generatedPassword) +
+            '</code><span class="swal-aviso">Cópiala ahora: no vuelve a mostrarse.</span>',
+          icono: 'success',
+        });
       }
 
       closeAlumnoModal();
@@ -396,7 +404,7 @@ export default function GrupoDetailPage() {
 
   async function handleToggleActive(alumno: AlumnoData) {
     const action = alumno.active ? 'Desactivar' : 'Activar';
-    if (!confirm(`¿${action} al alumno "${alumno.name}"?`)) return;
+    if (!(await confirmar({ titulo: `¿${action} al alumno "${alumno.name}"?` }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${id}/alumnos/${alumno.id}/archive`, { method: 'PATCH', headers });
       if (!res.ok) throw new Error(`Error al ${action.toLowerCase()}`);
@@ -409,7 +417,7 @@ export default function GrupoDetailPage() {
   }
 
   async function handleDeleteAlumno(alumno: AlumnoData) {
-    if (!confirm(`¿Eliminar al alumno "${alumno.name}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar al alumno "${alumno.name}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${id}/alumnos/${alumno.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');
@@ -473,7 +481,7 @@ export default function GrupoDetailPage() {
       setTimeout(() => setToast(''), 3000);
       return;
     }
-    if (!confirm(`¿Exportar la malla de evaluación de ${targets.length} alumno(s) en un ZIP?`)) return;
+    if (!(await confirmar({ titulo: `¿Exportar la malla de evaluación de ${targets.length} alumno(s) en un ZIP?` }))) return;
 
     setExportingMallas(true);
     setExportProgress(`0/${targets.length}`);

--- a/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -106,7 +107,7 @@ export default function GruposPage() {
 
   async function handleToggleActive(grupo: GrupoData) {
     const action = grupo.active ? 'Desactivar' : 'Activar';
-    if (!confirm(`¿${action} el grupo "${grupo.name}"?`)) return;
+    if (!(await confirmar({ titulo: `¿${action} el grupo "${grupo.name}"?` }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${grupo.id}/archive`, { method: 'PATCH', headers });
       if (!res.ok) throw new Error(`Error al ${action.toLowerCase()}`);
@@ -117,7 +118,7 @@ export default function GruposPage() {
   }
 
   async function handleDelete(grupo: GrupoData) {
-    if (!confirm(`¿Eliminar el grupo "${grupo.name}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar el grupo "${grupo.name}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/grupos/${grupo.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
@@ -164,7 +165,7 @@ export default function PaginasPage() {
   }
 
   async function handleDelete(pagina: PaginaData) {
-    if (!confirm(`¿Eliminar la página "${pagina.titulo}"? Esta acción no se puede deshacer.`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar la página "${pagina.titulo}"?`, texto: `Esta acción no se puede deshacer.`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/paginas/${pagina.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar');
@@ -282,7 +283,7 @@ export default function PaginasPage() {
   }
 
   async function handleDeleteTag(tag: EtiquetaData) {
-    if (!confirm(`¿Eliminar la etiqueta "${tag.nombre}"?`)) return;
+    if (!(await confirmar({ titulo: `¿Eliminar la etiqueta "${tag.nombre}"?`, confirmar: 'Eliminar', peligro: true }))) return;
     try {
       const res = await fetch(`${API_BASE}/admin/etiquetas/${tag.id}`, { method: 'DELETE', headers });
       if (!res.ok) throw new Error('Error al eliminar etiqueta');

--- a/packages/web/src/components/dashboard/pages/PlanEvaluacionPage/PlanEvaluacionPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PlanEvaluacionPage/PlanEvaluacionPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
+import { confirmar } from '../../../../utils/dialogos';
 import { useAuth } from '../../../../context/AuthContext';
 import DashButton from '../../atoms/DashButton/DashButton';
 import styles from './PlanEvaluacionPage.module.css';
@@ -318,15 +319,14 @@ export default function PlanEvaluacionPage() {
     }
     const accion = congelada ? 'congelar' : 'descongelar';
     const nombrePeriodo = periodo.nombre || `Periodo ${periodoIdx + 1}`;
-    if (!confirm(
-      `¿${accion.charAt(0).toUpperCase() + accion.slice(1)} ${ids.length} actividad(es) ` +
-      `seleccionadas en "${nombrePeriodo}"?\n\n` +
-      (congelada
+    const ok = await confirmar({
+      titulo: `¿${accion.charAt(0).toUpperCase() + accion.slice(1)} ${ids.length} actividad(es) seleccionadas en "${nombrePeriodo}"?`,
+      texto: congelada
         ? 'Los alumnos NO podrán modificar la "Semana completada" de estas actividades.'
-        : 'Los alumnos PODRÁN modificar nuevamente la "Semana completada" de estas actividades.')
-    )) {
-      return;
-    }
+        : 'Los alumnos PODRÁN modificar nuevamente la "Semana completada" de estas actividades.',
+      confirmar: accion.charAt(0).toUpperCase() + accion.slice(1),
+    });
+    if (!ok) return;
 
     setBulkBusy((prev) => ({ ...prev, [periodoIdx]: true }));
     setError('');

--- a/packages/web/src/components/dashboard/templates/DashboardLayout/DashboardLayout.tsx
+++ b/packages/web/src/components/dashboard/templates/DashboardLayout/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import Sidebar from '../../organisms/Sidebar/Sidebar';
 import DashboardHeader from '../../organisms/DashboardHeader/DashboardHeader';
 import { useSidebarCollapse } from '../../../../hooks/useSidebarCollapse';
 import { useAuth } from '../../../../context/AuthContext';
+import { ColeccionArbolProvider } from '../../../../context/ColeccionArbolContext';
 import styles from './DashboardLayout.module.css';
 import type { DashboardRole } from '../../../../types/dashboard';
 
@@ -23,15 +24,19 @@ export default function DashboardLayout({ role }: DashboardLayoutProps) {
   }
 
   return (
-    <div className={styles.layout}>
-      <Sidebar role={role} collapsed={collapsed} mobileOpen={mobileOpen} onCloseMobile={closeMobile} />
-      <DashboardHeader role={role} collapsed={collapsed} onToggleSidebar={toggle} />
-      <main
-        className={styles.content}
-        style={{ marginLeft: collapsed ? 'var(--sidebar-width-collapsed)' : 'var(--sidebar-width)' }}
-      >
-        <Outlet />
-      </main>
-    </div>
+    // El provider envuelve Sidebar y Outlet: el árbol de la colección abierta lo
+    // pinta el sidebar y lo muta la página, así que ambos comparten una fuente.
+    <ColeccionArbolProvider>
+      <div className={styles.layout}>
+        <Sidebar role={role} collapsed={collapsed} mobileOpen={mobileOpen} onCloseMobile={closeMobile} />
+        <DashboardHeader role={role} collapsed={collapsed} onToggleSidebar={toggle} />
+        <main
+          className={styles.content}
+          style={{ marginLeft: collapsed ? 'var(--sidebar-width-collapsed)' : 'var(--sidebar-width)' }}
+        >
+          <Outlet />
+        </main>
+      </div>
+    </ColeccionArbolProvider>
   );
 }

--- a/packages/web/src/context/ColeccionArbolContext.tsx
+++ b/packages/web/src/context/ColeccionArbolContext.tsx
@@ -1,0 +1,164 @@
+import { createContext, useContext, useCallback, useEffect, useMemo, useState } from 'react';
+import { useMatch } from 'react-router';
+import { useAuth } from './AuthContext';
+import { buildArbol, type DocumentoData, type ColeccionData, type DocumentoNodo } from '../types/contenidos';
+
+/**
+ * Árbol de páginas de la colección abierta en /admin/contenidos/:id.
+ *
+ * Vive por encima del Sidebar y del <Outlet/> (se monta en DashboardLayout)
+ * porque ambos lo necesitan: el sidebar pinta el árbol y la página edita los
+ * documentos. Sin esto, renombrar o mover una página desde la página dejaría al
+ * sidebar mostrando el árbol viejo.
+ */
+interface ColeccionArbolValue {
+  coleccionId: string | null;
+  coleccion: ColeccionData | null;
+  documentos: DocumentoData[];
+  arbol: DocumentoNodo[];
+  cargando: boolean;
+  error: string;
+  /** Recargar tras una mutación (crear/renombrar/mover/borrar). */
+  refetch: () => Promise<void>;
+
+  /* Mutaciones. Devuelven el mensaje de error, o null si fue bien. Viven aquí
+     —y no en la página— porque ahora quien las dispara es el árbol del sidebar. */
+
+  /**
+   * Renombrar = cambiar SOLO el título. El slug (y por tanto la URL pública) se
+   * queda como está: 82 de 120 documentos tienen un slug que no deriva de su
+   * título (`readme`, herencia de Docusaurus), y hay ~59 enlaces internos
+   * apuntando a esas rutas sin ningún redirect que los cubra. Regenerar el slug
+   * al renombrar los rompería en silencio.
+   */
+  renombrar: (docId: string, titulo: string) => Promise<string | null>;
+  /** Cambiar el slug SÍ cambia la URL pública: la UI debe advertirlo. */
+  cambiarSlug: (docId: string, slug: string) => Promise<string | null>;
+  mover: (docId: string, padreId: string | null, orden: number) => Promise<string | null>;
+  eliminar: (docId: string) => Promise<string | null>;
+}
+
+const Ctx = createContext<ColeccionArbolValue | null>(null);
+
+const NO_OP = async () => null;
+
+const VACIO: ColeccionArbolValue = {
+  coleccionId: null,
+  coleccion: null,
+  documentos: [],
+  arbol: [],
+  cargando: false,
+  error: '',
+  refetch: async () => {},
+  renombrar: NO_OP,
+  cambiarSlug: NO_OP,
+  mover: NO_OP,
+  eliminar: NO_OP,
+};
+
+export function useColeccionArbol(): ColeccionArbolValue {
+  return useContext(Ctx) ?? VACIO;
+}
+
+export function ColeccionArbolProvider({ children }: { children: React.ReactNode }) {
+  // Cubre tanto /admin/contenidos/:id como .../editar/:docId.
+  const exact = useMatch('/admin/contenidos/:id');
+  const sub = useMatch('/admin/contenidos/:id/*');
+  const coleccionId = (exact || sub)?.params.id ?? null;
+
+  const { sessionToken } = useAuth();
+  const [coleccion, setColeccion] = useState<ColeccionData | null>(null);
+  const [documentos, setDocumentos] = useState<DocumentoData[]>([]);
+  const [cargando, setCargando] = useState(false);
+  const [error, setError] = useState('');
+
+  const refetch = useCallback(async () => {
+    if (!coleccionId || !sessionToken) return;
+    setCargando(true);
+    setError('');
+    try {
+      const h = { 'x-session-token': sessionToken };
+      const [resCols, resDocs] = await Promise.all([
+        fetch('/api/admin/colecciones', { headers: h }),
+        fetch(`/api/admin/colecciones/${coleccionId}/documentos`, { headers: h }),
+      ]);
+      if (!resCols.ok || !resDocs.ok) throw new Error('No se pudo cargar la colección');
+      const [jsonCols, jsonDocs] = await Promise.all([resCols.json(), resDocs.json()]);
+      // No hay endpoint de detalle de colección: se busca en la lista.
+      const encontrada = (jsonCols.colecciones ?? []).find((c: ColeccionData) => c.id === coleccionId) ?? null;
+      setColeccion(encontrada);
+      setDocumentos(jsonDocs.documentos ?? []);
+    } catch (err: any) {
+      setError(err.message ?? 'Error al cargar la colección');
+    } finally {
+      setCargando(false);
+    }
+  }, [coleccionId, sessionToken]);
+
+  useEffect(() => {
+    if (!coleccionId) {
+      setColeccion(null);
+      setDocumentos([]);
+      return;
+    }
+    refetch();
+  }, [coleccionId, refetch]);
+
+  const arbol = useMemo(() => buildArbol(documentos), [documentos]);
+
+  /** Ejecuta la mutación y refresca. Devuelve el mensaje de error, o null. */
+  const mutar = useCallback(
+    async (url: string, method: string, body?: unknown): Promise<string | null> => {
+      try {
+        const res = await fetch(url, {
+          method,
+          headers: { 'Content-Type': 'application/json', 'x-session-token': sessionToken ?? '' },
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          return err.message || 'Error en la operación';
+        }
+        await refetch();
+        return null;
+      } catch (err: any) {
+        return err.message || 'Error en la operación';
+      }
+    },
+    [sessionToken, refetch],
+  );
+
+  const renombrar = useCallback(
+    (docId: string, titulo: string) =>
+      // Sin `slug` en el body: el PUT solo aplica los campos presentes, así que
+      // el slug —y la URL pública— quedan intactos.
+      mutar(`/api/admin/documentos/${docId}`, 'PUT', { titulo }),
+    [mutar],
+  );
+
+  const cambiarSlug = useCallback(
+    (docId: string, slug: string) => mutar(`/api/admin/documentos/${docId}`, 'PUT', { slug }),
+    [mutar],
+  );
+
+  const mover = useCallback(
+    (docId: string, padreId: string | null, orden: number) =>
+      mutar(`/api/admin/documentos/${docId}/mover`, 'PUT', { padreId, orden }),
+    [mutar],
+  );
+
+  const eliminar = useCallback(
+    (docId: string) => mutar(`/api/admin/documentos/${docId}`, 'DELETE'),
+    [mutar],
+  );
+
+  const value = useMemo<ColeccionArbolValue>(
+    () => ({
+      coleccionId, coleccion, documentos, arbol, cargando, error, refetch,
+      renombrar, cambiarSlug, mover, eliminar,
+    }),
+    [coleccionId, coleccion, documentos, arbol, cargando, error, refetch, renombrar, cambiarSlug, mover, eliminar],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}

--- a/packages/web/src/hooks/useSidebarCollapse.ts
+++ b/packages/web/src/hooks/useSidebarCollapse.ts
@@ -1,14 +1,21 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+const ANCHO_COMPACTO = 1024;
 
 export function useSidebarCollapse() {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(() => window.innerWidth <= ANCHO_COMPACTO);
   const [mobileOpen, setMobileOpen] = useState(false);
+  // Solo forzamos el colapso al CRUZAR el umbral, no en cada resize: antes,
+  // cualquier evento de resize por debajo de 1024px volvía a colapsar el
+  // sidebar, así que en una pantalla mediana era imposible dejarlo abierto
+  // (y con el árbol de Contenidos dentro, eso deja al usuario sin navegación).
+  const eraCompacto = useRef(window.innerWidth <= ANCHO_COMPACTO);
 
   const toggle = useCallback(() => {
     if (window.innerWidth <= 768) {
-      setMobileOpen(prev => !prev);
+      setMobileOpen((prev) => !prev);
     } else {
-      setCollapsed(prev => !prev);
+      setCollapsed((prev) => !prev);
     }
   }, []);
 
@@ -18,16 +25,18 @@ export function useSidebarCollapse() {
 
   useEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth > 768) {
-        setMobileOpen(false);
-      }
-      if (window.innerWidth <= 1024) {
-        setCollapsed(true);
+      const compacto = window.innerWidth <= ANCHO_COMPACTO;
+
+      if (window.innerWidth > 768) setMobileOpen(false);
+
+      if (compacto !== eraCompacto.current) {
+        // Cruzamos el umbral: colapsar al entrar en compacto, expandir al salir.
+        setCollapsed(compacto);
+        eraCompacto.current = compacto;
       }
     };
 
     window.addEventListener('resize', handleResize);
-    handleResize();
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -29,3 +29,174 @@ a:hover {
 }
 
 ul, ol { list-style: none; }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   SweetAlert2 — tema de la app (ver utils/dialogos.ts).
+   Sustituye a confirm()/prompt() nativos, que bloquean el hilo del navegador.
+   ───────────────────────────────────────────────────────────────────────── */
+.swal-popup {
+  border-radius: 14px;
+  padding: 24px;
+  font-family: inherit;
+}
+
+.swal-title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.swal-texto {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+/* Aviso destacado dentro del diálogo (p. ej. "esto cambia la URL pública"). */
+.swal-aviso {
+  display: block;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: #fff3e0;
+  color: #8a4b00;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  text-align: left;
+}
+
+.swal-input {
+  font-family: inherit;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  box-shadow: none;
+}
+.swal-input:focus {
+  border-color: var(--dash-primary);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.swal-validacion {
+  border-radius: 8px;
+  font-size: 0.82rem;
+}
+
+.swal-btn {
+  padding: 9px 18px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s, background 0.15s;
+}
+.swal-btn:hover {
+  filter: brightness(0.95);
+}
+
+.swal-btn-confirmar {
+  background: var(--dash-primary);
+  color: #fff;
+}
+
+.swal-btn-peligro {
+  background: var(--dash-danger, #c0392b);
+  color: #fff;
+}
+
+.swal-btn-cancelar {
+  background: transparent;
+  border-color: var(--border-color);
+  color: var(--text-secondary);
+}
+.swal-btn-cancelar:hover {
+  background: var(--bg-page);
+}
+
+/* Código destacado dentro de un diálogo (p. ej. una contraseña generada). */
+.swal-codigo {
+  display: inline-block;
+  margin: 8px 0 0;
+  padding: 6px 12px;
+  background: var(--bg-page);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  user-select: all;
+}
+
+/* Vista previa en vivo bajo el campo de un diálogo (utils/dialogos.ts →
+   `vistaPrevia`). Se usa para enseñar la consecuencia del valor ANTES de
+   guardarlo: p. ej. cómo queda la URL al cambiar un slug. */
+.swal-preview {
+  margin-top: 12px;
+  text-align: left;
+}
+
+.swal-ruta {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: var(--bg-page);
+  border: 1px solid var(--border-color);
+}
+.swal-ruta + .swal-ruta {
+  margin-top: 6px;
+}
+
+.swal-ruta code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  word-break: break-all;
+}
+
+.swal-ruta-label {
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* El segmento que cambia, resaltado dentro de la ruta. */
+.swal-seg {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.07);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* La ruta resultante: verde, para leerla de un vistazo como "el después". */
+.swal-ruta-nueva {
+  background: #e8f5e9;
+  border-color: #a5d6a7;
+}
+.swal-ruta-nueva .swal-ruta-label,
+.swal-ruta-nueva code {
+  color: #1b5e20;
+}
+.swal-ruta-nueva .swal-seg {
+  background: #a5d6a7;
+  color: #10371a;
+}
+
+/* "/…" al final: recuerda que las páginas hijas también se mueven. */
+.swal-ruta-cola {
+  opacity: 0.55;
+}
+
+.swal-ruta-nota {
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}

--- a/packages/web/src/utils/dialogos.ts
+++ b/packages/web/src/utils/dialogos.ts
@@ -1,0 +1,187 @@
+import Swal from 'sweetalert2';
+import type { SweetAlertOptions } from 'sweetalert2';
+
+/**
+ * Diálogos de la app (SweetAlert2), centralizados.
+ *
+ * Sustituyen a `confirm()` / `prompt()` nativos, que además de feos **bloquean
+ * el hilo del navegador**: mientras están abiertos no corre nada más, ni las
+ * herramientas de automatización pueden interactuar con la página.
+ *
+ * La configuración vive aquí para que los diálogos se vean igual en todos lados
+ * y no haya que repetir colores y textos de botón en cada llamada.
+ */
+
+/**
+ * Escapa texto para interpolarlo en la opción `html` de un diálogo.
+ * Sin esto, un título con `<` o `&` rompería el markup (o algo peor).
+ */
+export function escapar(texto: string): string {
+  return texto
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const BASE: SweetAlertOptions = {
+  buttonsStyling: false,
+  reverseButtons: true,
+  focusCancel: true,
+  customClass: {
+    popup: 'swal-popup',
+    title: 'swal-title',
+    htmlContainer: 'swal-texto',
+    confirmButton: 'swal-btn swal-btn-confirmar',
+    denyButton: 'swal-btn swal-btn-peligro',
+    cancelButton: 'swal-btn swal-btn-cancelar',
+    input: 'swal-input',
+    validationMessage: 'swal-validacion',
+  },
+};
+
+interface ConfirmarOpts {
+  titulo: string;
+  texto?: string;
+  /** HTML ya seguro (no interpolar entrada del usuario sin escapar). */
+  html?: string;
+  confirmar?: string;
+  cancelar?: string;
+  /** Pinta el botón en rojo: borrados y acciones irreversibles. */
+  peligro?: boolean;
+}
+
+/** Confirmación sí/no. Resuelve a `true` solo si el usuario confirma. */
+export async function confirmar({
+  titulo,
+  texto,
+  html,
+  confirmar: textoConfirmar = 'Confirmar',
+  cancelar = 'Cancelar',
+  peligro = false,
+}: ConfirmarOpts): Promise<boolean> {
+  const res = await Swal.fire({
+    ...BASE,
+    title: titulo,
+    text: html ? undefined : texto,
+    html,
+    icon: peligro ? 'warning' : 'question',
+    showCancelButton: true,
+    confirmButtonText: textoConfirmar,
+    cancelButtonText: cancelar,
+    customClass: {
+      ...(BASE.customClass as object),
+      confirmButton: peligro ? 'swal-btn swal-btn-peligro' : 'swal-btn swal-btn-confirmar',
+    },
+  });
+  return res.isConfirmed;
+}
+
+/** Aviso informativo de un solo botón. Sustituye a `alert()`. */
+export async function avisar(opts: {
+  titulo: string;
+  texto?: string;
+  html?: string;
+  icono?: 'success' | 'info' | 'warning' | 'error';
+}): Promise<void> {
+  await Swal.fire({
+    ...BASE,
+    title: opts.titulo,
+    text: opts.html ? undefined : opts.texto,
+    html: opts.html,
+    icon: opts.icono ?? 'info',
+    confirmButtonText: 'Entendido',
+  });
+}
+
+interface PedirTextoOpts {
+  titulo: string;
+  html?: string;
+  valor?: string;
+  placeholder?: string;
+  confirmar?: string;
+  /** Devuelve un mensaje de error, o null si el valor es válido. */
+  validar?: (valor: string) => string | null;
+  /** Se aplica al valor antes de validar y devolver (p. ej. slugify). */
+  normalizar?: (valor: string) => string;
+  /**
+   * HTML que se repinta bajo el campo cada vez que se escribe. Sirve para
+   * mostrar la consecuencia del valor ANTES de guardarlo (p. ej. cómo va a
+   * quedar la URL). Recibe el valor ya normalizado.
+   *
+   * Debe devolver HTML seguro: escapa cualquier cosa que venga del usuario.
+   */
+  vistaPrevia?: (valor: string) => string;
+}
+
+/**
+ * Pide un texto. Resuelve al valor normalizado, o `null` si se cancela.
+ *
+ * `normalizar` se aplica también EN VIVO mientras se escribe, para que lo que se
+ * ve en el campo sea exactamente lo que se va a guardar (nada de teclear
+ * "Introducción a Web" y que por detrás se guarde otra cosa).
+ */
+export async function pedirTexto({
+  titulo,
+  html,
+  valor = '',
+  placeholder,
+  confirmar: textoConfirmar = 'Guardar',
+  validar,
+  normalizar,
+  vistaPrevia,
+}: PedirTextoOpts): Promise<string | null> {
+  const res = await Swal.fire({
+    ...BASE,
+    title: titulo,
+    html,
+    input: 'text',
+    inputValue: valor,
+    inputPlaceholder: placeholder,
+    showCancelButton: true,
+    confirmButtonText: textoConfirmar,
+    cancelButtonText: 'Cancelar',
+    focusCancel: false,
+    didOpen: (popup) => {
+      const input = popup.querySelector('input.swal2-input') as HTMLInputElement | null;
+      if (!input) return;
+
+      // La vista previa se cuelga DEBAJO del input, no del htmlContainer (que
+      // SweetAlert pinta encima del campo).
+      let preview: HTMLDivElement | null = null;
+      if (vistaPrevia) {
+        preview = document.createElement('div');
+        preview.className = 'swal-preview';
+        input.insertAdjacentElement('afterend', preview);
+      }
+
+      const repintar = () => {
+        if (preview) preview.innerHTML = vistaPrevia!(normalizar ? normalizar(input.value) : input.value);
+      };
+
+      input.addEventListener('input', () => {
+        if (normalizar) {
+          const pos = input.selectionStart;
+          const limpio = normalizar(input.value);
+          if (limpio !== input.value) {
+            input.value = limpio;
+            // Sin esto, el cursor salta al final en cuanto se normaliza.
+            if (pos !== null) input.setSelectionRange(pos, pos);
+          }
+        }
+        repintar();
+      });
+
+      repintar();
+    },
+    inputValidator: (v) => {
+      const limpio = normalizar ? normalizar(v) : v;
+      return validar?.(limpio) ?? null;
+    },
+  });
+
+  if (!res.isConfirmed) return null;
+  const bruto = String(res.value ?? '');
+  return normalizar ? normalizar(bruto) : bruto;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,7 +2592,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33", "@types/express-serve-static-core@^4.17.43":
+"@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33":
   version "4.19.8"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz#99b960322a4d576b239a640ab52ef191989b036f"
   integrity sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==
@@ -2602,7 +2602,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*", "@types/express@4.17.21", "@types/express@^4.17.13", "@types/express@^4.17.20", "@types/express@^4.17.21":
+"@types/express@*", "@types/express@^4.17.13", "@types/express@^4.17.20":
   version "4.17.25"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
   integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
@@ -2611,6 +2611,16 @@
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "^1"
+
+"@types/express@4.17.21":
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
+  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
 
 "@types/hast@^3.0.0":
   version "3.0.4"
@@ -2747,7 +2757,15 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-static@^1", "@types/serve-static@^1.15.5":
+"@types/serve-static@*":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
+  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
+  dependencies:
+    "@types/http-errors" "*"
+    "@types/node" "*"
+
+"@types/serve-static@^1":
   version "1.15.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.10.tgz#768169145a778f8f5dfcb6360aead414a3994fee"
   integrity sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==
@@ -7419,6 +7437,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+sweetalert2@^11.26.25:
+  version "11.26.25"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.26.25.tgz#ba24ffb79c67648ac51f834620baa15866a56e35"
+  integrity sha512-+hunCOJdJ6FLj04T9YSLvvZXRjsvIkTeTKP2e4VF8CaBias961BTnWiSFAy7F/CM5eq3QK2Rraoc5Gzftslvkg==
 
 symbol-observable@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
## Descripción

Llegar al editor del CMS costaba demasiados clics: colección → árbol → seleccionar página → **"Abrir editor"** → otra ruta. Ahora:

- **El árbol vive en el sidebar** (modo contextual, el mismo patrón que ya usaba `/admin/grupos/:id`), con scroll propio.
- **Seleccionar una página abre el editor inline**, debajo. La ruta a pantalla completa (`/admin/contenidos/:id/editar/:docId`) sigue viva como modo enfocado, con un botón `⤢` para saltar a ella.
- **La selección viaja en la URL** (`?doc=<id>`): recargar o compartir el enlace conserva lo que estabas editando.

El árbol se maneja **como un explorador de archivos**: arrastrar mueve (vertical reordena, horizontal cambia de nivel), doble clic renombra en línea, y al pasar el cursor aparecen cambiar slug y eliminar. Con eso el **panel de metadatos se queda sin contenido y desaparece**; la plantilla baja a la toolbar del editor.

El editor gana **modos de vista** (código / ambos / preview; por defecto ambos, y se recuerda entre sesiones).

## La decisión que no es obvia: renombrar NO toca el slug

Se pidió que el slug se generara automáticamente del título. **Medí el impacto antes de hacerlo:**

| | |
|---|---|
| Documentos | 120 |
| **Con slug ≠ `slugify(título)`** | **82** |
| Enlaces internos a rutas `/contenidos/...` | ~59 (39 en cuerpos, 20 en bloques de Páginas) |
| Redirects para `/contenidos` | **ninguno** |

El patrón dominante viene de Docusaurus: **`slug = "readme"`** con títulos humanos.

```
"NodeJS"              slug=readme     → slugify daría "nodejs"
"Tutoriales"          slug=readme     → slugify daría "tutoriales"
"Introducción a Web"  slug=intro-web  → slugify daría "introduccion-a-web"
```

Regenerar el slug al renombrar habría cambiado la URL de **82 documentos de golpe** y roto ~59 enlaces internos **en silencio**. Así que:

- **Renombrar cambia solo el título.** El slug —y la URL— quedan congelados. El campo Slug desaparece de la UI igualmente, que era el objetivo.
- **Al crear, el slug sí se genera del título** (nada apunta aún a la página) y el campo se va del formulario.
- **Cambiar el slug a propósito** es una acción aparte del nodo, cuyo diálogo muestra **la ruta actual y cómo va a quedar** antes de guardar, con el segmento que cambia resaltado. Si es una categoría con hijos, avisa de que arrastra a todo lo que cuelga.

## Bugs corregidos (hacían falta para que esto no fuera un downgrade)

- **Pérdida de borrador.** El autosave (debounce 1.5 s) se **cancelaba** al cambiar de documento o desmontar: lo escrito en el último segundo y medio se perdía sin aviso. Ya pasaba antes; con el árbol al lado pasaría a diario. Ahora se vuelca antes de salir, con los valores del documento que se deja, encadenado al PUT en vuelo para respetar el single-flight.
- **El sidebar no se dejaba abrir** en pantallas ≤1024 px: el handler de `resize` forzaba el colapso en **cada evento**, no solo al cruzar el umbral, y nunca lo revertía. Con el árbol dentro, eso deja al admin sin navegación.
- **El colapso de paneles no funcionaba** por especificidad CSS: `.oculto` estaba declarado antes que `.fuente`, con la misma especificidad, así que ganaba el segundo y el panel seguía visible (los dos se apilaban). Ahora es `.fuente.oculto` / `.preview.oculto`, que gana sin depender del orden del archivo.

## Diálogos: SweetAlert2 (commit aparte)

Se sustituyen los **25 `confirm()`/`prompt()`/`alert()` nativos** de todo el web. No es solo estética: los nativos **bloquean el hilo del navegador** mientras están abiertos.

`utils/dialogos.ts` centraliza tres helpers (`confirmar`, `pedirTexto`, `avisar`). Los borrados van en rojo con el botón etiquetado ("Eliminar"), y la contraseña generada de un alumno —que salía en un `alert()` del sistema— se muestra copiable y avisando de que no vuelve a mostrarse.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` pasa — 175 tests (el fallo en `deprecated/archived/…` es preexistente, falla igual en `main`).
- [x] `npx tsc --noEmit` sin errores.
- [x] `yarn build` OK.
- [x] Verificado a mano en el admin: árbol en el sidebar, drag & drop entre niveles y carpetas, doble clic para renombrar, cambio de slug con vista previa de la URL, los tres modos de vista del editor.

## Notas

- `yarn add` requirió `--ignore-engines`: **`@parse/s3-files-adapter` declara soporte solo hasta Node 22** y aquí corre Node 26. Funciona, pero cualquier `yarn add` futuro va a fallar igual y conviene mirarlo aparte.
- Mover una página (arrastrando o antes con el select) **sí cambia su URL**, porque la ruta es la concatenación de los slugs de sus ancestros. No es una regresión —ya era así—, pero conviene tenerlo presente al reorganizar.
- Como abundan los slugs `readme`, arrastrar una página a una categoría que ya tiene uno la rechaza el servidor (dos hermanos no pueden compartir URL). El árbol muestra el error en vez de fallar en silencio.