### PR TITLE
feat(grupos): la agenda de entrevistas pasa a ser un campo del grupo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **La agenda de entrevistas es ahora un campo del grupo**
+  (`Grupo.urlAgendaEntrevistas`, opcional, editable en el form del grupo). Antes
+  era una URL **hardcodeada en tres sitios** (el sidebar, el navbar público y el
+  mock del calendario que lee el pie), la misma hoja para todos. Ahora cada grupo
+  tiene la suya: el ítem "Agendar Entrevistas" desaparece del menú global del
+  admin y aparece **dentro del grupo**, y el alumno ve la de **su** grupo. Sin
+  URL, el ítem no se muestra (mismo criterio que "Documentación" sin colecciones).
+  - **La URL se valida en el SERVIDOR: solo `http`/`https`.** Se renderiza como
+    `<a href>`, así que un `javascript:` guardado ahí sería XSS en la sesión de
+    quien pulsara el enlace. La validación vive en `utils/url.ts`, con 20 tests.
+  - `scripts/migrate-agenda-entrevistas.ts` — pone en los grupos existentes la URL
+    que estaba activa, para que nadie pierda el enlace (idempotente, `--dry-run`).
+  - Los enlaces del **sitio público** (navbar y pie), que no tienen contexto de
+    grupo, se consolidan en `config/enlaces.ts` en vez de estar copiados en dos
+    componentes.
+
+### Removed
+- **`Grupo.enlaces`**: el `Record<string,string>` del modelo. Estaba **vacío en
+  los 3 grupos** de producción y no lo consumía nadie — el pie del sitio, que
+  parecía leerlo, lee en realidad el mock estático. Se va del modelo, del payload
+  del calendario, del seed y del tipo del front. Es el quinto campo muerto que se
+  retira de `Grupo`.
+
 ### Changed
 - **CMS "Contenidos" — el editor a un clic.** El árbol de páginas se muda al
   sidebar (modo contextual, como `/admin/grupos/:id`) y seleccionar una página

--- a/packages/api/scripts/migrate-agenda-entrevistas.ts
+++ b/packages/api/scripts/migrate-agenda-entrevistas.ts
@@ -1,0 +1,84 @@
+/**
+ * Migración: la agenda de entrevistas pasa de URL global hardcodeada a campo del
+ * grupo (`Grupo.urlAgendaEntrevistas`).
+ *
+ * Antes, el ítem "Agendar Entrevistas" del menú apuntaba a una constante en
+ * `sidebarConfig.ts` — la misma hoja para todos. Ahora cada grupo tiene la suya
+ * y, sin URL, el ítem no aparece. Este script pone en los grupos existentes la
+ * URL que estaba activa, para que nadie pierda el enlace con el deploy.
+ *
+ * Idempotente: solo toca los grupos que aún NO tienen URL.
+ *
+ *   ./node_modules/.bin/tsx scripts/migrate-agenda-entrevistas.ts --dry-run
+ *   ./node_modules/.bin/tsx scripts/migrate-agenda-entrevistas.ts
+ *   ./node_modules/.bin/tsx scripts/migrate-agenda-entrevistas.ts --url https://…
+ *
+ * ⚠️ Dev comparte la BD de PRODUCCIÓN. Corre --dry-run primero, y córrelo
+ *    DESPUÉS de desplegar: si lo corres antes, no pasa nada malo (el código viejo
+ *    ignora el campo), pero el orden seguro es siempre deploy → migración.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+/** La que estaba hardcodeada en sidebarConfig.ts hasta este cambio. */
+const URL_ACTUAL =
+  'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462';
+
+const dryRun = process.argv.includes('--dry-run');
+const iUrl = process.argv.indexOf('--url');
+const url = iUrl !== -1 ? process.argv[iUrl + 1] : URL_ACTUAL;
+
+function urlValida(v: string): boolean {
+  try {
+    const u = new URL(v);
+    return u.protocol === 'http:' || u.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  if (!urlValida(url)) {
+    console.error(`✗ URL inválida (solo http/https): ${url}`);
+    process.exit(1);
+  }
+  console.log(`URL a asignar:\n  ${url}\n`);
+
+  // Sin filtro por `active`: un grupo archivado también debe conservar su enlace.
+  const q = new Parse.Query('Grupo');
+  q.equalTo('exists', true);
+  q.limit(500);
+  const grupos = await q.find({ useMasterKey: true });
+
+  const sinUrl = grupos.filter((g) => !g.get('urlAgendaEntrevistas'));
+
+  console.log(`Grupos: ${grupos.length}  |  sin URL: ${sinUrl.length}`);
+  for (const g of grupos) {
+    const actual = g.get('urlAgendaEntrevistas');
+    const marca = actual ? '[ya tiene]' : dryRun ? '[dry-run] ' : '[asignar] ';
+    console.log(`  ${marca} ${String(g.get('name')).padEnd(12)} ${actual ?? '(sin URL)'}`);
+  }
+
+  if (sinUrl.length === 0) {
+    console.log('\n✓ Todos los grupos ya tienen URL. Nada que hacer.');
+    return;
+  }
+  if (dryRun) {
+    console.log('\n--dry-run: no se escribió nada. Quita la bandera para aplicar.');
+    return;
+  }
+
+  for (const g of sinUrl) g.set('urlAgendaEntrevistas', url);
+  await Parse.Object.saveAll(sinUrl, { useMasterKey: true });
+  console.log(`\n✓ ${sinUrl.length} grupo(s) actualizados.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/scripts/seed-calendario.ts
+++ b/packages/api/scripts/seed-calendario.ts
@@ -48,21 +48,15 @@ type SemanaData = SemanaNormalData | SemanaEspecialData;
 interface GrupoData {
   name: string;
   salon: string;
-  enlaces: Record<string, string>;
+  urlAgendaEntrevistas: string;
 }
 
 const GRUPOS_DATA: GrupoData[] = [
   {
     name: '501',
     salon: '4205',
-    enlaces: {
-      asesoriaDenisse: 'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0glSuRv-Qk1CwD4IJ1nBDWu2LSplGiPrW0Eo0DdEYxakViDvjwVkBsWBgh4U3wYpsD8GP9TRqd',
-      asesoriaAlex: 'https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0glSuRv-Qk1CwD4IJ1nBDWu2LSplGiPrW0Eo0DdEYxakViDvjwVkBsWBgh4U3wYpsD8GP9TRqd',
-      politicasEquipo: '/politicas',
-      integridadMIT: 'https://integrity.mit.edu/handbook/writing-code',
-      mallaEvaluacion: 'https://docs.google.com/spreadsheets/d/1DzGDdW9kCbSaVki8JP3T85q9jfWLOmCUv7tRsYMLYLE/edit?usp=sharing',
-      agendaEntrevistas: 'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462',
-    },
+    urlAgendaEntrevistas:
+      'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462',
   },
 ];
 
@@ -539,7 +533,7 @@ async function findOrCreateGrupo(grupoData: GrupoData, dryRun: boolean): Promise
 
   if (!dryRun && grupo) {
     grupo.setSalon(grupoData.salon);
-    grupo.setEnlaces(grupoData.enlaces);
+    grupo.setUrlAgendaEntrevistas(grupoData.urlAgendaEntrevistas);
     await grupo.save(null, { useMasterKey: true });
   }
 

--- a/packages/api/src/controllers/auth.controller.ts
+++ b/packages/api/src/controllers/auth.controller.ts
@@ -3,11 +3,19 @@ import { AppUser } from '../models/index.js';
 import { BaseModel } from '../models/BaseModel.js';
 import { getGruposDeAlumno } from '../services/grupo-alumno.service.js';
 
-async function buildGruposExtras(user: AppUser): Promise<{ grupos: { id: string; name: string }[] }> {
+async function buildGruposExtras(
+  user: AppUser,
+): Promise<{ grupos: { id: string; name: string; urlAgendaEntrevistas: string | null }[] }> {
   if (!user.isAlumno()) return { grupos: [] };
   const grupos = await getGruposDeAlumno(user.id);
   return {
-    grupos: grupos.map((g) => ({ id: g.id, name: g.get('name') ?? '' })),
+    grupos: grupos.map((g) => ({
+      id: g.id,
+      name: g.get('name') ?? '',
+      // El menú del alumno enlaza a la agenda de SU grupo; sin URL, el ítem no
+      // se muestra (mismo criterio que "Documentación" sin colecciones).
+      urlAgendaEntrevistas: g.get('urlAgendaEntrevistas') ?? null,
+    })),
   };
 }
 

--- a/packages/api/src/controllers/calendario.controller.ts
+++ b/packages/api/src/controllers/calendario.controller.ts
@@ -114,7 +114,6 @@ export async function getCalendarioByGrupo(req: Request, res: Response): Promise
         grupoId: grupo.id,
         grupo: grupo.getName(),
         salon: grupo.getSalon(),
-        enlaces: grupo.getEnlaces(),
         semanas: semanasJSON,
       },
     });

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -3,6 +3,7 @@ import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { Grupo } from '../models/Grupo.js';
 import { invalidateColeccionesPermitidas } from '../services/contenidos.service.js';
+import { sanitizarUrlHref } from '../utils/url.js';
 
 export async function listGrupos(_req: Request, res: Response): Promise<void> {
   try {
@@ -38,10 +39,16 @@ async function resolverColecciones(value: unknown): Promise<Parse.Object[] | 'in
 }
 
 export async function createGrupo(req: Request, res: Response): Promise<void> {
-  const { name, fechaInicio, fechaFin, colecciones } = req.body;
+  const { name, fechaInicio, fechaFin, colecciones, urlAgendaEntrevistas } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim() === '') {
     res.status(400).json({ status: 'error', message: 'El nombre es requerido' });
+    return;
+  }
+
+  const url = sanitizarUrlHref(urlAgendaEntrevistas);
+  if (url === null) {
+    res.status(400).json({ status: 'error', message: 'La URL de la agenda debe empezar por http:// o https://' });
     return;
   }
 
@@ -50,6 +57,7 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
     grupo.setName(name.trim());
     if (fechaInicio) grupo.setFechaInicio(new Date(fechaInicio));
     if (fechaFin) grupo.setFechaFin(new Date(fechaFin));
+    if (url) grupo.setUrlAgendaEntrevistas(url);
 
     const coleccionesPtrs = await resolverColecciones(colecciones);
     if (coleccionesPtrs === 'invalido') {
@@ -69,7 +77,7 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
 
 export async function updateGrupo(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { name, fechaInicio, fechaFin, colecciones } = req.body;
+  const { name, fechaInicio, fechaFin, colecciones, urlAgendaEntrevistas } = req.body;
 
   try {
     const query = BaseModel.queryActive<Grupo>('Grupo');
@@ -90,6 +98,16 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
     }
     if (fechaFin !== undefined) {
       grupo.setFechaFin(fechaFin ? new Date(fechaFin) : undefined!);
+    }
+    if (urlAgendaEntrevistas !== undefined) {
+      const url = sanitizarUrlHref(urlAgendaEntrevistas);
+      if (url === null) {
+        res.status(400).json({ status: 'error', message: 'La URL de la agenda debe empezar por http:// o https://' });
+        return;
+      }
+      // '' limpia el campo: así se puede quitar el enlace de un grupo.
+      if (url) grupo.setUrlAgendaEntrevistas(url);
+      else grupo.unset('urlAgendaEntrevistas');
     }
     // Solo un array válido aplica ([] limpia); no-array se ignora.
     const coleccionesPtrs = colecciones !== undefined ? await resolverColecciones(colecciones) : null;

--- a/packages/api/src/models/Grupo.ts
+++ b/packages/api/src/models/Grupo.ts
@@ -34,13 +34,20 @@ export class Grupo extends BaseModel {
     this.set('salon', salon);
   }
 
-  getEnlaces(): Record<string, string> | undefined {
-    return this.get('enlaces');
+  /**
+   * URL de la agenda de entrevistas del grupo (p. ej. una hoja de cálculo).
+   * Opcional: sin ella, el ítem "Agendar Entrevistas" no aparece en el menú.
+   *
+   * ⚠️ Se renderiza como `<a href>`, así que el controlador SOLO acepta
+   * `http`/`https`. Un `javascript:` aquí sería XSS en la sesión del admin o del
+   * alumno. Ver `sanitizarUrl()` en grupos.controller.
+   */
+  getUrlAgendaEntrevistas(): string | undefined {
+    return this.get('urlAgendaEntrevistas');
   }
-  setEnlaces(enlaces: Record<string, string>): void {
-    this.set('enlaces', enlaces);
+  setUrlAgendaEntrevistas(url: string): void {
+    this.set('urlAgendaEntrevistas', url);
   }
-
 
   /**
    * Colecciones del CMS "Contenidos" asignadas al grupo (array de pointers —
@@ -62,7 +69,7 @@ export class Grupo extends BaseModel {
       fechaInicio: this.getFechaInicio(),
       fechaFin: this.getFechaFin(),
       salon: this.getSalon(),
-      enlaces: this.getEnlaces(),
+      urlAgendaEntrevistas: this.getUrlAgendaEntrevistas() ?? null,
       // Requiere query.include('colecciones'); las soft-deleted no se exponen.
       colecciones: this.getColecciones()
         .filter((c) => c && c.get('exists') !== false)

--- a/packages/api/src/utils/url.ts
+++ b/packages/api/src/utils/url.ts
@@ -1,0 +1,40 @@
+/**
+ * Sanitización de URLs que después se renderizan como `<a href>`.
+ *
+ * Vive aparte del controlador para poder testearse sin servidor ni BD: es código
+ * de seguridad, y el test es lo que impide que alguien "simplifique" la
+ * validación sin darse cuenta de lo que protege.
+ */
+
+/**
+ * Valida y normaliza una URL destinada a un `href`.
+ *
+ * SOLO acepta `http` y `https`. Un `javascript:alert(document.cookie)` guardado
+ * en un campo que luego se pinta como enlace se ejecuta al hacer clic, en la
+ * sesión de quien lo pulse — admin o alumno. Lo mismo `data:` (puede llevar un
+ * documento HTML entero) y `vbscript:`.
+ *
+ * @returns la URL normalizada, `''` si no hay URL (campo vacío = quitar el
+ *          enlace), o `null` si es inválida — que el llamador debe tratar como
+ *          error del cliente, nunca guardando el valor.
+ */
+export function sanitizarUrlHref(valor: unknown): string | null {
+  if (valor === null || valor === undefined) return '';
+  if (typeof valor !== 'string') return null;
+
+  const limpio = valor.trim();
+  if (!limpio) return '';
+
+  let url: URL;
+  try {
+    // `new URL` sin base rechaza las rutas relativas ("/politicas"), que es lo
+    // que queremos: este campo es para enlaces externos.
+    url = new URL(limpio);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+
+  return url.toString();
+}

--- a/packages/api/tests/url.test.ts
+++ b/packages/api/tests/url.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests de `sanitizarUrlHref`. Código de seguridad: el valor acaba en un
+ * `<a href>` del menú, así que un esquema ejecutable aquí es XSS en la sesión de
+ * quien pulse el enlace (admin o alumno).
+ * Corre sin servidor: `npx vitest run packages/api/tests/url.test.ts`
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitizarUrlHref } from '../src/utils/url.js';
+
+describe('sanitizarUrlHref', () => {
+  describe('rechaza (null) lo que podría ejecutar código', () => {
+    const peligrosas = [
+      'javascript:alert(document.cookie)',
+      'JavaScript:alert(1)',            // el esquema no distingue mayúsculas
+      '  javascript:alert(1)  ',        // espacios alrededor
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+    ];
+    for (const url of peligrosas) {
+      it(`rechaza ${JSON.stringify(url)}`, () => {
+        expect(sanitizarUrlHref(url)).toBeNull();
+      });
+    }
+  });
+
+  describe('rechaza (null) lo que no es una URL absoluta', () => {
+    const invalidas = [
+      'no-es-una-url',
+      '/politicas',                     // relativa: este campo es para externos
+      'docs.google.com/spreadsheets',   // sin esquema
+      123,
+      {},
+      [],
+      true,
+    ];
+    for (const valor of invalidas) {
+      it(`rechaza ${JSON.stringify(valor)}`, () => {
+        expect(sanitizarUrlHref(valor)).toBeNull();
+      });
+    }
+  });
+
+  describe('acepta http/https', () => {
+    it('acepta una hoja de cálculo con query y fragmento', () => {
+      const url =
+        'https://docs.google.com/spreadsheets/d/1U1fbfaB/edit?gid=32307462#gid=32307462';
+      expect(sanitizarUrlHref(url)).toBe(url);
+    });
+
+    it('acepta http (no solo https)', () => {
+      expect(sanitizarUrlHref('http://example.com/agenda')).toBe('http://example.com/agenda');
+    });
+
+    it('normaliza: recorta espacios', () => {
+      expect(sanitizarUrlHref('  https://example.com/x  ')).toBe('https://example.com/x');
+    });
+  });
+
+  describe('vacío = quitar el enlace, no error', () => {
+    it.each([undefined, null, '', '   '])('%p → cadena vacía', (valor) => {
+      expect(sanitizarUrlHref(valor)).toBe('');
+    });
+  });
+});

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
@@ -10,6 +10,7 @@ interface GrupoData {
   fechaInicio?: string;
   fechaFin?: string;
   colecciones?: ColeccionRef[];
+  urlAgendaEntrevistas?: string | null;
 }
 
 interface GrupoSavePayload {
@@ -17,6 +18,7 @@ interface GrupoSavePayload {
   fechaInicio?: string;
   fechaFin?: string;
   colecciones?: string[];
+  urlAgendaEntrevistas?: string;
 }
 
 interface GrupoFormProps {
@@ -47,7 +49,9 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
   const [coleccionesSel, setColeccionesSel] = useState<string[]>(
     (grupo?.colecciones ?? []).map((c) => c.id),
   );
+  const [agendaUrl, setAgendaUrl] = useState(grupo?.urlAgendaEntrevistas ?? '');
   const [error, setError] = useState('');
+  const [errorAgenda, setErrorAgenda] = useState('');
 
 
   function toggleColeccion(id: string) {
@@ -61,12 +65,22 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
       setError('El nombre es requerido');
       return;
     }
+    // El servidor vuelve a validar esto (es el que manda); aquí es solo para no
+    // hacer un viaje de ida y vuelta por una URL obviamente mal escrita.
+    const url = agendaUrl.trim();
+    if (url && !/^https?:\/\//i.test(url)) {
+      setErrorAgenda('La URL debe empezar por http:// o https://');
+      return;
+    }
     setError('');
+    setErrorAgenda('');
     onSave({
       name: name.trim(),
       fechaInicio: fechaInicio || undefined,
       fechaFin: fechaFin || undefined,
       colecciones: coleccionesSel,
+      // Cadena vacía = quitar el enlace del grupo.
+      urlAgendaEntrevistas: url,
     });
   }
 
@@ -109,6 +123,19 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
           })}
         </div>
       </div>
+      <TextInput
+        label="URL de la agenda de entrevistas (opcional)"
+        placeholder="https://docs.google.com/spreadsheets/…"
+        icon="event_available"
+        value={agendaUrl}
+        onChange={(v) => { setAgendaUrl(v); setErrorAgenda(''); }}
+        error={errorAgenda}
+        disabled={loading}
+      />
+      <p className={styles.hint}>
+        Aparece como “Agendar Entrevistas” en el menú del grupo y en el de sus alumnos.
+        Déjala vacía para no mostrar el enlace.
+      </p>
       <div className={styles.field}>
         <label className={styles.label}>Fecha de inicio</label>
         <input

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -36,6 +36,9 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
   const [selectedGrupoId, setSelectedGrupoId] = useState<string>('');
   const [docsHref, setDocsHref] = useState<string | null>(null);
   const [docusLinks, setDocusLinks] = useState<DocusLink[]>([]);
+  // Agenda de entrevistas del grupo abierto (admin). La del alumno sale del
+  // payload de sesión (user.grupos), no requiere fetch.
+  const [agendaGrupoHref, setAgendaGrupoHref] = useState<string | null>(null);
 
   useEffect(() => {
     if (role === 'alumno' && user?.grupos?.length) {
@@ -81,10 +84,12 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
           (g: {
             id: string;
             name?: string;
+            urlAgendaEntrevistas?: string | null;
             colecciones?: { slug: string; nombre: string; clave: string | null }[];
           }) => g.id === grupoId,
         );
         if (found?.name) setGrupoName(found.name);
+        setAgendaGrupoHref(found?.urlAgendaEntrevistas ?? null);
 
         // Documentación del grupo = sus colecciones del CMS Contenidos.
         const links: DocusLink[] = (found?.colecciones ?? []).map(
@@ -99,9 +104,22 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
       .catch(() => {});
   }, [grupoId, sessionToken]);
 
+  // La agenda del alumno es la de SU grupo seleccionado; viaja en el payload de
+  // sesión, así que no hace falta pedirla.
+  const agendaAlumnoHref =
+    role === 'alumno'
+      ? user?.grupos?.find((g) => g.id === selectedGrupoId)?.urlAgendaEntrevistas ?? null
+      : null;
+
   const items = isGrupoDetail
-    ? getGrupoDetailItems(grupoId!)
-    : getSidebarItems(role, role === 'alumno' ? selectedGrupoId : undefined, user?.perfilCompleto, docsHref);
+    ? getGrupoDetailItems(grupoId!, agendaGrupoHref)
+    : getSidebarItems(
+        role,
+        role === 'alumno' ? selectedGrupoId : undefined,
+        user?.perfilCompleto,
+        docsHref,
+        agendaAlumnoHref,
+      );
 
   return (
     <>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
@@ -1,7 +1,8 @@
 import type { SidebarItem, DashboardRole } from '../../../../types/dashboard';
 
-const AGENDA_ENTREVISTAS_URL =
-  'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462';
+// La agenda de entrevistas dejó de ser una URL global hardcodeada: ahora es un
+// campo del grupo (`Grupo.urlAgendaEntrevistas`). El admin la ve dentro del
+// grupo (getGrupoDetailItems) y el alumno, la de SU grupo. Sin URL, no hay ítem.
 
 // `docsHref` es el link del alumno al visor de Contenidos
 // (/contenidos/<slug>/ de su primera colección); null = sin colecciones,
@@ -11,6 +12,7 @@ export function getSidebarItems(
   selectedGrupoId?: string,
   perfilCompleto?: boolean,
   docsHref: string | null = null,
+  agendaHref: string | null = null,
 ): SidebarItem[] {
   if (role === 'admin') {
     return [
@@ -20,7 +22,6 @@ export function getSidebarItems(
       { label: 'Actividades', icon: 'assignment', path: '/admin/actividades' },
       { label: 'Páginas', icon: 'article', path: '/admin/paginas' },
       { label: 'Contenidos', icon: 'library_books', path: '/admin/contenidos' },
-      { label: 'Agendar Entrevistas', icon: 'event_available', path: AGENDA_ENTREVISTAS_URL, external: true },
     ];
   }
   const items: SidebarItem[] = [];
@@ -52,14 +53,29 @@ export function getSidebarItems(
   if (docsHref) {
     items.push({ label: 'Documentación', icon: 'menu_book', path: docsHref, external: true, disabled: !perfilCompleto });
   }
-  items.push(
-    { label: 'Agendar Entrevistas', icon: 'event_available', path: AGENDA_ENTREVISTAS_URL, external: true, disabled: !perfilCompleto },
-  );
+  // Sin URL en su grupo, no hay agenda que enlazar (igual que "Documentación").
+  if (agendaHref) {
+    items.push({
+      label: 'Agendar Entrevistas',
+      icon: 'event_available',
+      path: agendaHref,
+      external: true,
+      disabled: !perfilCompleto,
+    });
+  }
   return items;
 }
 
-export function getGrupoDetailItems(grupoId: string): SidebarItem[] {
-  return [
+/**
+ * Menú contextual del detalle de grupo.
+ *
+ * Ojo con los dos "entrevistas", que no son lo mismo:
+ *  - "Entrevistas" → página interna de gestión (`/admin/grupos/:id/entrevistas`).
+ *  - "Agendar Entrevistas" → enlace EXTERNO a la agenda del grupo (una hoja de
+ *    cálculo, normalmente). Solo aparece si el grupo tiene URL.
+ */
+export function getGrupoDetailItems(grupoId: string, agendaHref: string | null = null): SidebarItem[] {
+  const items: SidebarItem[] = [
     { label: 'Calendario', icon: 'calendar_month', path: `/admin/grupos/${grupoId}/calendario` },
     { label: 'Alumnos', icon: 'people', path: `/admin/grupos/${grupoId}` },
     { label: 'Actividades Evaluación', icon: 'assignment', path: `/admin/grupos/${grupoId}/actividades-evaluacion` },
@@ -67,4 +83,8 @@ export function getGrupoDetailItems(grupoId: string): SidebarItem[] {
     { label: 'Equipos', icon: 'group_work', path: `/admin/grupos/${grupoId}/equipos` },
     { label: 'Entrevistas', icon: 'record_voice_over', path: `/admin/grupos/${grupoId}/entrevistas` },
   ];
+  if (agendaHref) {
+    items.push({ label: 'Agendar Entrevistas', icon: 'event_available', path: agendaHref, external: true });
+  }
+  return items;
 }

--- a/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
@@ -17,6 +17,7 @@ interface GrupoData {
   fechaFin?: string;
   active: boolean;
   colecciones?: ColeccionRef[];
+  urlAgendaEntrevistas?: string | null;
 }
 
 const API_BASE = '/api';
@@ -82,7 +83,7 @@ export default function GruposPage() {
     setEditGrupo(undefined);
   }
 
-  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; colecciones?: string[] }) {
+  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; colecciones?: string[]; urlAgendaEntrevistas?: string }) {
     setSaving(true);
     setError('');
     try {

--- a/packages/web/src/components/layout/Footer.tsx
+++ b/packages/web/src/components/layout/Footer.tsx
@@ -1,8 +1,6 @@
 import { Link } from 'react-router';
-import { calendarioGrupo2 } from '@/data/calendario';
+import { ENLACES_SITIO } from '@/config/enlaces';
 import styles from './Footer.module.css';
-
-const enlaces = calendarioGrupo2.enlaces;
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
@@ -12,21 +10,19 @@ export default function Footer() {
       <div className={styles.content}>
         <h3 className={styles.title}>Enlaces importantes</h3>
         <div className={styles.links}>
-          <a href="https://calendar.app.google/YjY5BqzNsrFAxkpJ6" target="_blank" rel="noopener noreferrer">
+          <a href={ENLACES_SITIO.asesoria} target="_blank" rel="noopener noreferrer">
             Solicitud de asesoría (Denisse / Alex)
           </a>
           <Link to="/politicas">Políticas de trabajo en equipo</Link>
-          <a href={enlaces.integridadMIT} target="_blank" rel="noopener noreferrer">
+          <a href={ENLACES_SITIO.integridadMIT} target="_blank" rel="noopener noreferrer">
             Guía de integridad académica del MIT
           </a>
-          <a href={enlaces.mallaEvaluacion} target="_blank" rel="noopener noreferrer">
+          <a href={ENLACES_SITIO.mallaEvaluacion} target="_blank" rel="noopener noreferrer">
             Malla de evaluación
           </a>
-          {enlaces.agendaEntrevistas && (
-            <a href={enlaces.agendaEntrevistas} target="_blank" rel="noopener noreferrer">
-              Agenda de entrevistas
-            </a>
-          )}
+          <a href={ENLACES_SITIO.agendaEntrevistas} target="_blank" rel="noopener noreferrer">
+            Agenda de entrevistas
+          </a>
         </div>
         <div className={styles.copyright}>
           &copy; {currentYear} Escuela de Ingeniería y Ciencias &mdash; Tecnológico de Monterrey, Campus Querétaro.

--- a/packages/web/src/components/layout/Navbar.tsx
+++ b/packages/web/src/components/layout/Navbar.tsx
@@ -1,9 +1,7 @@
 import { Link } from 'react-router';
 import styles from './Navbar.module.css';
 import { APP_NAME, APP_TAGLINE } from '../../config/app';
-
-const AGENDA_ENTREVISTAS_URL =
-  'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462';
+import { ENLACES_SITIO } from '../../config/enlaces';
 
 export default function Navbar() {
   return (
@@ -16,7 +14,7 @@ export default function Navbar() {
       </span>
       <div className={styles.navLinks}>
         <a
-          href={AGENDA_ENTREVISTAS_URL}
+          href={ENLACES_SITIO.agendaEntrevistas}
           className={styles.agendaBtn}
           target="_blank"
           rel="noopener noreferrer"

--- a/packages/web/src/config/enlaces.ts
+++ b/packages/web/src/config/enlaces.ts
@@ -1,0 +1,21 @@
+/**
+ * Enlaces del SITIO PÚBLICO (navbar y pie), que no tiene contexto de grupo.
+ *
+ * Antes vivían hardcodeados en tres sitios (Navbar, el mock del calendario que
+ * lee el Footer, y sidebarConfig) con la misma URL copiada. El del sidebar se
+ * fue: la agenda de entrevistas es ahora un campo del grupo
+ * (`Grupo.urlAgendaEntrevistas`), y el menú del admin y el del alumno enlazan a
+ * la de SU grupo.
+ *
+ * Estos, en cambio, los ve un visitante anónimo, que no pertenece a ningún
+ * grupo: por eso siguen siendo del sitio. Si algún día el sitio público deja de
+ * ofrecer la agenda, se borra de aquí y de los dos componentes.
+ */
+export const ENLACES_SITIO = {
+  asesoria: 'https://calendar.app.google/YjY5BqzNsrFAxkpJ6',
+  integridadMIT: 'https://integrity.mit.edu/handbook/writing-code',
+  mallaEvaluacion:
+    'https://docs.google.com/spreadsheets/d/1DzGDdW9kCbSaVki8JP3T85q9jfWLOmCUv7tRsYMLYLE/edit?usp=sharing',
+  agendaEntrevistas:
+    'https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462',
+} as const;

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -7,7 +7,7 @@ interface AppUserData {
   name: string;
   userType: string;
   grupo: string;
-  grupos: { id: string; name: string }[];
+  grupos: { id: string; name: string; urlAgendaEntrevistas?: string | null }[];
   attributes: Record<string, unknown>;
   lastLogin?: string;
   perfilCompleto?: boolean;

--- a/packages/web/src/data/calendario/calendario-grupo2.ts
+++ b/packages/web/src/data/calendario/calendario-grupo2.ts
@@ -4,14 +4,6 @@ import type { Calendario } from '@/types/calendario';
 const calendario: Calendario = {
   grupo: "501",
   salon: "4205",
-  enlaces: {
-    asesoriaDenisse: "https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0glSuRv-Qk1CwD4IJ1nBDWu2LSplGiPrW0Eo0DdEYxakViDvjwVkBsWBgh4U3wYpsD8GP9TRqd",
-    asesoriaAlex: "https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ0glSuRv-Qk1CwD4IJ1nBDWu2LSplGiPrW0Eo0DdEYxakViDvjwVkBsWBgh4U3wYpsD8GP9TRqd",
-    politicasEquipo: "/politicas",
-    integridadMIT: "https://integrity.mit.edu/handbook/writing-code",
-    mallaEvaluacion: "https://docs.google.com/spreadsheets/d/1DzGDdW9kCbSaVki8JP3T85q9jfWLOmCUv7tRsYMLYLE/edit?usp=sharing",
-    agendaEntrevistas: "https://docs.google.com/spreadsheets/d/1U1fbfaBWMp4Nje13qi2C3mhjhW0B8NxC-JXD0ff6fNQ/edit?gid=32307462#gid=32307462"
-  },
   semanas: [
     // ==================== SEMANA 1 ====================
     {

--- a/packages/web/src/types/calendario.ts
+++ b/packages/web/src/types/calendario.ts
@@ -53,19 +53,9 @@ export interface SemanaEspecial {
 
 export type Semana = SemanaNormal | SemanaEspecial;
 
-export interface CalendarioEnlaces {
-  asesoriaDenisse: string;
-  asesoriaAlex: string;
-  politicasEquipo: string;
-  integridadMIT: string;
-  mallaEvaluacion: string;
-  agendaEntrevistas: string;
-}
-
 export interface Calendario {
   grupoId?: string;
   grupo: string;
   salon: string;
-  enlaces: CalendarioEnlaces;
   semanas: Semana[];
 }


### PR DESCRIPTION
## Descripción

La URL de "Agendar Entrevistas" estaba **hardcodeada en tres sitios** —el sidebar, el navbar público y el mock del calendario que lee el pie— con la misma hoja de cálculo copiada. Y el ítem vivía en el **menú global del admin**, como si la agenda fuera del sitio y no de cada grupo.

Ahora es **`Grupo.urlAgendaEntrevistas`**: campo opcional, editable en el formulario del grupo.

- El ítem **se va del menú global del admin** y aparece **dentro del grupo**.
- El **alumno** ve la agenda de **su** grupo (viaja en el payload de sesión, sin fetch extra).
- **Sin URL, no hay ítem** — mismo criterio que "Documentación" sin colecciones. Así se puede quitar el enlace de un grupo concreto, cosa que antes era imposible.

## Seguridad: la URL acaba en un `<a href>`

Un `javascript:alert(document.cookie)` guardado en ese campo **se ejecutaría al hacer clic en el ítem del menú**, en la sesión de un admin o de un alumno. "Sanitizar" aquí no es cosmético.

- **El servidor valida el esquema (solo `http`/`https`)** y rechaza el resto con 400. La validación **no puede estar solo en el formulario**: el formulario no es la única puerta al API.
- La lógica vive en `utils/url.ts`, aparte del controlador, precisamente para poder testearla sin servidor.
- **20 tests** la cubren: `javascript:` (con mayúsculas y con espacios alrededor), `data:text/html`, `vbscript:`, `file://`, rutas relativas, cadenas que no son URL, y no-strings. Más los casos válidos y el vacío (= quitar el enlace).

## Limpieza: `Grupo.enlaces` era el quinto campo muerto

```
FebJun26   enlaces = NO EXISTE EL CAMPO
Prueba     enlaces = NO EXISTE EL CAMPO
Prueba 2   enlaces = NO EXISTE EL CAMPO
```

Vacío en los 3 grupos, y **sin consumidores**: el pie del sitio, que parecía leerlo, lee en realidad el **mock estático** del calendario. Se retira del modelo, del payload del calendario, del seed y del tipo del front.

Los enlaces del **sitio público** (navbar y pie) no tienen contexto de grupo —los ve un visitante anónimo—, así que siguen siendo del sitio, pero **consolidados en `config/enlaces.ts`** en vez de copiados en dos componentes.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` — **195 tests** (antes 175; los 20 nuevos son los de sanitización). El fallo en `deprecated/archived/…` es preexistente.
- [x] `npx tsc --noEmit` sin errores en `web` y `api`.
- [x] `yarn build` OK.
- [x] `grep` de la URL hardcodeada: ya solo aparece en `config/enlaces.ts` (sitio público), el seed y el script de migración.

## Migración — ⚠️ correr ANTES del deploy

`scripts/migrate-agenda-entrevistas.ts` (idempotente, `--dry-run`) pone en los grupos existentes la URL que está activa hoy:

```
Grupos: 3  |  sin URL: 3
  [dry-run]  FebJun26     (sin URL)
  [dry-run]  Prueba       (sin URL)
  [dry-run]  Prueba 2     (sin URL)
```

**Aquí el orden se invierte respecto a las migraciones anteriores.** Esta es *aditiva*: escribe un campo que el código viejo ignora, así que correrla antes no rompe nada. Y si se corre **después**, hay una ventana en la que el ítem "Agendar Entrevistas" **desaparece del menú de todos** (el código nuevo lee el campo del grupo, y aún está vacío). Correrla antes elimina esa ventana.