### PR TITLE
feat(cms): las Páginas se alcanzan desde Contenidos, ya filtradas por colección

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Las Páginas se alcanzan desde Contenidos**, que es donde viven (cada `Pagina`
+  pertenece a una `Coleccion`). Cada colección gana una acción **"Páginas"** que
+  abre las suyas **ya filtradas**; el filtro vive ahora en la URL
+  (`/admin/paginas?coleccion=<id>`), así que el enlace se puede compartir y
+  recargar sin perderlo. "Páginas" se retira del menú lateral, pero la pantalla de
+  Contenidos conserva un **"Ver todas las páginas"**: sin él solo se llegaría a
+  listas ya filtradas, y se perderían la vista de conjunto (filtro por etiqueta
+  entre colecciones) y el acceso a las páginas **sin colección**.
+
 ### Added
 - **La agenda de entrevistas es ahora un campo del grupo**
   (`Grupo.urlAgendaEntrevistas`, opcional, editable en el form del grupo). Antes

--- a/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
@@ -20,7 +20,10 @@ export function getSidebarItems(
       { label: 'Grupos', icon: 'groups', path: '/admin/grupos' },
       { label: 'Competencias', icon: 'emoji_events', path: '/admin/competencias' },
       { label: 'Actividades', icon: 'assignment', path: '/admin/actividades' },
-      { label: 'Páginas', icon: 'article', path: '/admin/paginas' },
+      // "Páginas" ya no es una entrada propia: se llega desde Contenidos, que es
+      // donde viven (cada Pagina pertenece a una Coleccion). La acción "Páginas"
+      // de cada colección abre las suyas ya filtradas, y el botón "Ver todas las
+      // páginas" de esa pantalla conserva la vista de conjunto.
       { label: 'Contenidos', icon: 'library_books', path: '/admin/contenidos' },
     ];
   }

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.module.css
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.module.css
@@ -44,3 +44,30 @@
   border-radius: 8px;
   font-size: 14px;
 }
+
+/* Cabecera: título + acceso a la vista global de páginas. */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.verTodas {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  padding: 7px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-card, #fff);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+.verTodas:hover {
+  background: var(--bg-page);
+  color: var(--text-primary);
+}

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { confirmar } from '../../../../utils/dialogos';
-import { useNavigate } from 'react-router';
+import { useNavigate, Link } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
+import Icon from '../../atoms/Icon/Icon';
 import Modal from '../../atoms/Modal/Modal';
 import ColeccionForm from '../../organisms/ColeccionForm/ColeccionForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
@@ -121,14 +122,28 @@ export default function ContenidosPage() {
   ];
 
   const getActions = (coleccion: ColeccionData): ActionItem[] => [
-    { label: 'Abrir', icon: 'account_tree', onClick: () => navigate(`/admin/contenidos/${coleccion.id}`) },
+    // "Abrir" = el árbol de documentación (Documento). "Páginas" = las páginas de
+    // bloques (Pagina) que se sirven en /paginas/:slug. Son dos contenidos
+    // distintos de la misma colección; de ahí las dos acciones.
+    { label: 'Abrir documentación', icon: 'account_tree', onClick: () => navigate(`/admin/contenidos/${coleccion.id}`) },
+    { label: 'Páginas', icon: 'article', onClick: () => navigate(`/admin/paginas?coleccion=${coleccion.id}`) },
     { label: 'Editar', icon: 'edit', onClick: () => openEdit(coleccion) },
     { label: 'Eliminar', icon: 'delete', onClick: () => handleDelete(coleccion), variant: 'danger' },
   ];
 
   return (
     <div className={styles.page}>
-      <h1 className={styles.pageTitle}>Contenidos</h1>
+      <div className={styles.header}>
+        <h1 className={styles.pageTitle}>Contenidos</h1>
+        {/* Sin esto, al quitar "Páginas" del menú lateral solo se llegaría a las
+            páginas YA filtradas por colección: se perdería la vista de conjunto
+            (todas, filtro por etiqueta) y las páginas sin colección quedarían
+            inalcanzables. */}
+        <Link to="/admin/paginas" className={styles.verTodas}>
+          <Icon name="article" size="sm" />
+          <span>Ver todas las páginas</span>
+        </Link>
+      </div>
 
       {error && <div className={styles.error}>{error}</div>}
 

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.module.css
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.module.css
@@ -331,3 +331,36 @@
   font-weight: 600;
   white-space: nowrap;
 }
+
+/* Cabecera: vuelta a Contenidos + de qué colección son las páginas que se ven. */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.volver {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+.volver:hover {
+  color: var(--text-primary);
+}
+.volver .material-icons {
+  font-size: 18px;
+}
+
+/* El nombre de la colección activa, junto al título: sin esto no se sabe si la
+   lista está filtrada o son todas. */
+.pageTitleSub {
+  margin-left: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams, Link } from 'react-router';
 import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -37,7 +38,16 @@ export default function PaginasPage() {
   const [editPagina, setEditPagina] = useState<PaginaData | undefined>();
   const [previewPagina, setPreviewPagina] = useState<PaginaData | undefined>();
   const [filtroEtiqueta, setFiltroEtiqueta] = useState<string | null>(null);
-  const [filtroColeccion, setFiltroColeccion] = useState<string>('');
+
+  // El filtro de colección vive en la URL (`?coleccion=<id>`): así la acción
+  // "Páginas" de la tabla de Contenidos puede llegar aquí ya filtrada, y el
+  // enlace se puede compartir o recargar sin perder el filtro.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filtroColeccion = searchParams.get('coleccion') ?? '';
+
+  function setFiltroColeccion(valor: string) {
+    setSearchParams(valor ? { coleccion: valor } : {}, { replace: true });
+  }
 
   // Etiquetas CRUD state
   const [etiquetasOpen, setEtiquetasOpen] = useState(false);
@@ -62,6 +72,12 @@ export default function PaginasPage() {
   }, [paginas, filtroEtiqueta, filtroColeccion]);
 
   const sinColeccion = useMemo(() => paginas.filter((p) => !p.coleccionId).length, [paginas]);
+
+  /** La colección del filtro, para dar contexto en el título. */
+  const coleccionActiva = useMemo(
+    () => colecciones.find((c) => c.id === filtroColeccion) ?? null,
+    [colecciones, filtroColeccion],
+  );
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -365,7 +381,20 @@ export default function PaginasPage() {
 
   return (
     <div className={styles.page}>
-      <h1 className={styles.pageTitle}>Páginas</h1>
+      <div className={styles.header}>
+        <Link to="/admin/contenidos" className={styles.volver}>
+          <span className="material-icons">arrow_back</span>
+          <span>Contenidos</span>
+        </Link>
+        <h1 className={styles.pageTitle}>
+          Páginas
+          {coleccionActiva && (
+            <span className={styles.pageTitleSub}>
+              {coleccionActiva.clave ?? coleccionActiva.slug} — {coleccionActiva.nombre}
+            </span>
+          )}
+        </h1>
+      </div>
 
       {error && <div className={styles.error}>{error}</div>}
 


### PR DESCRIPTION
## Descripción

Cada `Pagina` pertenece a una `Coleccion` desde el PR #34, pero "Páginas" seguía siendo una sección aparte del menú: para llegar a las de una materia había que entrar y volver a filtrar a mano.

- **Cada colección gana una acción "Páginas"** que abre las suyas **ya filtradas**.
- **El filtro vive ahora en la URL** (`/admin/paginas?coleccion=<id>`), así que el enlace se puede compartir y recargar sin perderlo — antes era estado local que se evaporaba.
- **"Páginas" se retira del menú lateral.**

## La salida que hacía falta

Si solo se llegara desde la tabla, **siempre se llegaría filtrado**. Eso perdía dos cosas, así que la pantalla de Contenidos conserva un **"Ver todas las páginas"**:

- La **vista de conjunto**: las 47 páginas juntas, con el filtro por etiqueta cruzando colecciones.
- El acceso a las páginas **sin colección**, que de otro modo quedarían **inalcanzables** (hoy son 0, pero nada impide crear una).

## Nota de nomenclatura

La acción de abrir una colección pasa a llamarse **"Abrir documentación"**, porque ahora convive con "Páginas" y son **dos contenidos distintos de la misma colección**:

| | Qué es | Cuántas | Dónde se sirve |
|---|---|---|---|
| `Documento` | El árbol de documentación (Markdown/HTML, con categorías) | 120 | `/contenidos/tc2005b/…` |
| `Pagina` | Labs, avances y talleres, con el editor de bloques | 47 | `/paginas/:slug` |

Sin distinguirlas, "Páginas" dentro de "Páginas" habría sido un enredo.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores.
- [x] `yarn build` OK.