### PR TITLE
feat(competencias): las competencias pertenecen a una colección, no al sistema entero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- **Las Competencias pertenecen a una colección (materia)** y dejan de ser una
+  lista global. Antes, la malla de un alumno se materializaba con **todas** las
+  competencias del sistema, sin importar la materia de su grupo. Ahora se arma
+  con las de las colecciones de su grupo (`Grupo.colecciones` →
+  `Competencia.coleccion`), y cada colección gana una acción **"Competencias"** en
+  la tabla de Contenidos que abre las suyas ya filtradas
+  (`/admin/competencias?coleccion=<id>`).
+  - **El plan de evaluación y las entrevistas solo ofrecen —y aceptan— las
+    competencias del grupo.** `PlanEvaluacion.periodos[].competencias` son ids
+    sueltos sin FK: si un periodo referenciara una competencia de otra materia, el
+    alumno no tendría celda para ella y `computeCompetenciasScore` la omitiría del
+    promedio — **la nota cambiaría sin que nadie tocara nada**. Ahora se valida la
+    pertenencia, no solo la existencia.
+  - **Una competencia calculada solo puede depender de competencias de su misma
+    colección.** Si dependiera de una de otra materia, el alumno no tendría celda
+    para esa dependencia y la calculada quedaría sin evaluar **para siempre, sin
+    error ni log**. Se valida en el servidor y ni siquiera se ofrece en el form.
+  - **Crear una malla sin colecciones ya no falla en silencio**: si el grupo no
+    tiene materia asignada, el error lo dice y manda a Editar Grupo, en vez de
+    dejar una malla vacía.
+  - `scripts/migrate-competencias-coleccion.ts` — backfill idempotente con
+    `--dry-run`. **No toca ninguna calificación**: las 198 celdas de malla, los
+    planes y las entrevistas siguen apuntando a las mismas competencias.
 - **Las Páginas se alcanzan desde Contenidos**, que es donde viven (cada `Pagina`
   pertenece a una `Coleccion`). Cada colección gana una acción **"Páginas"** que
   abre las suyas **ya filtradas**; el filtro vive ahora en la URL

--- a/packages/api/scripts/migrate-competencias-coleccion.ts
+++ b/packages/api/scripts/migrate-competencias-coleccion.ts
@@ -1,0 +1,123 @@
+/**
+ * Backfill: `Competencia.coleccion` + colección para los grupos que no tienen.
+ *
+ * Las competencias eran GLOBALES: una sola lista que se materializaba para todos
+ * los alumnos de todos los grupos. Ahora la malla se arma con las competencias de
+ * las colecciones del grupo (`Grupo.colecciones` → `Competencia.coleccion`).
+ *
+ * Sin este backfill, una competencia sin colección **no le llega a nadie** y un
+ * grupo sin colecciones se queda sin malla.
+ *
+ * NO TOCA NINGUNA CALIFICACIÓN. `CompetenciaAlumno`, `PlanEvaluacion`,
+ * `Entrevista` y `EvaluacionEntrevista` se quedan exactamente como están: siguen
+ * apuntando a las mismas competencias por pointer/id. Lo único que cambia es de
+ * qué colección es cada competencia.
+ *
+ * Idempotente: solo toca lo que aún no tiene colección.
+ *
+ *   ./node_modules/.bin/tsx scripts/migrate-competencias-coleccion.ts --coleccion tc2005b --dry-run
+ *   ./node_modules/.bin/tsx scripts/migrate-competencias-coleccion.ts --coleccion tc2005b
+ *
+ * ⚠️ Dev comparte la BD de PRODUCCIÓN. Corre --dry-run primero, y córrelo ANTES
+ *    de desplegar: el código viejo ignora el campo, pero el nuevo, sin backfill,
+ *    dejaría a todos los grupos sin competencias.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const i = argv.indexOf('--coleccion');
+  const slug = i >= 0 ? argv[i + 1] : undefined;
+  if (!slug) {
+    console.error('Uso: migrate-competencias-coleccion.ts --coleccion <slug> [--dry-run]');
+    process.exit(1);
+  }
+  return { slug, dryRun };
+}
+
+async function main() {
+  const { slug, dryRun } = parseArgs();
+
+  const qc = new Parse.Query('Coleccion');
+  qc.equalTo('slug', slug);
+  qc.equalTo('exists', true);
+  const coleccion = await qc.first({ useMasterKey: true });
+  if (!coleccion) {
+    console.error(`✗ No existe la colección con slug "${slug}". Abortado.`);
+    process.exit(1);
+  }
+  console.log(`Colección destino: ${coleccion.get('nombre')} (${coleccion.get('clave')})\n`);
+
+  /* ── 1. Competencias sin colección ── */
+  const qk = new Parse.Query('Competencia');
+  qk.equalTo('exists', true);
+  qk.doesNotExist('coleccion');
+  qk.ascending('orden');
+  qk.limit(1000);
+  const huerfanas = await qk.find({ useMasterKey: true });
+
+  console.log(`── COMPETENCIAS sin colección: ${huerfanas.length}`);
+  for (const c of huerfanas) {
+    const tipo = c.get('esCalculada') ? 'calculada' : 'directa  ';
+    console.log(`   ${dryRun ? '[dry-run]' : '[migrar] '} ${tipo}  ${c.get('competencia')}`);
+  }
+
+  /* ── 2. Grupos sin colecciones ──
+     Un grupo sin colecciones se queda sin competencias: no podría crear la malla
+     de un alumno nuevo. Se le asigna la misma colección. */
+  const qg = new Parse.Query('Grupo');
+  qg.equalTo('exists', true);
+  qg.include('colecciones');
+  qg.limit(500);
+  const grupos = await qg.find({ useMasterKey: true });
+  const sinColecciones = grupos.filter(
+    (g) => ((g.get('colecciones') ?? []) as Parse.Object[]).filter((c) => c && c.get('exists') !== false).length === 0,
+  );
+
+  console.log(`\n── GRUPOS sin colecciones: ${sinColecciones.length} de ${grupos.length}`);
+  for (const g of grupos) {
+    const cols = ((g.get('colecciones') ?? []) as Parse.Object[]).filter((c) => c && c.get('exists') !== false);
+    const marca = cols.length === 0 ? (dryRun ? '[dry-run]' : '[asignar]') : '[ya tiene]';
+    console.log(`   ${marca} ${String(g.get('name')).padEnd(12)} [${cols.map((c) => c.get('slug')).join(', ') || '(ninguna)'}]`);
+  }
+
+  /* ── 3. Comprobación de seguridad: nada de calificaciones se toca ── */
+  const qca = new Parse.Query('CompetenciaAlumno');
+  qca.equalTo('exists', true);
+  qca.limit(5000);
+  const celdas = await qca.find({ useMasterKey: true });
+  console.log(`\n── CALIFICACIONES: ${celdas.length} celdas de malla — NO se tocan (siguen apuntando a las mismas competencias).`);
+
+  if (huerfanas.length === 0 && sinColecciones.length === 0) {
+    console.log('\n✓ Nada que migrar.');
+    return;
+  }
+  if (dryRun) {
+    console.log('\n--dry-run: no se escribió nada. Quita la bandera para aplicar.');
+    return;
+  }
+
+  if (huerfanas.length > 0) {
+    for (const c of huerfanas) c.set('coleccion', coleccion);
+    await Parse.Object.saveAll(huerfanas, { useMasterKey: true });
+    console.log(`\n✓ ${huerfanas.length} competencia(s) asignadas a "${slug}".`);
+  }
+  if (sinColecciones.length > 0) {
+    for (const g of sinColecciones) g.set('colecciones', [coleccion]);
+    await Parse.Object.saveAll(sinColecciones, { useMasterKey: true });
+    console.log(`✓ ${sinColecciones.length} grupo(s) con la colección "${slug}" asignada.`);
+    console.log('  (esto también les da acceso a la documentación de esa colección en el CMS)');
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/competencias-alumno.controller.ts
+++ b/packages/api/src/controllers/competencias-alumno.controller.ts
@@ -5,6 +5,7 @@ import { Competencia } from '../models/Competencia.js';
 import { AppUser } from '../models/AppUser.js';
 import { Grupo } from '../models/Grupo.js';
 import { getAlumnosDeGrupo } from '../services/grupo-alumno.service.js';
+import { competenciasDeGrupo } from '../services/competencias.service.js';
 
 export async function crearCompetenciasAlumno(req: Request, res: Response): Promise<void> {
   const { grupoId } = req.params;
@@ -12,16 +13,26 @@ export async function crearCompetenciasAlumno(req: Request, res: Response): Prom
   try {
     const grupoPointer = Parse.Object.extend('Grupo').createWithoutData(grupoId) as Grupo;
 
-    // Fetch competencias activas
-    const compQuery = new Parse.Query<Competencia>('Competencia');
-    compQuery.equalTo('exists' as any, true as any);
-    compQuery.equalTo('active' as any, true as any);
-    compQuery.ascending('orden');
-    compQuery.limit(1000);
-    const competencias = await compQuery.find({ useMasterKey: true });
+    // La malla se materializa SOLO con las competencias de las colecciones del
+    // grupo. Antes se usaba la lista global: todos los grupos recibían todas las
+    // competencias, incluso las de otra materia.
+    const { competencias, sinColecciones } = await competenciasDeGrupo(grupoId);
 
+    // Los dos vacíos se distinguen a propósito: "el grupo no tiene materia" y
+    // "la materia no tiene competencias" son problemas distintos, y un mensaje
+    // genérico manda al admin a buscar en el sitio equivocado.
+    if (sinColecciones) {
+      res.status(400).json({
+        status: 'error',
+        message: 'El grupo no tiene colecciones asignadas: asígnale una materia en Editar Grupo para poder crear su malla.',
+      });
+      return;
+    }
     if (competencias.length === 0) {
-      res.status(404).json({ status: 'error', message: 'No hay competencias activas' });
+      res.status(404).json({
+        status: 'error',
+        message: 'Las colecciones de este grupo no tienen competencias activas.',
+      });
       return;
     }
 

--- a/packages/api/src/controllers/competencias.controller.ts
+++ b/packages/api/src/controllers/competencias.controller.ts
@@ -2,13 +2,95 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { Competencia } from '../models/Competencia.js';
+import { coleccionesDeGrupo } from '../services/competencias.service.js';
 
-export async function listCompetencias(_req: Request, res: Response): Promise<void> {
+/** Resuelve un coleccionId a un pointer VALIDADO. `null` si no existe. */
+async function resolverColeccion(coleccionId: string): Promise<Parse.Object | null> {
+  const q = new Parse.Query('Coleccion');
+  q.equalTo('exists' as any, true as any);
+  try {
+    return await q.get(coleccionId, { useMasterKey: true });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Comprueba que las dependencias de una calculada estén en la MISMA colección.
+ *
+ * Si una calculada de TC2005B dependiera de una directa de TC2007B, el alumno de
+ * un grupo de TC2005B no tendría celda para esa dependencia: `recalcularCalculadas`
+ * la vería como "sin evaluar" y dejaría la calculada vacía **para siempre, sin
+ * error ni log**. Es la clase de fallo que hay que hacer imposible, no depurar.
+ *
+ * Devuelve el mensaje de error, o null si todo cuadra.
+ */
+async function validarDependencias(
+  ids: string[],
+  coleccionId: string | null,
+  propioId?: string,
+): Promise<string | null> {
+  if (ids.length === 0) return null;
+  if (ids.some((d) => d === propioId)) return 'Una competencia no puede depender de sí misma';
+
+  const q = new Parse.Query('Competencia');
+  q.equalTo('exists' as any, true as any);
+  q.containedIn('objectId' as any, ids as any);
+  q.include('coleccion' as any);
+  const deps = await q.find({ useMasterKey: true });
+
+  if (deps.length !== new Set(ids).size) return 'Alguna dependencia indicada no existe';
+
+  const fuera = deps.filter((d) => (d.get('coleccion')?.id ?? null) !== coleccionId);
+  if (fuera.length > 0) {
+    const nombres = fuera.map((d) => d.get('competencia')).join(', ');
+    return `Las dependencias deben pertenecer a la misma colección. Fuera de la colección: ${nombres}`;
+  }
+  return null;
+}
+
+/**
+ * Lista competencias.
+ *
+ * - `?coleccionId=` → las de esa colección (`sin-coleccion` = las huérfanas).
+ * - `?grupoId=`     → las de las colecciones del grupo. Es lo que deben usar el
+ *   plan de evaluación y las entrevistas: ofrecer competencias que no le tocan al
+ *   grupo lleva a mallas incoherentes.
+ * - sin parámetros  → todas (la vista global del admin).
+ */
+export async function listCompetencias(req: Request, res: Response): Promise<void> {
+  const { coleccionId, grupoId } = req.query;
+
   try {
     const query = new Parse.Query<Competencia>('Competencia');
     query.equalTo('exists' as any, true as any);
     query.ascending('orden');
     query.include('dependencias' as any);
+    query.include('coleccion' as any);
+    query.limit(1000);
+
+    if (typeof grupoId === 'string' && grupoId) {
+      const colecciones = await coleccionesDeGrupo(grupoId);
+      if (colecciones.length === 0) {
+        // Sin colecciones no hay competencias que le toquen: lista vacía, y se
+        // avisa para que la UI pueda explicar por qué en vez de mostrar un hueco.
+        res.json({ status: 'ok', competencias: [], sinColecciones: true });
+        return;
+      }
+      query.containedIn('coleccion' as any, colecciones as any);
+    } else if (typeof coleccionId === 'string' && coleccionId) {
+      if (coleccionId === 'sin-coleccion') {
+        query.doesNotExist('coleccion' as any);
+      } else {
+        const coleccion = await resolverColeccion(coleccionId);
+        if (!coleccion) {
+          res.status(404).json({ status: 'error', message: 'Colección no encontrada' });
+          return;
+        }
+        query.equalTo('coleccion' as any, coleccion as any);
+      }
+    }
+
     const competencias = await query.find({ useMasterKey: true });
 
     res.json({
@@ -21,7 +103,7 @@ export async function listCompetencias(_req: Request, res: Response): Promise<vo
 }
 
 export async function createCompetencia(req: Request, res: Response): Promise<void> {
-  const { competencia, nivel, descripcionNivel, guiaEvidencias, incipienteB, incipienteA, basico, solido, destacado, fechaIdealEvaluacion, orden, esCalculada, dependencias } = req.body;
+  const { competencia, nivel, descripcionNivel, guiaEvidencias, incipienteB, incipienteA, basico, solido, destacado, fechaIdealEvaluacion, orden, esCalculada, dependencias, coleccionId } = req.body;
 
   if (!competencia || typeof competencia !== 'string' || competencia.trim() === '') {
     res.status(400).json({ status: 'error', message: 'La competencia es requerida' });
@@ -43,7 +125,28 @@ export async function createCompetencia(req: Request, res: Response): Promise<vo
   }
 
   try {
+    // Sin colección la competencia no le llega a ningún alumno (la malla se
+    // materializa desde `Grupo.colecciones`), así que se exige.
+    if (!coleccionId || typeof coleccionId !== 'string') {
+      res.status(400).json({ status: 'error', message: 'La colección es requerida: sin ella la competencia no aparece en ninguna malla' });
+      return;
+    }
+    const coleccion = await resolverColeccion(coleccionId);
+    if (!coleccion) {
+      res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+      return;
+    }
+
+    if (isCalculada) {
+      const err = await validarDependencias(dependencias as string[], coleccion.id!);
+      if (err) {
+        res.status(400).json({ status: 'error', message: err });
+        return;
+      }
+    }
+
     const comp = new Competencia().initDefaults();
+    comp.setColeccion(coleccion);
     comp.setCompetencia(competencia.trim());
     comp.setNivel(nivel.trim());
     if (descripcionNivel) comp.setDescripcionNivel(descripcionNivel.trim());
@@ -71,6 +174,7 @@ export async function createCompetencia(req: Request, res: Response): Promise<vo
     // Re-fetch with include to return full dependencias data
     const fetchQuery = new Parse.Query<Competencia>('Competencia');
     fetchQuery.include('dependencias' as any);
+    fetchQuery.include('coleccion' as any);
     const saved = await fetchQuery.get(comp.id, { useMasterKey: true });
 
     res.status(201).json({ status: 'ok', competencia: saved.toSafeJSON() });
@@ -81,11 +185,30 @@ export async function createCompetencia(req: Request, res: Response): Promise<vo
 
 export async function updateCompetencia(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { competencia, nivel, descripcionNivel, guiaEvidencias, incipienteB, incipienteA, basico, solido, destacado, fechaIdealEvaluacion, orden, esCalculada, dependencias } = req.body;
+  const { competencia, nivel, descripcionNivel, guiaEvidencias, incipienteB, incipienteA, basico, solido, destacado, fechaIdealEvaluacion, orden, esCalculada, dependencias, coleccionId } = req.body;
 
   try {
     const query = BaseModel.queryActive<Competencia>('Competencia');
+    query.include('coleccion' as any);
     const comp = await query.get(id, { useMasterKey: true });
+
+    // La colección efectiva tras este update: se valida contra ella, no contra
+    // la que tenía antes (si se mueve de colección, sus dependencias también
+    // tienen que estar en la nueva).
+    let coleccionFinalId = comp.getColeccion()?.id ?? null;
+    if (coleccionId !== undefined) {
+      if (!coleccionId || typeof coleccionId !== 'string') {
+        res.status(400).json({ status: 'error', message: 'La colección es requerida' });
+        return;
+      }
+      const coleccion = await resolverColeccion(coleccionId);
+      if (!coleccion) {
+        res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+        return;
+      }
+      comp.setColeccion(coleccion);
+      coleccionFinalId = coleccion.id!;
+    }
 
     if (competencia !== undefined) {
       if (typeof competencia !== 'string' || competencia.trim() === '') {
@@ -120,6 +243,11 @@ export async function updateCompetencia(req: Request, res: Response): Promise<vo
           res.status(400).json({ status: 'error', message: 'Una competencia calculada debe tener al menos 1 dependencia' });
           return;
         }
+        const err = await validarDependencias(dependencias as string[], coleccionFinalId, id);
+        if (err) {
+          res.status(400).json({ status: 'error', message: err });
+          return;
+        }
         const depPointers = dependencias.map((depId: string) =>
           Parse.Object.extend('Competencia').createWithoutData(depId),
         );
@@ -127,13 +255,25 @@ export async function updateCompetencia(req: Request, res: Response): Promise<vo
       } else {
         comp.setDependencias([]);
       }
-    } else if (dependencias !== undefined) {
-      // Update dependencias without changing esCalculada
-      if (Array.isArray(dependencias)) {
-        const depPointers = dependencias.map((depId: string) =>
-          Parse.Object.extend('Competencia').createWithoutData(depId),
-        );
-        comp.setDependencias(depPointers);
+    } else if (dependencias !== undefined && Array.isArray(dependencias)) {
+      // Cambiar dependencias sin tocar esCalculada.
+      const err = await validarDependencias(dependencias as string[], coleccionFinalId, id);
+      if (err) {
+        res.status(400).json({ status: 'error', message: err });
+        return;
+      }
+      const depPointers = dependencias.map((depId: string) =>
+        Parse.Object.extend('Competencia').createWithoutData(depId),
+      );
+      comp.setDependencias(depPointers);
+    } else if (coleccionId !== undefined && comp.getEsCalculada()) {
+      // Se movió de colección sin tocar dependencias: las que tenía podrían
+      // haber quedado fuera. Se revalidan contra la colección nueva.
+      const depsActuales = comp.getDependencias().map((d) => d.id!);
+      const err = await validarDependencias(depsActuales, coleccionFinalId, id);
+      if (err) {
+        res.status(400).json({ status: 'error', message: `${err} — mueve también sus dependencias, o cámbialas.` });
+        return;
       }
     }
 
@@ -142,6 +282,7 @@ export async function updateCompetencia(req: Request, res: Response): Promise<vo
     // Re-fetch with include to return full dependencias data
     const fetchQuery = new Parse.Query<Competencia>('Competencia');
     fetchQuery.include('dependencias' as any);
+    fetchQuery.include('coleccion' as any);
     const saved = await fetchQuery.get(comp.id, { useMasterKey: true });
 
     res.json({ status: 'ok', competencia: saved.toSafeJSON() });

--- a/packages/api/src/controllers/plan-evaluacion.controller.ts
+++ b/packages/api/src/controllers/plan-evaluacion.controller.ts
@@ -3,6 +3,7 @@ import Parse from 'parse/node';
 import { PlanEvaluacion } from '../models/PlanEvaluacion.js';
 import { Grupo } from '../models/Grupo.js';
 import { Competencia } from '../models/Competencia.js';
+import { competenciasDeGrupo } from '../services/competencias.service.js';
 import { ActividadEvaluacionGrupo } from '../models/ActividadEvaluacionGrupo.js';
 import { BaseModel } from '../models/BaseModel.js';
 import type { PeriodoConfig } from '../models/PlanEvaluacion.js';
@@ -53,15 +54,30 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
     const grupoQuery = BaseModel.queryActive<Grupo>('Grupo');
     const grupo = await grupoQuery.get(grupoId, { useMasterKey: true });
 
-    // Validate competencia IDs exist
+    // Validar que las competencias existan Y que le toquen a ESTE grupo.
+    //
+    // `PlanEvaluacion.periodos[].competencias` son ids sueltos en un array JSON,
+    // sin FK. Si un periodo referenciara una competencia de otra materia, el
+    // alumno no tendría celda para ella: `computeCompetenciasScore` simplemente
+    // no la encontraría y la omitiría del promedio — la nota cambiaría sin que
+    // nadie tocara nada. Por eso se valida la pertenencia, no solo la existencia.
     const allCompIds = [...new Set(periodos.flatMap((p: PeriodoConfig) => p.competencias))];
     if (allCompIds.length > 0) {
-      const compQuery = new Parse.Query<Competencia>('Competencia');
-      compQuery.equalTo('exists' as any, true as any);
-      compQuery.containedIn('objectId' as any, allCompIds as any);
-      const found = await compQuery.find({ useMasterKey: true });
-      if (found.length !== allCompIds.length) {
-        res.status(400).json({ status: 'error', message: 'Algunas competencias no existen' });
+      const { competencias: permitidas, sinColecciones } = await competenciasDeGrupo(grupoId);
+      if (sinColecciones) {
+        res.status(400).json({
+          status: 'error',
+          message: 'El grupo no tiene colecciones asignadas: no puede tener competencias en su plan.',
+        });
+        return;
+      }
+      const permitidasIds = new Set(permitidas.map((c) => c.id!));
+      const fuera = allCompIds.filter((id: string) => !permitidasIds.has(id));
+      if (fuera.length > 0) {
+        res.status(400).json({
+          status: 'error',
+          message: `${fuera.length} competencia(s) del plan no pertenecen a las colecciones de este grupo.`,
+        });
         return;
       }
     }

--- a/packages/api/src/models/Competencia.ts
+++ b/packages/api/src/models/Competencia.ts
@@ -97,11 +97,42 @@ export class Competencia extends BaseModel {
     this.set('dependencias', deps);
   }
 
+  /**
+   * Colección (materia) a la que pertenece la competencia — pointer, nunca string.
+   *
+   * NO es decorativo: la malla de un alumno se materializa solo con las
+   * competencias de las colecciones de su grupo (`Grupo.colecciones`). Una
+   * competencia sin colección no le llega a nadie.
+   *
+   * Una competencia CALCULADA solo puede depender de competencias de SU MISMA
+   * colección: si dependiera de una de otra, el alumno no tendría celda para esa
+   * dependencia y la calculada quedaría sin evaluar para siempre, en silencio.
+   * Lo valida `competencias.controller.ts`.
+   */
+  getColeccion(): Parse.Object | undefined {
+    return this.get('coleccion');
+  }
+  setColeccion(coleccion: Parse.Object): void {
+    this.set('coleccion', coleccion);
+  }
+
   toSafeJSON(): Record<string, unknown> {
     const deps = this.getDependencias();
+    const coleccion = this.getColeccion();
+    const coleccionActiva = coleccion && coleccion.get('exists') !== false ? coleccion : null;
     return {
       id: this.id,
       competencia: this.getCompetencia(),
+      coleccionId: coleccionActiva?.id ?? null,
+      // Requiere query.include('coleccion') para traer nombre/clave.
+      coleccion: coleccionActiva
+        ? {
+            id: coleccionActiva.id,
+            nombre: coleccionActiva.get('nombre') ?? null,
+            slug: coleccionActiva.get('slug') ?? null,
+            clave: coleccionActiva.get('clave') ?? null,
+          }
+        : null,
       nivel: this.getNivel(),
       descripcionNivel: this.getDescripcionNivel(),
       guiaEvidencias: this.getGuiaEvidencias(),

--- a/packages/api/src/services/competencias.service.ts
+++ b/packages/api/src/services/competencias.service.ts
@@ -1,0 +1,61 @@
+import Parse from 'parse/node';
+
+/**
+ * Resolución de "qué competencias le tocan a un grupo".
+ *
+ * La cadena es: `Grupo.colecciones[]` → `Competencia.coleccion`. Vive aquí y no
+ * en un controller porque la necesitan varios (crear la malla del alumno,
+ * validar el plan de evaluación, poblar los selectores del admin) y si cada uno
+ * la reimplementa, divergen — que es exactamente lo que ya pasó con
+ * `recalcularCalculadas`, duplicada en dos archivos.
+ */
+
+/** Colecciones (pointers) asignadas al grupo. Vacío si no tiene o no existe. */
+export async function coleccionesDeGrupo(grupoId: string): Promise<Parse.Object[]> {
+  const query = new Parse.Query('Grupo');
+  query.equalTo('exists' as any, true as any);
+  query.include('colecciones' as any);
+  try {
+    const grupo = await query.get(grupoId, { useMasterKey: true });
+    const cols = (grupo.get('colecciones') ?? []) as Parse.Object[];
+    return cols.filter((c) => c && c.get('exists') !== false);
+  } catch {
+    return [];
+  }
+}
+
+export interface CompetenciasDeGrupo {
+  competencias: Parse.Object[];
+  /**
+   * El grupo no tiene ninguna colección asignada. Se distingue de "tiene
+   * colecciones pero están vacías de competencias" a propósito: son problemas
+   * distintos y el mensaje de error debe decir cuál es.
+   */
+  sinColecciones: boolean;
+}
+
+/**
+ * Competencias ACTIVAS de las colecciones del grupo, ordenadas.
+ *
+ * Ojo: filtra por `active`, igual que hacía el query global que sustituye. La
+ * lista del admin (`listCompetencias`) NO filtra `active` — esa asimetría ya
+ * existía y no la toco aquí, pero es la razón de que una competencia inactiva se
+ * vea en el admin y nunca aparezca en la malla de nadie.
+ */
+export async function competenciasDeGrupo(grupoId: string): Promise<CompetenciasDeGrupo> {
+  const colecciones = await coleccionesDeGrupo(grupoId);
+  if (colecciones.length === 0) {
+    return { competencias: [], sinColecciones: true };
+  }
+
+  const query = new Parse.Query('Competencia');
+  query.equalTo('exists' as any, true as any);
+  query.equalTo('active' as any, true as any);
+  query.containedIn('coleccion' as any, colecciones as any);
+  query.ascending('orden');
+  query.include('dependencias' as any);
+  query.limit(1000);
+  const competencias = await query.find({ useMasterKey: true });
+
+  return { competencias, sinColecciones: false };
+}

--- a/packages/web/src/components/dashboard/organisms/CompetenciaForm/CompetenciaForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/CompetenciaForm/CompetenciaForm.tsx
@@ -23,23 +23,46 @@ interface CompetenciaData {
   fechaIdealEvaluacion?: string;
   esCalculada?: boolean;
   dependencias?: DependenciaRef[];
+  coleccionId?: string | null;
 }
 
 interface CompetenciaOption {
   id: string;
   competencia: string;
   esCalculada?: boolean;
+  coleccionId?: string | null;
+}
+
+interface ColeccionOption {
+  id: string;
+  nombre: string;
+  slug: string;
+  clave: string | null;
 }
 
 interface CompetenciaFormProps {
   competencia?: CompetenciaData;
   allCompetencias?: CompetenciaOption[];
+  colecciones?: ColeccionOption[];
+  /** Preselecciona la colección (p. ej. si se entró filtrando por una). */
+  coleccionInicial?: string;
   onSave: (data: Omit<CompetenciaData, 'id'>) => void;
   onCancel: () => void;
   loading?: boolean;
 }
 
-export default function CompetenciaForm({ competencia, allCompetencias = [], onSave, onCancel, loading }: CompetenciaFormProps) {
+export default function CompetenciaForm({
+  competencia,
+  allCompetencias = [],
+  colecciones = [],
+  coleccionInicial,
+  onSave,
+  onCancel,
+  loading,
+}: CompetenciaFormProps) {
+  const [coleccionId, setColeccionId] = useState(
+    competencia?.coleccionId ?? coleccionInicial ?? '',
+  );
   const [orden, setOrden] = useState<number | ''>(competencia?.orden ?? '');
   const [nombre, setNombre] = useState(competencia?.competencia ?? '');
   const [nivel, setNivel] = useState(competencia?.nivel ?? '');
@@ -57,12 +80,22 @@ export default function CompetenciaForm({ competencia, allCompetencias = [], onS
   );
   const [error, setError] = useState('');
 
-  // Filter: only show direct (non-calculated) competencias, exclude self
+  // Dependencias posibles: directas, no ella misma, y **de la misma colección**.
+  // Una calculada que dependiera de una competencia de otra materia quedaría sin
+  // evaluar para siempre: el alumno no tendría celda para esa dependencia. El
+  // servidor también lo rechaza; aquí simplemente no se ofrece.
   const availableDeps = allCompetencias.filter(
-    (c) => !c.esCalculada && c.id !== competencia?.id,
+    (c) =>
+      !c.esCalculada &&
+      c.id !== competencia?.id &&
+      (c.coleccionId ?? '') === coleccionId,
   );
 
   function handleSubmit() {
+    if (!coleccionId) {
+      setError('La colección es requerida: sin ella la competencia no aparece en ninguna malla');
+      return;
+    }
     if (!nombre.trim()) {
       setError('La competencia es requerida');
       return;
@@ -77,6 +110,7 @@ export default function CompetenciaForm({ competencia, allCompetencias = [], onS
     }
     setError('');
     onSave({
+      coleccionId,
       orden: orden !== '' ? Number(orden) : undefined,
       competencia: nombre.trim(),
       nivel: nivel.trim(),
@@ -101,6 +135,31 @@ export default function CompetenciaForm({ competencia, allCompetencias = [], onS
 
   return (
     <div className={styles.form}>
+      <div className={styles.field}>
+        <label className={styles.label}>Colección (materia) *</label>
+        <select
+          className={styles.select}
+          value={coleccionId}
+          onChange={(e) => {
+            // Al cambiar de colección, las dependencias elegidas pueden haber
+            // quedado fuera: se limpian en vez de guardarse inválidas.
+            setColeccionId(e.target.value);
+            setSelectedDeps([]);
+            setError('');
+          }}
+          disabled={loading}
+        >
+          <option value="">Selecciona una colección…</option>
+          {colecciones.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.clave ? `${c.clave} — ${c.nombre}` : c.nombre}
+            </option>
+          ))}
+        </select>
+        <span className={styles.hint}>
+          La malla de un alumno se arma con las competencias de las colecciones de su grupo.
+        </span>
+      </div>
       <TextInput
         label="Orden"
         placeholder="Ej: 0"

--- a/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.module.css
+++ b/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.module.css
@@ -64,3 +64,34 @@ details[open] > .panelSummary .material-icons {
   overflow: hidden;
   white-space: pre-line;
 }
+
+/* Cabecera: vuelta a Contenidos + de qué colección son las competencias. */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.volver {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+.volver:hover {
+  color: var(--text-primary);
+}
+.volver .material-icons {
+  font-size: 18px;
+}
+
+.pageTitleSub {
+  margin-left: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}

--- a/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
@@ -1,9 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams, Link } from 'react-router';
 import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
 import Modal from '../../atoms/Modal/Modal';
+import type { ColeccionRef } from '../../../../types/contenidos';
 import IndicacionMallaForm from '../../organisms/IndicacionMallaForm/IndicacionMallaForm';
 import CompetenciaForm from '../../organisms/CompetenciaForm/CompetenciaForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
@@ -34,6 +36,8 @@ interface CompetenciaData {
   fechaIdealEvaluacion?: string;
   esCalculada?: boolean;
   dependencias?: DependenciaRef[];
+  coleccionId?: string | null;
+  coleccion?: { id: string; nombre: string | null; slug: string | null; clave: string | null } | null;
 }
 
 const API_BASE = '/api';
@@ -43,6 +47,22 @@ export default function CompetenciasPage() {
 
   const [indicaciones, setIndicaciones] = useState<IndicacionData[]>([]);
   const [competencias, setCompetencias] = useState<CompetenciaData[]>([]);
+  const [colecciones, setColecciones] = useState<ColeccionRef[]>([]);
+
+  // El filtro por colección vive en la URL: la acción "Competencias" de la tabla
+  // de Contenidos llega aquí ya filtrada, y el enlace se puede compartir.
+  const [searchParams] = useSearchParams();
+  const filtroColeccion = searchParams.get('coleccion') ?? '';
+
+  const coleccionActiva = useMemo(
+    () => colecciones.find((c) => c.id === filtroColeccion) ?? null,
+    [colecciones, filtroColeccion],
+  );
+
+  const competenciasFiltradas = useMemo(
+    () => (filtroColeccion ? competencias.filter((c) => c.coleccionId === filtroColeccion) : competencias),
+    [competencias, filtroColeccion],
+  );
   const [loadingInd, setLoadingInd] = useState(true);
   const [loadingComp, setLoadingComp] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -75,6 +95,9 @@ export default function CompetenciasPage() {
     }
   }, [sessionToken]);
 
+  // Siempre se piden TODAS: el filtro por colección se aplica en cliente porque
+  // el formulario necesita la lista completa para el picker de dependencias (que
+  // luego acota a la colección elegida).
   const fetchCompetencias = useCallback(async () => {
     try {
       setLoadingComp(true);
@@ -91,10 +114,24 @@ export default function CompetenciasPage() {
     }
   }, [sessionToken]);
 
+  const fetchColecciones = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/admin/colecciones`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setColecciones(data.colecciones ?? []);
+    } catch {
+      // no crítico: sin colecciones el form no deja crear, que es lo correcto
+    }
+  }, [sessionToken]);
+
   useEffect(() => {
     fetchIndicaciones();
     fetchCompetencias();
-  }, [fetchIndicaciones, fetchCompetencias]);
+    fetchColecciones();
+  }, [fetchIndicaciones, fetchCompetencias, fetchColecciones]);
 
   // --- Indicaciones CRUD ---
   function openCreateInd() {
@@ -205,6 +242,20 @@ export default function CompetenciasPage() {
   const compColumns = [
     compColumnHelper.accessor('orden', { header: 'Orden', cell: (info) => info.getValue() ?? '—' }),
     compColumnHelper.accessor('competencia', { header: 'Competencia' }),
+    // Solo en la vista global: filtrando, la colección ya está en el título y la
+    // columna sería la misma palabra repetida en todas las filas.
+    ...(coleccionActiva
+      ? []
+      : [
+          compColumnHelper.accessor('coleccion', {
+            header: 'Colección',
+            cell: (info) => {
+              const col = info.getValue();
+              if (!col) return <span style={{ color: 'var(--dash-danger)' }}>Sin asignar</span>;
+              return <span>{col.clave ?? col.slug}</span>;
+            },
+          }),
+        ]),
     compColumnHelper.accessor('nivel', { header: 'Nivel' }),
     compColumnHelper.accessor('esCalculada', {
       header: 'Tipo',
@@ -270,32 +321,52 @@ export default function CompetenciasPage() {
 
   return (
     <div className={styles.page}>
-      <h1 className={styles.pageTitle}>Competencias</h1>
+      <div className={styles.header}>
+        {coleccionActiva && (
+          <Link to="/admin/contenidos" className={styles.volver}>
+            <span className="material-icons">arrow_back</span>
+            <span>Contenidos</span>
+          </Link>
+        )}
+        <h1 className={styles.pageTitle}>
+          Competencias
+          {coleccionActiva && (
+            <span className={styles.pageTitleSub}>
+              {coleccionActiva.clave ?? coleccionActiva.slug} — {coleccionActiva.nombre}
+            </span>
+          )}
+        </h1>
+      </div>
 
       {error && <div className={styles.error}>{error}</div>}
 
-      <details className={styles.panel}>
-        <summary className={styles.panelSummary}>
-          <span className="material-icons">chevron_right</span>
-          Indicaciones para Malla de Competencias
-        </summary>
-        <div className={styles.panelContent}>
-          {loadingInd ? (
-            <p>Cargando...</p>
-          ) : (
-            <AdminTable
-              title="Indicaciones"
-              columns={indColumns}
-              data={indicaciones}
-              actions={getIndActions}
-              onAdd={openCreateInd}
-              addLabel="Agregar Indicación"
-              emptyMessage="No hay indicaciones registradas"
-              searchPlaceholder="Buscar indicación..."
-            />
-          )}
-        </div>
-      </details>
+      {/* Las Indicaciones de Malla NO tienen colección: son globales. Mostrarlas
+          bajo el título de una colección haría creer que son suyas, así que solo
+          aparecen en la vista sin filtrar. */}
+      {!coleccionActiva && (
+        <details className={styles.panel}>
+          <summary className={styles.panelSummary}>
+            <span className="material-icons">chevron_right</span>
+            Indicaciones para Malla de Competencias
+          </summary>
+          <div className={styles.panelContent}>
+            {loadingInd ? (
+              <p>Cargando...</p>
+            ) : (
+              <AdminTable
+                title="Indicaciones"
+                columns={indColumns}
+                data={indicaciones}
+                actions={getIndActions}
+                onAdd={openCreateInd}
+                addLabel="Agregar Indicación"
+                emptyMessage="No hay indicaciones registradas"
+                searchPlaceholder="Buscar indicación..."
+              />
+            )}
+          </div>
+        </details>
+      )}
 
       <details open className={styles.panel}>
         <summary className={styles.panelSummary}>
@@ -309,7 +380,7 @@ export default function CompetenciasPage() {
             <AdminTable
               title="Competencias registradas"
               columns={compColumns}
-              data={competencias}
+              data={competenciasFiltradas}
               actions={getCompActions}
               onAdd={openCreateComp}
               addLabel="Agregar Competencia"
@@ -334,6 +405,8 @@ export default function CompetenciasPage() {
         <CompetenciaForm
           competencia={editCompetencia}
           allCompetencias={competencias}
+          colecciones={colecciones}
+          coleccionInicial={filtroColeccion || undefined}
           onSave={handleSaveComp}
           onCancel={closeCompModal}
           loading={saving}

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
@@ -127,6 +127,7 @@ export default function ContenidosPage() {
     // distintos de la misma colección; de ahí las dos acciones.
     { label: 'Abrir documentación', icon: 'account_tree', onClick: () => navigate(`/admin/contenidos/${coleccion.id}`) },
     { label: 'Páginas', icon: 'article', onClick: () => navigate(`/admin/paginas?coleccion=${coleccion.id}`) },
+    { label: 'Competencias', icon: 'emoji_events', onClick: () => navigate(`/admin/competencias?coleccion=${coleccion.id}`) },
     { label: 'Editar', icon: 'edit', onClick: () => openEdit(coleccion) },
     { label: 'Eliminar', icon: 'delete', onClick: () => handleDelete(coleccion), variant: 'danger' },
   ];

--- a/packages/web/src/components/dashboard/pages/EntrevistasPage/EntrevistasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EntrevistasPage/EntrevistasPage.tsx
@@ -82,7 +82,7 @@ export default function EntrevistasPage() {
         fetch(`${API_BASE}/admin/grupos/${grupoId}/entrevistas`, { headers: authHeaders }),
         fetch(`${API_BASE}/admin/grupos/${grupoId}/equipos`, { headers: authHeaders }),
         fetch(`${API_BASE}/admin/profesores`, { headers: authHeaders }),
-        fetch(`${API_BASE}/admin/competencias`, { headers: authHeaders }),
+        fetch(`${API_BASE}/admin/competencias?grupoId=${grupoId}`, { headers: authHeaders }),
         fetch(`${API_BASE}/admin/grupos/${grupoId}/entrevistas/progress`, { headers: authHeaders }),
       ]);
 

--- a/packages/web/src/components/dashboard/pages/GrupoDetailPage/GrupoDetailPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GrupoDetailPage/GrupoDetailPage.tsx
@@ -281,7 +281,7 @@ export default function GrupoDetailPage() {
 
   async function fetchCompetenciasList() {
     try {
-      const res = await fetch(`${API_BASE}/admin/competencias`, {
+      const res = await fetch(`${API_BASE}/admin/competencias?grupoId=${id}`, {
         headers: { 'x-session-token': sessionToken ?? '' },
       });
       if (res.ok) {

--- a/packages/web/src/components/dashboard/pages/PlanEvaluacionPage/PlanEvaluacionPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PlanEvaluacionPage/PlanEvaluacionPage.tsx
@@ -82,7 +82,7 @@ export default function PlanEvaluacionPage() {
 
       const [planRes, compRes, actRes] = await Promise.all([
         fetch(`${API_BASE}/admin/grupos/${grupoId}/plan-evaluacion`, { headers: authHeaders }),
-        fetch(`${API_BASE}/admin/competencias`, { headers: authHeaders }),
+        fetch(`${API_BASE}/admin/competencias?grupoId=${grupoId}`, { headers: authHeaders }),
         fetch(`${API_BASE}/admin/grupos/${grupoId}/actividades-evaluacion`, { headers: authHeaders }),
       ]);
 


### PR DESCRIPTION
## Descripción

Las competencias eran **globales**: una sola lista que se materializaba para **todos los alumnos de todos los grupos**, sin importar su materia. Con dos colecciones (TC2005B y TC2007B) eso ya no se sostiene.

Ahora `Competencia.coleccion` (pointer), y **la malla de un alumno se arma con las competencias de las colecciones de SU grupo**. Cada colección gana una acción **"Competencias"** en la tabla de Contenidos que abre las suyas ya filtradas (`/admin/competencias?coleccion=<id>`), igual que las Páginas.

## Esto NO es como las Páginas

Las páginas eran metadatos inertes. **De las competencias cuelgan las calificaciones:**

| | |
|---|---|
| Competencias | 9 (7 directas, 2 calculadas) |
| Celdas de malla (`CompetenciaAlumno`) | **198** |
| …con calificación real puesta | **198 de 198** |
| Planes de evaluación | 3, con 12 competencias cada uno **como ids sueltos, sin FK** |
| Entrevistas / evaluaciones | 6 / 40 |

Por eso el scope **manda de verdad**, y con guardas explícitas:

**Plan de evaluación.** `PlanEvaluacion.periodos[].competencias` son ids sueltos en un array JSON. Si un periodo referenciara una competencia de otra materia, el alumno **no tendría celda para ella** y `computeCompetenciasScore` simplemente la omitiría del promedio: **la nota cambiaría sin que nadie tocara nada**. Ahora se valida la **pertenencia** al grupo, no solo la existencia.

**Dependencias de las calculadas.** Una calculada solo puede depender de competencias de **su misma colección**. Si dependiera de una de otra materia, el alumno no tendría celda para esa dependencia, `recalcularCalculadas` la vería como "sin evaluar" y la calculada quedaría vacía **para siempre, sin error ni log**. Se valida en el servidor y ni siquiera se ofrece en el formulario.

**Malla sin colecciones.** Crear la malla de un grupo sin materia dejaba una malla vacía en silencio. Ahora el error lo dice y manda a Editar Grupo — y se distingue de *"la materia no tiene competencias"*, que es otro problema y se busca en otro sitio.

**Los consumidores per-grupo** (plan de evaluación, entrevistas, modal rápido) pedían la lista global; ahora piden `?grupoId=` y solo ofrecen lo que le toca al grupo.

La resolución `grupo → colecciones → competencias` vive en `services/competencias.service.ts`, no en cada controller: la necesitan cuatro, y si cada uno la reimplementa divergen — que es **exactamente lo que ya pasó con `recalcularCalculadas`, que está duplicada en dos archivos**.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores en `web` y `api`.
- [x] `yarn build` OK.

## Migración — ⚠️ correr ANTES del deploy

`scripts/migrate-competencias-coleccion.ts` (idempotente, `--dry-run`):

```
── COMPETENCIAS sin colección: 9  → todas a tc2005b
── GRUPOS sin colecciones: 1 de 3
   [ya tiene] FebJun26     [tc2005b]
   [ya tiene] Prueba       [tc2005b]
   [dry-run]  Prueba 2     [(ninguna)]  → recibe tc2005b
── CALIFICACIONES: 198 celdas — NO se tocan
```

**No toca ninguna calificación**: las 198 celdas, los 3 planes y las 6 entrevistas siguen apuntando a las mismas competencias por id. Lo único que cambia es de qué colección es cada competencia.

**Es un no-op de comportamiento** para FebJun26 y Prueba: sus colecciones son `[tc2005b]` y las 9 competencias van ahí, así que filtrar da **exactamente el mismo conjunto** que la lista global de hoy.

Hay que correrla **antes de desplegar**: el código viejo ignora el campo, pero el nuevo, sin backfill, dejaría a todos los grupos sin competencias.

**Nota:** asignar `tc2005b` a "Prueba 2" también le da acceso a la documentación de esa colección en el CMS. Es un efecto lateral querido —un grupo sin materia es una inconsistencia de datos—, pero conviene tenerlo presente.