### PR TITLE
feat(grupos): Páginas y Competencias de cada colección, desde el menú del grupo

### DIFF
--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.module.css
@@ -46,7 +46,9 @@
 
 /* Cada colección: enlace truncado a una sola línea con … */
 .link {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 7px;
   padding: 8px 12px;
   border-radius: 8px;
   color: var(--text-secondary);
@@ -66,4 +68,21 @@
   padding: 8px 12px;
   font-size: 13px;
   color: var(--text-secondary);
+}
+
+/* El texto trunca; el icono no. */
+.linkLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Enlace interno activo (Páginas/Competencias de la colección que se está viendo). */
+.linkActive,
+.linkActive:hover {
+  background: var(--sidebar-active-bg, #eef2ff);
+  color: var(--sidebar-active-color, #4f46e5);
+  font-weight: 600;
 }

--- a/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
+++ b/packages/web/src/components/dashboard/molecules/DocusMenu/DocusMenu.tsx
@@ -1,15 +1,24 @@
 import { useState } from 'react';
+import { NavLink } from 'react-router';
 import Icon from '../../atoms/Icon/Icon';
 import styles from './DocusMenu.module.css';
 
 /**
- * Una documentación habilitada para el grupo: destino + etiqueta
- * "CLAVE — Nombre" (colecciones del CMS: /contenidos/<slug>/).
+ * Una entrada del submenú "Contenidos" del grupo.
+ *
+ * Cada colección asignada al grupo aporta varias: su documentación (el visor,
+ * externo) y sus Páginas y Competencias (pantallas del admin, internas). La
+ * etiqueta va prefijada con la clave —"TC2005B — Páginas"— porque con más de una
+ * colección, "Páginas" a secas no dice de cuál.
  */
 export interface DocusLink {
-  slug: string;
+  /** Clave única del ítem: varias entradas comparten el slug de la colección. */
+  key: string;
   label: string;
   href: string;
+  /** Abre en pestaña nueva (el visor). Los enlaces del admin, no. */
+  externo?: boolean;
+  icono?: string;
 }
 
 interface DocusMenuProps {
@@ -20,9 +29,7 @@ interface DocusMenuProps {
 }
 
 /**
- * Ítem "Contenidos" del sidebar con submenú colapsable (colapsado por
- * defecto) que lista las colecciones del CMS habilitadas para el grupo.
- * Abre en pestaña nueva; etiqueta a una sola línea.
+ * Ítem "Contenidos" del sidebar con submenú colapsable (colapsado por defecto).
  */
 export default function DocusMenu({ items, collapsed, defaultOpen = false }: DocusMenuProps) {
   const [open, setOpen] = useState(defaultOpen);
@@ -53,18 +60,32 @@ export default function DocusMenu({ items, collapsed, defaultOpen = false }: Doc
           {items.length === 0 ? (
             <span className={styles.hint}>Sin contenidos asignados</span>
           ) : (
-            items.map((it) => (
-              <a
-                key={it.slug}
-                href={it.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.link}
-                title={it.label}
-              >
-                {it.label}
-              </a>
-            ))
+            items.map((it) =>
+              it.externo ? (
+                <a
+                  key={it.key}
+                  href={it.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.link}
+                  title={it.label}
+                >
+                  {it.icono && <Icon name={it.icono} size="sm" />}
+                  <span className={styles.linkLabel}>{it.label}</span>
+                </a>
+              ) : (
+                // Enlaces del admin: navegación interna, sin pestaña nueva.
+                <NavLink
+                  key={it.key}
+                  to={it.href}
+                  className={({ isActive }) => `${styles.link} ${isActive ? styles.linkActive : ''}`}
+                  title={it.label}
+                >
+                  {it.icono && <Icon name={it.icono} size="sm" />}
+                  <span className={styles.linkLabel}>{it.label}</span>
+                </NavLink>
+              ),
+            )
           )}
         </div>
       )}

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useMatch } from 'react-router';
+import { Link, useMatch, useSearchParams } from 'react-router';
 import NavItem from '../../molecules/NavItem/NavItem';
 import DocusMenu, { type DocusLink } from '../../molecules/DocusMenu/DocusMenu';
 import Icon from '../../atoms/Icon/Icon';
@@ -22,8 +22,18 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
   const grupoMatchExact = useMatch('/admin/grupos/:id');
   const grupoMatchSub = useMatch('/admin/grupos/:id/*');
   const grupoMatch = grupoMatchExact || grupoMatchSub;
-  const isGrupoDetail = !!grupoMatch;
-  const grupoId = grupoMatch?.params.id;
+
+  // Las Páginas y Competencias de un grupo viven en pantallas globales
+  // (/admin/paginas, /admin/competencias) filtradas por colección. Sin esto, al
+  // entrar ahí desde el menú del grupo el sidebar volvería al menú admin y se
+  // perdería la navegación del grupo. `?grupo=` conserva el contexto.
+  const [params] = useSearchParams();
+  // Solo para el admin: el menú del alumno no tiene modo "detalle de grupo", y un
+  // `?grupo=` en su URL no debe cambiarle el sidebar.
+  const grupoDeQuery = role === 'admin' ? params.get('grupo') : null;
+
+  const grupoId = grupoMatch?.params.id ?? grupoDeQuery ?? undefined;
+  const isGrupoDetail = !!grupoId;
 
   // Colección abierta: el sidebar se vuelve el árbol de páginas (mismo patrón
   // contextual que el detalle de grupo). Los datos vienen del provider, que los
@@ -85,19 +95,46 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
             id: string;
             name?: string;
             urlAgendaEntrevistas?: string | null;
-            colecciones?: { slug: string; nombre: string; clave: string | null }[];
+            colecciones?: { id: string; slug: string; nombre: string; clave: string | null }[];
           }) => g.id === grupoId,
         );
         if (found?.name) setGrupoName(found.name);
         setAgendaGrupoHref(found?.urlAgendaEntrevistas ?? null);
 
-        // Documentación del grupo = sus colecciones del CMS Contenidos.
-        const links: DocusLink[] = (found?.colecciones ?? []).map(
-          (c: { slug: string; nombre: string; clave: string | null }) => ({
-            slug: c.slug,
-            label: `${c.clave || c.slug.toUpperCase()} — ${c.nombre}`,
-            href: `/contenidos/${c.slug}/`,
-          }),
+        // Por cada colección del grupo, sus tres contenidos: la documentación
+        // (el visor, externo) y sus Páginas y Competencias (pantallas del admin,
+        // ya filtradas por esa colección).
+        //
+        // La etiqueta lleva la clave delante — "TC2005B — Páginas" — porque con
+        // más de una colección asignada, "Páginas" a secas no dice de cuál.
+        const links: DocusLink[] = (found?.colecciones ?? []).flatMap(
+          (c: { id: string; slug: string; nombre: string; clave: string | null }) => {
+            const clave = c.clave || c.slug.toUpperCase();
+            return [
+              {
+                key: `${c.slug}-doc`,
+                label: `${clave} — Documentación`,
+                href: `/contenidos/${c.slug}/`,
+                externo: true,
+                icono: 'menu_book',
+              },
+              // `grupo=` no filtra nada: mantiene el contexto. Sin él, al salir
+              // a /admin/paginas el sidebar dejaría de estar en modo grupo y
+              // perderías su navegación justo al usarla.
+              {
+                key: `${c.slug}-paginas`,
+                label: `${clave} — Páginas`,
+                href: `/admin/paginas?coleccion=${c.id}&grupo=${grupoId}`,
+                icono: 'article',
+              },
+              {
+                key: `${c.slug}-competencias`,
+                label: `${clave} — Competencias`,
+                href: `/admin/competencias?coleccion=${c.id}&grupo=${grupoId}`,
+                icono: 'emoji_events',
+              },
+            ];
+          },
         );
         setDocusLinks(links);
       })

--- a/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/CompetenciasPage/CompetenciasPage.tsx
@@ -53,6 +53,10 @@ export default function CompetenciasPage() {
   // de Contenidos llega aquí ya filtrada, y el enlace se puede compartir.
   const [searchParams] = useSearchParams();
   const filtroColeccion = searchParams.get('coleccion') ?? '';
+  // Igual que en Páginas: si se llegó desde un grupo, volver devuelve al grupo.
+  const grupoOrigen = searchParams.get('grupo');
+  const volverA = grupoOrigen ? `/admin/grupos/${grupoOrigen}` : '/admin/contenidos';
+  const volverLabel = grupoOrigen ? 'Grupo' : 'Contenidos';
 
   const coleccionActiva = useMemo(
     () => colecciones.find((c) => c.id === filtroColeccion) ?? null,
@@ -323,9 +327,9 @@ export default function CompetenciasPage() {
     <div className={styles.page}>
       <div className={styles.header}>
         {coleccionActiva && (
-          <Link to="/admin/contenidos" className={styles.volver}>
+          <Link to={volverA} className={styles.volver}>
             <span className="material-icons">arrow_back</span>
-            <span>Contenidos</span>
+            <span>{volverLabel}</span>
           </Link>
         )}
         <h1 className={styles.pageTitle}>

--- a/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
+++ b/packages/web/src/components/dashboard/pages/PaginasPage/PaginasPage.tsx
@@ -44,6 +44,11 @@ export default function PaginasPage() {
   // enlace se puede compartir o recargar sin perder el filtro.
   const [searchParams, setSearchParams] = useSearchParams();
   const filtroColeccion = searchParams.get('coleccion') ?? '';
+  // Si se llegó desde el menú de un grupo, volver debe devolver AL GRUPO, no a
+  // Contenidos: si no, se sale del contexto en el que estabas trabajando.
+  const grupoOrigen = searchParams.get('grupo');
+  const volverA = grupoOrigen ? `/admin/grupos/${grupoOrigen}` : '/admin/contenidos';
+  const volverLabel = grupoOrigen ? 'Grupo' : 'Contenidos';
 
   function setFiltroColeccion(valor: string) {
     setSearchParams(valor ? { coleccion: valor } : {}, { replace: true });
@@ -382,9 +387,9 @@ export default function PaginasPage() {
   return (
     <div className={styles.page}>
       <div className={styles.header}>
-        <Link to="/admin/contenidos" className={styles.volver}>
+        <Link to={volverA} className={styles.volver}>
           <span className="material-icons">arrow_back</span>
-          <span>Contenidos</span>
+          <span>{volverLabel}</span>
         </Link>
         <h1 className={styles.pageTitle}>
           Páginas


### PR DESCRIPTION
## Descripción

El submenú colapsable **"Contenidos"** del detalle de grupo solo enlazaba al visor de la documentación. Ahora, **por cada colección asignada al grupo**, ofrece sus tres contenidos:

```
▾ Contenidos
    📖 TC2005B — Documentación     → /contenidos/tc2005b/        (pestaña nueva)
    📄 TC2005B — Páginas           → /admin/paginas?coleccion=…
    🏆 TC2005B — Competencias      → /admin/competencias?coleccion=…
    📖 TC2007B — Documentación
    📄 TC2007B — Páginas
    🏆 TC2007B — Competencias
```

**La clave va delante** — "TC2005B — Páginas" — porque con más de una colección asignada, "Páginas" a secas no dice de cuál.

## El detalle que hacía falta resolver

Páginas y Competencias son **pantallas globales** (`/admin/paginas`, `/admin/competencias`) filtradas por colección. Pero el sidebar detectaba el modo "detalle de grupo" **solo por la ruta** `/admin/grupos/:id`.

Es decir: al pulsar "TC2005B — Páginas" desde el menú del grupo, el sidebar **habría vuelto al menú admin global** y habrías perdido la navegación del grupo **justo al usarla**.

Se resuelve llevando **`?grupo=<id>`** en esos enlaces. **No filtra nada** — conserva el contexto:

- El sidebar sigue en modo grupo (mismo menú: Calendario, Alumnos, Plan de Evaluación…).
- El enlace de volver de esas pantallas te devuelve **al grupo**, no a Contenidos.

Se acota a **rol admin**: el menú del alumno no tiene modo detalle de grupo, y un `?grupo=` en su URL no debe cambiarle el sidebar.

`DocusMenu` pasa a soportar enlaces **internos** (`NavLink`, sin pestaña nueva) además de los externos, con icono y estado activo.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores.
- [x] `yarn build` OK.

Sin migración: `Grupo.toSafeJSON()` ya exponía el `id` de cada colección, que es todo lo que necesitaban los enlaces.