### PR TITLE
chore(admin): "Competencias" sale del menú lateral; se llega desde Contenidos

### DIFF
--- a/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
@@ -18,12 +18,11 @@ export function getSidebarItems(
     return [
       { label: 'Dashboard', icon: 'dashboard', path: '/admin' },
       { label: 'Grupos', icon: 'groups', path: '/admin/grupos' },
-      { label: 'Competencias', icon: 'emoji_events', path: '/admin/competencias' },
       { label: 'Actividades', icon: 'assignment', path: '/admin/actividades' },
-      // "Páginas" ya no es una entrada propia: se llega desde Contenidos, que es
-      // donde viven (cada Pagina pertenece a una Coleccion). La acción "Páginas"
-      // de cada colección abre las suyas ya filtradas, y el botón "Ver todas las
-      // páginas" de esa pantalla conserva la vista de conjunto.
+      // "Páginas" y "Competencias" ya no son entradas propias: se llega a ellas
+      // desde Contenidos, que es donde viven (ambas pertenecen a una Coleccion).
+      // Cada colección tiene su acción, que las abre ya filtradas, y esa pantalla
+      // conserva los accesos a las vistas globales.
       { label: 'Contenidos', icon: 'library_books', path: '/admin/contenidos' },
     ];
   }

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.module.css
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.module.css
@@ -53,11 +53,18 @@
   flex-wrap: wrap;
 }
 
+.headerLinks {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+
 .verTodas {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  margin-left: auto;
   padding: 7px 14px;
   border: 1px solid var(--border-color);
   border-radius: 8px;

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
@@ -136,14 +136,23 @@ export default function ContenidosPage() {
     <div className={styles.page}>
       <div className={styles.header}>
         <h1 className={styles.pageTitle}>Contenidos</h1>
-        {/* Sin esto, al quitar "Páginas" del menú lateral solo se llegaría a las
-            páginas YA filtradas por colección: se perdería la vista de conjunto
-            (todas, filtro por etiqueta) y las páginas sin colección quedarían
-            inalcanzables. */}
-        <Link to="/admin/paginas" className={styles.verTodas}>
-          <Icon name="article" size="sm" />
-          <span>Ver todas las páginas</span>
-        </Link>
+        {/* Páginas y Competencias salieron del menú lateral: sin estas salidas
+            solo se llegaría a listas YA filtradas por colección, y se perderían
+            tres cosas.
+              · La vista de conjunto (filtro por etiqueta cruzando colecciones).
+              · Las páginas/competencias SIN colección, que quedarían inalcanzables.
+              · Las "Indicaciones para Malla", que son GLOBALES (no tienen
+                colección) y por eso solo se muestran en la vista sin filtrar. */}
+        <div className={styles.headerLinks}>
+          <Link to="/admin/paginas" className={styles.verTodas}>
+            <Icon name="article" size="sm" />
+            <span>Ver todas las páginas</span>
+          </Link>
+          <Link to="/admin/competencias" className={styles.verTodas}>
+            <Icon name="emoji_events" size="sm" />
+            <span>Ver todas las competencias</span>
+          </Link>
+        </div>
       </div>
 
       {error && <div className={styles.error}>{error}</div>}


### PR DESCRIPTION
## Descripción

Las competencias pertenecen a una colección (PR #41), así que tenerlas como sección propia del menú obligaba a entrar y volver a filtrar a mano. Ahora se llega desde **Contenidos**, donde cada colección tiene su acción 🏆 y las abre ya filtradas.

El menú del admin queda: `Dashboard · Grupos · Actividades · Contenidos`.

## La salida que hacía falta (y que no era obvia)

La pantalla de Contenidos gana un segundo acceso, **"Ver todas las competencias"**, junto al de páginas. Sin él se perderían **tres** cosas, no una:

- La **vista de conjunto**: las 9 competencias juntas, con la columna de colección.
- Las competencias **sin colección**, que quedarían inalcanzables.
- **Las "Indicaciones para Malla de Competencias"**, que son **globales** — no tienen colección — y por eso solo se muestran en la vista **sin filtrar**: enseñarlas bajo el título de TC2005B haría creer que son suyas.

Ese tercer punto es el que decide el asunto: **sin esta salida, las Indicaciones dejarían de ser alcanzables por completo**. Viven en la misma pantalla que las competencias por conveniencia histórica, pero no tienen nada que ver con ellas ni con las colecciones.

## Tipo de cambio

- [x] `chore` — reorganización de navegación, sin cambio funcional

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores.
- [x] `yarn build` OK.