### PR TITLE
feat(actividades): la plantilla de evaluación pertenece a una colección

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- **Las Actividades de Evaluación (la plantilla) pertenecen a una colección** y
+  dejan de ser una lista global. `copiarPlantilla` estampaba la plantilla ENTERA
+  en cualquier grupo, fuera de su materia o no; ahora copia solo las de las
+  colecciones del grupo. Cada colección gana una acción **"Actividades"** en la
+  tabla de Contenidos (`/admin/actividades?coleccion=<id>`), aparece en el menú
+  del grupo como "TC2005B — Actividades", y **"Actividades" se retira del menú
+  lateral**. La pantalla de Contenidos conserva "Ver todas las actividades".
+  - **Copiar la plantilla es ahora INCREMENTAL.** Antes devolvía 409 si el grupo
+    ya tenía cualquier actividad, lo que dejaba a un grupo con dos materias sin
+    poder traer la segunda: copiaba las de la primera y quedaba bloqueado para
+    siempre. Ahora deduplica por nombre y avisa de cuántas omitió.
+  - `scripts/migrate-actividades-coleccion.ts` — backfill idempotente con
+    `--dry-run`. **No toca ninguna calificación**, y esta vez es literal: la
+    plantilla es un troquel de un solo uso, se copia POR VALOR y nada de lo ya
+    estampado (274 actividades de grupo, 1482 celdas de malla) apunta a ella.
+
+### Fixed
+- **El plan de evaluación no validaba que sus actividades fueran del grupo**, solo
+  que existieran. Un plan podía referenciar la actividad de OTRO grupo y
+  `computeActividadesScore` la omitiría del denominador: **la nota cambiaría sin
+  error ni log**. Es el mismo agujero que ya se tapó para las competencias; a las
+  actividades no se les había aplicado el mismo razonamiento.
 - **Las Competencias pertenecen a una colección (materia)** y dejan de ser una
   lista global. Antes, la malla de un alumno se materializaba con **todas** las
   competencias del sistema, sin importar la materia de su grupo. Ahora se arma

--- a/packages/api/scripts/migrate-actividades-coleccion.ts
+++ b/packages/api/scripts/migrate-actividades-coleccion.ts
@@ -1,0 +1,104 @@
+/**
+ * Backfill: `ActividadEvaluacion.coleccion` (la plantilla de la malla).
+ *
+ * La plantilla era GLOBAL: `copiarPlantilla` la estampaba entera en cualquier
+ * grupo, fuera de su materia o no. Ahora solo se copian las plantillas de las
+ * colecciones del grupo.
+ *
+ * NO TOCA NINGUNA CALIFICACIÓN, y esta vez es literal: la plantilla es un TROQUEL
+ * de un solo uso. `copiarPlantilla` la copia POR VALOR a `ActividadEvaluacionGrupo`
+ * y no guarda referencia de vuelta. El plan de evaluación, la malla del alumno y
+ * el cálculo de la nota trabajan sobre esas copias y **nunca miran la plantilla**.
+ * Cambiar de qué colección es una plantilla no puede mover nada ya estampado.
+ *
+ * Sin colección, una plantilla no se copia a ningún grupo: de ahí el backfill.
+ *
+ * Idempotente: solo toca las plantillas que aún no tienen colección.
+ *
+ *   ./node_modules/.bin/tsx scripts/migrate-actividades-coleccion.ts --coleccion tc2005b --dry-run
+ *   ./node_modules/.bin/tsx scripts/migrate-actividades-coleccion.ts --coleccion tc2005b
+ *
+ * ⚠️ Dev comparte la BD de PRODUCCIÓN. Corre --dry-run primero, y córrelo ANTES
+ *    de desplegar: el código viejo ignora el campo, pero el nuevo, sin backfill,
+ *    dejaría a `copiarPlantilla` sin nada que copiar en ningún grupo.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+function parseArgs() {
+  const argv = process.argv.slice(2);
+  const dryRun = argv.includes('--dry-run');
+  const i = argv.indexOf('--coleccion');
+  const slug = i >= 0 ? argv[i + 1] : undefined;
+  if (!slug) {
+    console.error('Uso: migrate-actividades-coleccion.ts --coleccion <slug> [--dry-run]');
+    process.exit(1);
+  }
+  return { slug, dryRun };
+}
+
+async function main() {
+  const { slug, dryRun } = parseArgs();
+
+  const qc = new Parse.Query('Coleccion');
+  qc.equalTo('slug', slug);
+  qc.equalTo('exists', true);
+  const coleccion = await qc.first({ useMasterKey: true });
+  if (!coleccion) {
+    console.error(`✗ No existe la colección con slug "${slug}". Abortado.`);
+    process.exit(1);
+  }
+  console.log(`Colección destino: ${coleccion.get('nombre')} (${coleccion.get('clave')})\n`);
+
+  const qa = new Parse.Query('ActividadEvaluacion');
+  qa.equalTo('exists', true);
+  qa.doesNotExist('coleccion');
+  qa.ascending('orden');
+  qa.limit(1000);
+  const huerfanas = await qa.find({ useMasterKey: true });
+
+  console.log(`── PLANTILLA (ActividadEvaluacion) sin colección: ${huerfanas.length}`);
+  for (const a of huerfanas.slice(0, 15)) {
+    console.log(`   ${dryRun ? '[dry-run]' : '[migrar] '} [${String(a.get('tipo')).padEnd(10)}] ${a.get('nombre')}`);
+  }
+  if (huerfanas.length > 15) console.log(`   … y ${huerfanas.length - 15} más`);
+
+  // Lo ya estampado no se toca: se cuenta solo para dejarlo por escrito.
+  const qg = new Parse.Query('ActividadEvaluacionGrupo');
+  qg.equalTo('exists', true);
+  qg.limit(5000);
+  const delGrupo = await qg.find({ useMasterKey: true });
+
+  const qal = new Parse.Query('ActividadEvaluacionAlumno');
+  qal.equalTo('exists', true);
+  qal.limit(10000);
+  const delAlumno = await qal.find({ useMasterKey: true });
+
+  console.log(`\n── YA ESTAMPADO (no se toca):`);
+  console.log(`   ActividadEvaluacionGrupo:  ${delGrupo.length}  (las actividades reales de los grupos)`);
+  console.log(`   ActividadEvaluacionAlumno: ${delAlumno.length}  (las celdas de malla con la nota)`);
+  console.log(`   La copia es POR VALOR: nada de esto apunta a la plantilla.`);
+
+  if (huerfanas.length === 0) {
+    console.log('\n✓ Nada que migrar.');
+    return;
+  }
+  if (dryRun) {
+    console.log('\n--dry-run: no se escribió nada. Quita la bandera para aplicar.');
+    return;
+  }
+
+  for (const a of huerfanas) a.set('coleccion', coleccion);
+  await Parse.Object.saveAll(huerfanas, { useMasterKey: true });
+  console.log(`\n✓ ${huerfanas.length} plantilla(s) asignadas a "${slug}".`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/actividades-evaluacion-grupo.controller.ts
+++ b/packages/api/src/controllers/actividades-evaluacion-grupo.controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { ActividadEvaluacionGrupo } from '../models/ActividadEvaluacionGrupo.js';
-import { ActividadEvaluacion } from '../models/ActividadEvaluacion.js';
+import { plantillasDeGrupo } from '../services/grupo-colecciones.service.js';
 import { ActividadEvaluacionAlumno } from '../models/ActividadEvaluacionAlumno.js';
 import { PlanEvaluacion } from '../models/PlanEvaluacion.js';
 import { Grupo } from '../models/Grupo.js';
@@ -334,42 +334,67 @@ export async function bulkCongelarActividades(req: Request, res: Response): Prom
   }
 }
 
+/**
+ * Estampa las plantillas de las colecciones del grupo como actividades suyas.
+ *
+ * Antes copiaba la lista GLOBAL de plantillas: todos los grupos recibían todas
+ * las actividades, fueran de su materia o no. Ahora copia solo las de sus
+ * colecciones.
+ *
+ * Y ahora es INCREMENTAL. Antes devolvía 409 si el grupo ya tenía cualquier
+ * actividad, lo que dejaba a un grupo con dos materias sin poder traer la
+ * segunda: copiaba las de la primera y quedaba bloqueado para siempre. Se
+ * deduplica por nombre —que es lo único que hay, porque la copia es por valor y
+ * no guarda referencia a su plantilla— y se informa de cuántas se omitieron.
+ */
 export async function copiarPlantilla(req: Request, res: Response): Promise<void> {
   const { grupoId } = req.params;
 
   try {
     const grupoPointer = Parse.Object.extend('Grupo').createWithoutData(grupoId) as Grupo;
 
-    // Verify grupo doesn't already have actividades
+    const { plantillas, sinColecciones } = await plantillasDeGrupo(grupoId);
+
+    // Los dos vacíos se distinguen: "el grupo no tiene materia" y "la materia no
+    // tiene plantilla" son problemas distintos y se arreglan en sitios distintos.
+    if (sinColecciones) {
+      res.status(400).json({
+        status: 'error',
+        message: 'El grupo no tiene colecciones asignadas: asígnale una materia en Editar Grupo.',
+      });
+      return;
+    }
+    if (plantillas.length === 0) {
+      res.status(404).json({
+        status: 'error',
+        message: 'Las colecciones de este grupo no tienen actividades en su plantilla.',
+      });
+      return;
+    }
+
+    // Lo que el grupo ya tiene, para no duplicarlo al volver a copiar.
     const existQuery = new Parse.Query<ActividadEvaluacionGrupo>('ActividadEvaluacionGrupo');
     existQuery.equalTo('exists' as any, true as any);
     existQuery.equalTo('grupo' as any, grupoPointer as any);
-    const existCount = await existQuery.count({ useMasterKey: true });
-    if (existCount > 0) {
-      res.status(409).json({ status: 'error', message: 'El grupo ya tiene actividades de evaluación' });
+    existQuery.limit(1000);
+    const yaTiene = await existQuery.find({ useMasterKey: true });
+    const nombresExistentes = new Set(yaTiene.map((a) => a.getNombre()));
+
+    const nuevas = plantillas.filter((p) => !nombresExistentes.has(p.get('nombre')));
+    const omitidas = plantillas.length - nuevas.length;
+
+    if (nuevas.length === 0) {
+      res.json({ status: 'ok', copiadas: 0, omitidas, actividades: [] });
       return;
     }
 
-    // Get all global template actividades
-    const plantillaQuery = new Parse.Query<ActividadEvaluacion>('ActividadEvaluacion');
-    plantillaQuery.equalTo('exists' as any, true as any);
-    plantillaQuery.ascending('orden');
-    plantillaQuery.limit(1000);
-    const plantilla = await plantillaQuery.find({ useMasterKey: true });
-
-    if (plantilla.length === 0) {
-      res.status(404).json({ status: 'error', message: 'No hay actividades de evaluación en la plantilla global' });
-      return;
-    }
-
-    // Create copies for this grupo
-    const copies = plantilla.map((original) => {
+    const copies = nuevas.map((original) => {
       const copy = new ActividadEvaluacionGrupo().initDefaults();
-      copy.setNombre(original.getNombre());
-      copy.setTipo(original.getTipo());
-      copy.setAprendizajePlaneado(original.getAprendizajePlaneado());
-      copy.setSemanaPlaneada(original.getSemanaPlaneada());
-      copy.setOrden(original.getOrden());
+      copy.setNombre(original.get('nombre') ?? '');
+      copy.setTipo(original.get('tipo') ?? 'actividad');
+      copy.setAprendizajePlaneado(original.get('aprendizajePlaneado') ?? 0);
+      copy.setSemanaPlaneada(original.get('semanaPlaneada') ?? 0);
+      copy.setOrden(original.get('orden') ?? 0);
       copy.setGrupo(grupoPointer);
       return copy;
     });
@@ -378,6 +403,8 @@ export async function copiarPlantilla(req: Request, res: Response): Promise<void
 
     res.status(201).json({
       status: 'ok',
+      copiadas: copies.length,
+      omitidas,
       actividades: copies.map((a) => a.toSafeJSON()),
     });
   } catch (error) {

--- a/packages/api/src/controllers/actividades-evaluacion.controller.ts
+++ b/packages/api/src/controllers/actividades-evaluacion.controller.ts
@@ -2,17 +2,61 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { ActividadEvaluacion } from '../models/ActividadEvaluacion.js';
+import { coleccionesDeGrupo } from '../services/grupo-colecciones.service.js';
 
 const TIPOS_VALIDOS = [
   'lab', 'lectura', 'ejercicio', 'proyecto', 'evaluacion',
   'trabajo', 'discusion', 'info', 'actividad',
 ];
 
-export async function listActividadesEvaluacion(_req: Request, res: Response): Promise<void> {
+/** Resuelve un coleccionId a un pointer VALIDADO. `null` si no existe. */
+async function resolverColeccion(coleccionId: string): Promise<Parse.Object | null> {
+  const q = new Parse.Query('Coleccion');
+  q.equalTo('exists' as any, true as any);
+  try {
+    return await q.get(coleccionId, { useMasterKey: true });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Lista las plantillas de actividades de evaluación.
+ *
+ * - `?coleccionId=` → las de esa colección (`sin-coleccion` = las huérfanas).
+ * - `?grupoId=`     → las de las colecciones del grupo.
+ * - sin parámetros  → todas (la vista global del admin).
+ */
+export async function listActividadesEvaluacion(req: Request, res: Response): Promise<void> {
+  const { coleccionId, grupoId } = req.query;
+
   try {
     const query = new Parse.Query<ActividadEvaluacion>('ActividadEvaluacion');
     query.equalTo('exists' as any, true as any);
     query.ascending('orden');
+    query.include('coleccion' as any);
+    query.limit(1000);
+
+    if (typeof grupoId === 'string' && grupoId) {
+      const colecciones = await coleccionesDeGrupo(grupoId);
+      if (colecciones.length === 0) {
+        res.json({ status: 'ok', actividades: [], sinColecciones: true });
+        return;
+      }
+      query.containedIn('coleccion' as any, colecciones as any);
+    } else if (typeof coleccionId === 'string' && coleccionId) {
+      if (coleccionId === 'sin-coleccion') {
+        query.doesNotExist('coleccion' as any);
+      } else {
+        const coleccion = await resolverColeccion(coleccionId);
+        if (!coleccion) {
+          res.status(404).json({ status: 'error', message: 'Colección no encontrada' });
+          return;
+        }
+        query.equalTo('coleccion' as any, coleccion as any);
+      }
+    }
+
     const actividades = await query.find({ useMasterKey: true });
 
     res.json({
@@ -25,7 +69,7 @@ export async function listActividadesEvaluacion(_req: Request, res: Response): P
 }
 
 export async function createActividadEvaluacion(req: Request, res: Response): Promise<void> {
-  const { nombre, tipo, aprendizajePlaneado, semanaPlaneada } = req.body;
+  const { nombre, tipo, aprendizajePlaneado, semanaPlaneada, coleccionId } = req.body;
 
   if (!nombre || typeof nombre !== 'string' || nombre.trim() === '') {
     res.status(400).json({ status: 'error', message: 'El nombre es requerido' });
@@ -37,15 +81,29 @@ export async function createActividadEvaluacion(req: Request, res: Response): Pr
   }
 
   try {
-    // Calculate next orden
+    // Sin colección, la plantilla no se copia a ningún grupo: no sirve de nada.
+    if (!coleccionId || typeof coleccionId !== 'string') {
+      res.status(400).json({ status: 'error', message: 'La colección es requerida: sin ella la actividad no se copia a ningún grupo' });
+      return;
+    }
+    const coleccion = await resolverColeccion(coleccionId);
+    if (!coleccion) {
+      res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+      return;
+    }
+
+    // El orden es POR COLECCIÓN. Un contador global intercalaría los órdenes de
+    // dos materias y `copiarPlantilla` los estamparía mezclados en el grupo.
     const countQuery = new Parse.Query<ActividadEvaluacion>('ActividadEvaluacion');
     countQuery.equalTo('exists' as any, true as any);
+    countQuery.equalTo('coleccion' as any, coleccion as any);
     countQuery.descending('orden');
     countQuery.limit(1);
     const last = await countQuery.first({ useMasterKey: true });
     const nextOrden = last ? last.getOrden() + 1 : 1;
 
     const act = new ActividadEvaluacion().initDefaults();
+    act.setColeccion(coleccion);
     act.setNombre(nombre.trim());
     act.setTipo(tipo);
     act.setAprendizajePlaneado(Number(aprendizajePlaneado) || 0);
@@ -62,11 +120,25 @@ export async function createActividadEvaluacion(req: Request, res: Response): Pr
 
 export async function updateActividadEvaluacion(req: Request, res: Response): Promise<void> {
   const { id } = req.params;
-  const { nombre, tipo, aprendizajePlaneado, semanaPlaneada } = req.body;
+  const { nombre, tipo, aprendizajePlaneado, semanaPlaneada, coleccionId } = req.body;
 
   try {
     const query = BaseModel.queryActive<ActividadEvaluacion>('ActividadEvaluacion');
+    query.include('coleccion' as any);
     const act = await query.get(id, { useMasterKey: true });
+
+    if (coleccionId !== undefined) {
+      if (!coleccionId || typeof coleccionId !== 'string') {
+        res.status(400).json({ status: 'error', message: 'La colección es requerida' });
+        return;
+      }
+      const coleccion = await resolverColeccion(coleccionId);
+      if (!coleccion) {
+        res.status(400).json({ status: 'error', message: 'La colección indicada no existe' });
+        return;
+      }
+      act.setColeccion(coleccion);
+    }
 
     if (nombre !== undefined) {
       if (typeof nombre !== 'string' || nombre.trim() === '') {

--- a/packages/api/src/controllers/competencias-alumno.controller.ts
+++ b/packages/api/src/controllers/competencias-alumno.controller.ts
@@ -5,7 +5,7 @@ import { Competencia } from '../models/Competencia.js';
 import { AppUser } from '../models/AppUser.js';
 import { Grupo } from '../models/Grupo.js';
 import { getAlumnosDeGrupo } from '../services/grupo-alumno.service.js';
-import { competenciasDeGrupo } from '../services/competencias.service.js';
+import { competenciasDeGrupo } from '../services/grupo-colecciones.service.js';
 
 export async function crearCompetenciasAlumno(req: Request, res: Response): Promise<void> {
   const { grupoId } = req.params;

--- a/packages/api/src/controllers/competencias.controller.ts
+++ b/packages/api/src/controllers/competencias.controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import { BaseModel } from '../models/BaseModel.js';
 import { Competencia } from '../models/Competencia.js';
-import { coleccionesDeGrupo } from '../services/competencias.service.js';
+import { coleccionesDeGrupo } from '../services/grupo-colecciones.service.js';
 
 /** Resuelve un coleccionId a un pointer VALIDADO. `null` si no existe. */
 async function resolverColeccion(coleccionId: string): Promise<Parse.Object | null> {

--- a/packages/api/src/controllers/plan-evaluacion.controller.ts
+++ b/packages/api/src/controllers/plan-evaluacion.controller.ts
@@ -3,7 +3,7 @@ import Parse from 'parse/node';
 import { PlanEvaluacion } from '../models/PlanEvaluacion.js';
 import { Grupo } from '../models/Grupo.js';
 import { Competencia } from '../models/Competencia.js';
-import { competenciasDeGrupo } from '../services/competencias.service.js';
+import { competenciasDeGrupo } from '../services/grupo-colecciones.service.js';
 import { ActividadEvaluacionGrupo } from '../models/ActividadEvaluacionGrupo.js';
 import { BaseModel } from '../models/BaseModel.js';
 import type { PeriodoConfig } from '../models/PlanEvaluacion.js';
@@ -82,15 +82,28 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
       }
     }
 
-    // Validate actividad IDs exist
+    // Validar que las actividades existan Y que sean DE ESTE GRUPO.
+    //
+    // Antes solo se comprobaba la existencia: un plan podía referenciar la
+    // actividad de OTRO grupo y `computeActividadesScore` la omitiría del
+    // denominador — la nota cambiaría sin error ni log. Es el mismo agujero que
+    // ya se tapó arriba para las competencias; a las actividades no se les había
+    // aplicado el mismo razonamiento.
     const allActIds = [...new Set(periodos.flatMap((p: PeriodoConfig) => p.actividades))];
     if (allActIds.length > 0) {
       const actQuery = new Parse.Query<ActividadEvaluacionGrupo>('ActividadEvaluacionGrupo');
       actQuery.equalTo('exists' as any, true as any);
+      actQuery.equalTo('grupo' as any, grupo as any);
       actQuery.containedIn('objectId' as any, allActIds as any);
+      actQuery.limit(1000);
       const found = await actQuery.find({ useMasterKey: true });
       if (found.length !== allActIds.length) {
-        res.status(400).json({ status: 'error', message: 'Algunas actividades no existen' });
+        const encontrados = new Set(found.map((a) => a.id));
+        const fuera = allActIds.filter((id: string) => !encontrados.has(id));
+        res.status(400).json({
+          status: 'error',
+          message: `${fuera.length} actividad(es) del plan no existen o no son de este grupo.`,
+        });
         return;
       }
     }

--- a/packages/api/src/models/ActividadEvaluacion.ts
+++ b/packages/api/src/models/ActividadEvaluacion.ts
@@ -41,7 +41,28 @@ export class ActividadEvaluacion extends BaseModel {
     this.set('orden', orden);
   }
 
+  /**
+   * Colección (materia) a la que pertenece la plantilla — pointer, nunca string.
+   *
+   * Esta clase es un TROQUEL: `copiarPlantilla` la copia POR VALOR a
+   * `ActividadEvaluacionGrupo` y no guarda referencia de vuelta. El plan de
+   * evaluación, la malla del alumno y el cálculo de la nota trabajan sobre esas
+   * copias y **nunca miran la plantilla**. Por eso atarla a una colección no
+   * puede mover ninguna nota ya existente: solo decide qué se estampa a partir
+   * de ahora, y para qué grupos.
+   *
+   * Sin colección, la plantilla no se copia a ningún grupo.
+   */
+  getColeccion(): Parse.Object | undefined {
+    return this.get('coleccion');
+  }
+  setColeccion(coleccion: Parse.Object): void {
+    this.set('coleccion', coleccion);
+  }
+
   toSafeJSON(): Record<string, unknown> {
+    const coleccion = this.getColeccion();
+    const coleccionActiva = coleccion && coleccion.get('exists') !== false ? coleccion : null;
     return {
       id: this.id,
       nombre: this.getNombre(),
@@ -49,6 +70,16 @@ export class ActividadEvaluacion extends BaseModel {
       aprendizajePlaneado: this.getAprendizajePlaneado(),
       semanaPlaneada: this.getSemanaPlaneada(),
       orden: this.getOrden(),
+      coleccionId: coleccionActiva?.id ?? null,
+      // Requiere query.include('coleccion') para traer nombre/clave.
+      coleccion: coleccionActiva
+        ? {
+            id: coleccionActiva.id,
+            nombre: coleccionActiva.get('nombre') ?? null,
+            slug: coleccionActiva.get('slug') ?? null,
+            clave: coleccionActiva.get('clave') ?? null,
+          }
+        : null,
       active: this.get('active'),
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,

--- a/packages/api/src/services/grupo-colecciones.service.ts
+++ b/packages/api/src/services/grupo-colecciones.service.ts
@@ -1,12 +1,15 @@
 import Parse from 'parse/node';
 
 /**
- * Resolución de "qué competencias le tocan a un grupo".
+ * Resolución de "qué le toca a un grupo" a partir de sus colecciones.
  *
- * La cadena es: `Grupo.colecciones[]` → `Competencia.coleccion`. Vive aquí y no
- * en un controller porque la necesitan varios (crear la malla del alumno,
- * validar el plan de evaluación, poblar los selectores del admin) y si cada uno
- * la reimplementa, divergen — que es exactamente lo que ya pasó con
+ * La cadena es `Grupo.colecciones[]` → `<Entidad>.coleccion`, y hoy la recorren
+ * dos entidades: `Competencia` (de la que cuelga la malla del alumno) y
+ * `ActividadEvaluacion` (la plantilla que se estampa en el grupo).
+ *
+ * Vive aquí y no en cada controller porque la necesitan varios —crear la malla,
+ * copiar la plantilla, validar el plan, poblar los selectores del admin— y si
+ * cada uno la reimplementa, divergen: que es exactamente lo que ya pasó con
  * `recalcularCalculadas`, duplicada en dos archivos.
  */
 
@@ -58,4 +61,32 @@ export async function competenciasDeGrupo(grupoId: string): Promise<Competencias
   const competencias = await query.find({ useMasterKey: true });
 
   return { competencias, sinColecciones: false };
+}
+
+export interface PlantillasDeGrupo {
+  plantillas: Parse.Object[];
+  sinColecciones: boolean;
+}
+
+/**
+ * Plantillas de actividades de evaluación (`ActividadEvaluacion`) de las
+ * colecciones del grupo, ordenadas.
+ *
+ * Es el troquel: de aquí sale lo que `copiarPlantilla` estampa como
+ * `ActividadEvaluacionGrupo`. Nada de lo ya estampado depende de esto.
+ */
+export async function plantillasDeGrupo(grupoId: string): Promise<PlantillasDeGrupo> {
+  const colecciones = await coleccionesDeGrupo(grupoId);
+  if (colecciones.length === 0) {
+    return { plantillas: [], sinColecciones: true };
+  }
+
+  const query = new Parse.Query('ActividadEvaluacion');
+  query.equalTo('exists' as any, true as any);
+  query.containedIn('coleccion' as any, colecciones as any);
+  query.ascending('orden');
+  query.limit(1000);
+  const plantillas = await query.find({ useMasterKey: true });
+
+  return { plantillas, sinColecciones: false };
 }

--- a/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/Sidebar.tsx
@@ -133,6 +133,12 @@ export default function Sidebar({ role, collapsed, mobileOpen, onCloseMobile }: 
                 href: `/admin/competencias?coleccion=${c.id}&grupo=${grupoId}`,
                 icono: 'emoji_events',
               },
+              {
+                key: `${c.slug}-actividades`,
+                label: `${clave} — Actividades`,
+                href: `/admin/actividades?coleccion=${c.id}&grupo=${grupoId}`,
+                icono: 'assignment',
+              },
             ];
           },
         );

--- a/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
@@ -18,11 +18,10 @@ export function getSidebarItems(
     return [
       { label: 'Dashboard', icon: 'dashboard', path: '/admin' },
       { label: 'Grupos', icon: 'groups', path: '/admin/grupos' },
-      { label: 'Actividades', icon: 'assignment', path: '/admin/actividades' },
-      // "Páginas" y "Competencias" ya no son entradas propias: se llega a ellas
-      // desde Contenidos, que es donde viven (ambas pertenecen a una Coleccion).
-      // Cada colección tiene su acción, que las abre ya filtradas, y esa pantalla
-      // conserva los accesos a las vistas globales.
+      // "Páginas", "Competencias" y "Actividades" ya no son entradas propias: se
+      // llega a ellas desde Contenidos, que es donde viven (las tres pertenecen a
+      // una Coleccion). Cada colección tiene su acción, que las abre ya filtradas,
+      // y esa pantalla conserva los accesos a las vistas globales.
       { label: 'Contenidos', icon: 'library_books', path: '/admin/contenidos' },
     ];
   }

--- a/packages/web/src/components/dashboard/pages/ActividadesGrupoPage/ActividadesGrupoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ActividadesGrupoPage/ActividadesGrupoPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { confirmar } from '../../../../utils/dialogos';
+import { confirmar, avisar } from '../../../../utils/dialogos';
 import { useParams, useNavigate } from 'react-router';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -166,9 +166,18 @@ export default function ActividadesGrupoPage() {
         method: 'POST',
         headers,
       });
+      const json = await res.json();
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.message || 'Error al copiar plantilla');
+        throw new Error(json.message || 'Error al copiar plantilla');
+      }
+      // Copiar es ahora incremental (antes daba 409 si el grupo ya tenía algo).
+      // Sin este aviso, volver a copiar cuando ya está todo no daría ninguna
+      // señal: parecería que el botón no hizo nada.
+      if (json.copiadas === 0) {
+        await avisar({
+          titulo: 'No había nada nuevo que copiar',
+          texto: `Las ${json.omitidas} actividades de la plantilla de este grupo ya estaban.`,
+        });
       }
       await fetchActividades();
     } catch (err: any) {

--- a/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.module.css
+++ b/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.module.css
@@ -101,3 +101,34 @@
   gap: 8px;
   padding-top: 8px;
 }
+
+/* Cabecera: vuelta (a Contenidos o al grupo) + de qué colección son. */
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.volver {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+.volver:hover {
+  color: var(--text-primary);
+}
+.volver .material-icons {
+  font-size: 18px;
+}
+
+.pageTitleSub {
+  margin-left: 10px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}

--- a/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ActividadesPage/ActividadesPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams, Link } from 'react-router';
 import { confirmar } from '../../../../utils/dialogos';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
@@ -7,6 +8,7 @@ import Modal from '../../atoms/Modal/Modal';
 import DashButton from '../../atoms/DashButton/DashButton';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
 import type { ActividadTipo } from '@/types/calendario';
+import type { ColeccionRef } from '../../../../types/contenidos';
 import styles from './ActividadesPage.module.css';
 
 interface ActividadEvaluacionData {
@@ -16,6 +18,8 @@ interface ActividadEvaluacionData {
   aprendizajePlaneado: number;
   semanaPlaneada: number;
   orden: number;
+  coleccionId?: string | null;
+  coleccion?: { id: string; nombre: string | null; slug: string | null; clave: string | null } | null;
 }
 
 const API_BASE = '/api';
@@ -44,6 +48,7 @@ interface FormData {
   tipo: ActividadTipo;
   aprendizajePlaneado: number;
   semanaPlaneada: number;
+  coleccionId: string;
 }
 
 const EMPTY_FORM: FormData = {
@@ -51,12 +56,33 @@ const EMPTY_FORM: FormData = {
   tipo: 'actividad',
   aprendizajePlaneado: 0,
   semanaPlaneada: 0,
+  coleccionId: '',
 };
 
 export default function ActividadesPage() {
   const { sessionToken } = useAuth();
 
   const [data, setData] = useState<ActividadEvaluacionData[]>([]);
+  const [colecciones, setColecciones] = useState<ColeccionRef[]>([]);
+
+  // El filtro por colección vive en la URL: la acción "Actividades" de la tabla
+  // de Contenidos llega aquí ya filtrada, y el enlace se puede compartir.
+  const [searchParams] = useSearchParams();
+  const filtroColeccion = searchParams.get('coleccion') ?? '';
+  // Si se llegó desde el menú de un grupo, volver debe devolver AL GRUPO.
+  const grupoOrigen = searchParams.get('grupo');
+  const volverA = grupoOrigen ? `/admin/grupos/${grupoOrigen}` : '/admin/contenidos';
+  const volverLabel = grupoOrigen ? 'Grupo' : 'Contenidos';
+
+  const coleccionActiva = useMemo(
+    () => colecciones.find((c) => c.id === filtroColeccion) ?? null,
+    [colecciones, filtroColeccion],
+  );
+  const dataFiltrada = useMemo(
+    () => (filtroColeccion ? data.filter((a) => a.coleccionId === filtroColeccion) : data),
+    [data, filtroColeccion],
+  );
+
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -69,6 +95,19 @@ export default function ActividadesPage() {
     'Content-Type': 'application/json',
     'x-session-token': sessionToken ?? '',
   };
+
+  const fetchColecciones = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/admin/colecciones`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) return;
+      const json = await res.json();
+      setColecciones(json.colecciones ?? []);
+    } catch {
+      // no crítico: sin colecciones el form no deja crear, que es lo correcto
+    }
+  }, [sessionToken]);
 
   const fetchActividades = useCallback(async () => {
     try {
@@ -88,11 +127,14 @@ export default function ActividadesPage() {
 
   useEffect(() => {
     fetchActividades();
-  }, [fetchActividades]);
+    fetchColecciones();
+  }, [fetchActividades, fetchColecciones]);
 
   function openCreate() {
     setEditItem(undefined);
-    setForm({ ...EMPTY_FORM });
+    // Si se entró filtrando por una colección, se preselecciona: es la que se
+    // quiere el 99% de las veces.
+    setForm({ ...EMPTY_FORM, coleccionId: filtroColeccion });
     setShowModal(true);
   }
 
@@ -103,6 +145,7 @@ export default function ActividadesPage() {
       tipo: item.tipo,
       aprendizajePlaneado: item.aprendizajePlaneado,
       semanaPlaneada: item.semanaPlaneada,
+      coleccionId: item.coleccionId ?? '',
     });
     setShowModal(true);
   }
@@ -114,6 +157,10 @@ export default function ActividadesPage() {
 
   async function handleSave() {
     if (!form.nombre.trim()) return;
+    if (!form.coleccionId) {
+      setError('La colección es requerida: sin ella la actividad no se copia a ningún grupo');
+      return;
+    }
     setSaving(true);
     setError('');
     try {
@@ -181,6 +228,19 @@ export default function ActividadesPage() {
         );
       },
     }),
+    // Solo en la vista global: filtrando, la colección ya está en el título.
+    ...(coleccionActiva
+      ? []
+      : [
+          columnHelper.accessor('coleccion', {
+            header: 'Colección',
+            cell: (info) => {
+              const col = info.getValue();
+              if (!col) return <span style={{ color: 'var(--dash-danger)' }}>Sin asignar</span>;
+              return <span>{col.clave ?? col.slug}</span>;
+            },
+          }),
+        ]),
     columnHelper.accessor('nombre', {
       header: 'Actividad',
       cell: (info) => <span className={styles.nombreCell}>{info.getValue()}</span>,
@@ -202,7 +262,22 @@ export default function ActividadesPage() {
 
   return (
     <div className={styles.page}>
-      <h1 className={styles.pageTitle}>Actividades de Evaluación</h1>
+      <div className={styles.header}>
+        {coleccionActiva && (
+          <Link to={volverA} className={styles.volver}>
+            <span className="material-icons">arrow_back</span>
+            <span>{volverLabel}</span>
+          </Link>
+        )}
+        <h1 className={styles.pageTitle}>
+          Actividades de Evaluación
+          {coleccionActiva && (
+            <span className={styles.pageTitleSub}>
+              {coleccionActiva.clave ?? coleccionActiva.slug} — {coleccionActiva.nombre}
+            </span>
+          )}
+        </h1>
+      </div>
 
       {error && <div className={styles.error}>{error}</div>}
 
@@ -212,7 +287,7 @@ export default function ActividadesPage() {
         <AdminTable
           title="Plantilla de Malla de Evaluación"
           columns={columns}
-          data={data}
+          data={dataFiltrada}
           onAdd={openCreate}
           addLabel="Agregar actividad"
           searchPlaceholder="Buscar actividad..."
@@ -228,6 +303,21 @@ export default function ActividadesPage() {
         title={editItem ? 'Editar actividad' : 'Agregar actividad'}
       >
         <div className={styles.form}>
+          <label className={styles.formLabel}>
+            Colección (materia) *
+            <select
+              className={styles.formInput}
+              value={form.coleccionId}
+              onChange={(e) => { setForm((f) => ({ ...f, coleccionId: e.target.value })); setError(''); }}
+            >
+              <option value="">Selecciona una colección…</option>
+              {colecciones.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.clave ? `${c.clave} — ${c.nombre}` : c.nombre}
+                </option>
+              ))}
+            </select>
+          </label>
           <label className={styles.formLabel}>
             Nombre
             <input

--- a/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
+++ b/packages/web/src/components/dashboard/pages/ContenidosPage/ContenidosPage.tsx
@@ -128,6 +128,7 @@ export default function ContenidosPage() {
     { label: 'Abrir documentación', icon: 'account_tree', onClick: () => navigate(`/admin/contenidos/${coleccion.id}`) },
     { label: 'Páginas', icon: 'article', onClick: () => navigate(`/admin/paginas?coleccion=${coleccion.id}`) },
     { label: 'Competencias', icon: 'emoji_events', onClick: () => navigate(`/admin/competencias?coleccion=${coleccion.id}`) },
+    { label: 'Actividades', icon: 'assignment', onClick: () => navigate(`/admin/actividades?coleccion=${coleccion.id}`) },
     { label: 'Editar', icon: 'edit', onClick: () => openEdit(coleccion) },
     { label: 'Eliminar', icon: 'delete', onClick: () => handleDelete(coleccion), variant: 'danger' },
   ];
@@ -151,6 +152,10 @@ export default function ContenidosPage() {
           <Link to="/admin/competencias" className={styles.verTodas}>
             <Icon name="emoji_events" size="sm" />
             <span>Ver todas las competencias</span>
+          </Link>
+          <Link to="/admin/actividades" className={styles.verTodas}>
+            <Icon name="assignment" size="sm" />
+            <span>Ver todas las actividades</span>
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Descripción

`copiarPlantilla` estampaba la **plantilla global entera** en cualquier grupo, fuera de su materia o no. Ahora `ActividadEvaluacion.coleccion`, y solo se copian las de las colecciones del grupo.

- Cada colección tiene su acción **"Actividades"** en la tabla de Contenidos (`/admin/actividades?coleccion=<id>`).
- Aparece en el menú del grupo como **"TC2005B — Actividades"**.
- **"Actividades" se retira del menú lateral.** El menú del admin queda: `Dashboard · Grupos · Contenidos`.
- Contenidos conserva **"Ver todas las actividades"**, que preserva la vista global y el acceso a las plantillas sin colección.

## Esto NO puede mover ninguna nota (y esta vez es literal)

A diferencia de las competencias, `ActividadEvaluacion` es un **troquel de un solo uso**:

```
ActividadEvaluacion  ──copia POR VALOR──▶  ActividadEvaluacionGrupo  ──▶  ActividadEvaluacionAlumno
   (la plantilla)         sin FK de vuelta      (la del grupo)              (la celda con la nota)
```

El plan de evaluación, la malla del alumno y el cálculo de la nota trabajan **sobre las copias** y **nunca miran la plantilla**. Cambiar de qué colección es una plantilla no puede tocar nada ya estampado:

```
── YA ESTAMPADO (no se toca):
   ActividadEvaluacionGrupo:  274
   ActividadEvaluacionAlumno: 1482   ← las celdas de malla con la nota
```

## Copiar la plantilla es ahora INCREMENTAL

Antes devolvía **409** si el grupo ya tenía cualquier actividad. Eso dejaba a un grupo con **dos materias** sin poder traer la segunda: copiaba las de la primera y **quedaba bloqueado para siempre**. Ahora deduplica por nombre —lo único que hay, porque la copia por valor no guarda referencia a su plantilla— y avisa de cuántas omitió.

## Bug aparte, ya existente: el plan no validaba pertenencia

`plan-evaluacion.controller.ts` validaba que las actividades **existieran**, pero no que fueran **del grupo**:

```ts
actQuery.containedIn('objectId', allActIds);   // ← sin equalTo('grupo')
```

Un plan podía referenciar la `ActividadEvaluacionGrupo` de **otro grupo**, y `computeActividadesScore` la omitiría del denominador: **la nota cambiaría sin error ni log**. Es exactamente el agujero que ya se tapó para las competencias en el PR #41 —con su comentario explicando por qué—, pero a las actividades **no se les había aplicado el mismo razonamiento**. Arreglado.

## Otros

- **El orden de las plantillas pasa a ser por colección.** Un contador global intercalaría los órdenes de dos materias y `copiarPlantilla` los estamparía mezclados en el grupo.
- `competencias.service.ts` → **`grupo-colecciones.service.ts`**: ya no es solo de competencias, resuelve "qué le toca a un grupo" para ambas entidades.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores en `web` y `api`.
- [x] `yarn build` OK.

## Migración — ⚠️ correr ANTES del deploy

```
── PLANTILLA sin colección: 69  → todas a tc2005b
── YA ESTAMPADO (no se toca): 274 actividades de grupo, 1482 celdas de malla
```

Sin el backfill, `copiarPlantilla` se quedaría **sin nada que copiar en ningún grupo** (el `containedIn('coleccion', …)` excluye los `null`).