### PR TITLE
fix(plan): ids muertos en el plan se podan en vez de atascarlo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
     estampado (274 actividades de grupo, 1482 celdas de malla) apunta a ella.
 
 ### Fixed
+- **El plan de evaluación se podía quedar atascado por ids muertos.** Sus
+  `periodos[].competencias` y `periodos[].actividades` son ids sueltos sin FK, y
+  cuando una actividad se borra (soft-delete) su id se puede quedar colgado ahí —
+  en producción había dos así. La validación de pertenencia (abajo) los habría
+  rechazado con un 400, dejando ese plan **imposible de guardar**: esos ids ni
+  siquiera se pintan en la UI, así que nadie podía quitarlos. Ahora se distinguen
+  dos casos: un id que apunta a algo **vivo de otro grupo/materia** es un error
+  (400), y un id **muerto** se poda en silencio al guardar. `podados` viaja en la
+  respuesta para que la UI pueda decirlo. `scripts/limpiar-plan-ids-huerfanos.ts`
+  saca la basura ya existente. **No cambia ninguna nota**: esos ids no sumaban al
+  numerador ni al denominador, porque al borrarse la actividad se borraron también
+  las celdas de los alumnos.
 - **El plan de evaluación no validaba que sus actividades fueran del grupo**, solo
   que existieran. Un plan podía referenciar la actividad de OTRO grupo y
   `computeActividadesScore` la omitiría del denominador: **la nota cambiaría sin

--- a/packages/api/scripts/limpiar-plan-ids-huerfanos.ts
+++ b/packages/api/scripts/limpiar-plan-ids-huerfanos.ts
@@ -1,0 +1,116 @@
+/**
+ * Limpieza: quita de `PlanEvaluacion.periodos[]` los ids que ya no apuntan a
+ * nada vivo.
+ *
+ * `periodos[].competencias` y `periodos[].actividades` son ids sueltos en un
+ * array JSON, sin FK ni cascada fiable. Cuando una actividad o competencia se
+ * borra (soft-delete), su id se puede quedar colgado ahí. En producción había
+ * dos así en el plan de un grupo.
+ *
+ * NO CAMBIA NINGUNA NOTA: esos ids ya no sumaban nada. Al borrarse la actividad
+ * se borraron también las celdas de los alumnos, así que no entraban ni al
+ * numerador ni al denominador. Se calculaba sobre las vivas, que es lo correcto.
+ * Esto solo saca la basura.
+ *
+ * Sí evita, en cambio, que el plan quede ATASCADO: la validación nueva rechaza
+ * los ids que apuntan a algo vivo de OTRO grupo, y esos ids muertos no se pintan
+ * en la UI, así que un admin no podría quitarlos a mano.
+ *
+ *   ./node_modules/.bin/tsx scripts/limpiar-plan-ids-huerfanos.ts --dry-run
+ *   ./node_modules/.bin/tsx scripts/limpiar-plan-ids-huerfanos.ts
+ *
+ * Idempotente. ⚠️ Dev comparte la BD de PRODUCCIÓN: corre --dry-run primero.
+ */
+import Parse from 'parse/node';
+import { config } from '../src/config/index.js';
+import '../src/models/index.js';
+
+Parse.initialize(config.appId);
+(Parse as any).serverURL = config.serverURL;
+(Parse as any).masterKey = config.masterKey;
+
+const dryRun = process.argv.includes('--dry-run');
+
+async function main() {
+  const qgr = new Parse.Query('Grupo');
+  qgr.equalTo('exists', true);
+  qgr.limit(500);
+  const grupos = await qgr.find({ useMasterKey: true });
+  const nombreDe = (id?: string) => grupos.find((g) => g.id === id)?.get('name') ?? '(?)';
+
+  const qp = new Parse.Query('PlanEvaluacion');
+  qp.equalTo('exists', true);
+  qp.limit(500);
+  const planes = await qp.find({ useMasterKey: true });
+
+  const aGuardar: Parse.Object[] = [];
+
+  for (const plan of planes) {
+    const gid = plan.get('grupo')?.id;
+    if (!gid) continue;
+    const grupoPtr = Parse.Object.extend('Grupo').createWithoutData(gid);
+
+    // Actividades VIVAS del grupo.
+    const qa = new Parse.Query('ActividadEvaluacionGrupo');
+    qa.equalTo('exists', true);
+    qa.equalTo('grupo', grupoPtr);
+    qa.limit(1000);
+    const actsVivas = new Set((await qa.find({ useMasterKey: true })).map((a) => a.id!));
+
+    // Competencias VIVAS de las colecciones del grupo.
+    const grupo = grupos.find((g) => g.id === gid)!;
+    const cols = ((grupo.get('colecciones') ?? []) as Parse.Object[]).filter((c) => c);
+    let compsVivas = new Set<string>();
+    if (cols.length > 0) {
+      const qc = new Parse.Query('Competencia');
+      qc.equalTo('exists', true);
+      qc.equalTo('active', true);
+      qc.containedIn('coleccion', cols);
+      qc.limit(1000);
+      compsVivas = new Set((await qc.find({ useMasterKey: true })).map((c) => c.id!));
+    }
+
+    const periodos = (plan.get('periodos') ?? []) as any[];
+    let podadosAct = 0;
+    let podadosComp = 0;
+
+    for (const p of periodos) {
+      const a0 = (p.actividades ?? []).length;
+      p.actividades = (p.actividades ?? []).filter((id: string) => actsVivas.has(id));
+      podadosAct += a0 - p.actividades.length;
+
+      const c0 = (p.competencias ?? []).length;
+      p.competencias = (p.competencias ?? []).filter((id: string) => compsVivas.has(id));
+      podadosComp += c0 - p.competencias.length;
+    }
+
+    const total = podadosAct + podadosComp;
+    const marca = total === 0 ? '[limpio]  ' : dryRun ? '[dry-run] ' : '[limpiar] ';
+    console.log(`${marca} ${String(nombreDe(gid)).padEnd(12)} ids muertos: ${podadosAct} actividad(es), ${podadosComp} competencia(s)`);
+
+    if (total > 0) {
+      plan.set('periodos', periodos);
+      aGuardar.push(plan);
+    }
+  }
+
+  console.log(`\nPlanes con basura: ${aGuardar.length} de ${planes.length}`);
+  console.log('NOTA: esto no cambia ninguna calificación — esos ids ya no sumaban nada.');
+
+  if (aGuardar.length === 0) {
+    console.log('\n✓ Nada que limpiar.');
+    return;
+  }
+  if (dryRun) {
+    console.log('\n--dry-run: no se escribió nada. Quita la bandera para aplicar.');
+    return;
+  }
+
+  await Parse.Object.saveAll(aGuardar, { useMasterKey: true });
+  console.log(`\n✓ ${aGuardar.length} plan(es) limpiados.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/plan-evaluacion.controller.ts
+++ b/packages/api/src/controllers/plan-evaluacion.controller.ts
@@ -54,13 +54,28 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
     const grupoQuery = BaseModel.queryActive<Grupo>('Grupo');
     const grupo = await grupoQuery.get(grupoId, { useMasterKey: true });
 
-    // Validar que las competencias existan Y que le toquen a ESTE grupo.
-    //
-    // `PlanEvaluacion.periodos[].competencias` son ids sueltos en un array JSON,
-    // sin FK. Si un periodo referenciara una competencia de otra materia, el
-    // alumno no tendría celda para ella: `computeCompetenciasScore` simplemente
-    // no la encontraría y la omitiría del promedio — la nota cambiaría sin que
-    // nadie tocara nada. Por eso se valida la pertenencia, no solo la existencia.
+    /* ── Validación de las referencias del plan ──
+     *
+     * `periodos[].competencias` y `periodos[].actividades` son ids sueltos en un
+     * array JSON, sin FK. Hay que distinguir DOS casos, y confundirlos rompe
+     * cosas distintas:
+     *
+     *   1. El id apunta a algo VIVO que no le toca a este grupo (una competencia
+     *      de otra materia, la actividad de otro grupo). Eso es un error real:
+     *      el alumno no tendría celda para ella y el cálculo la omitiría del
+     *      promedio — la nota cambiaría sin error ni log. → 400.
+     *
+     *   2. El id no apunta a nada vivo: la entidad se borró (soft-delete) y su id
+     *      se quedó colgado en el plan. En producción ya había dos así en el plan
+     *      de un grupo. NO es un error del que guarda: es basura previa, y
+     *      rechazar el guardado lo dejaría ATASCADO —esos ids ni siquiera se
+     *      pintan en la UI, así que no podría quitarlos—. → se podan en silencio.
+     *
+     * La poda deja el plan sano al guardarlo, que es justo lo que el borrado en
+     * cascada debió hacer en su momento.
+     */
+    let podados = 0;
+
     const allCompIds = [...new Set(periodos.flatMap((p: PeriodoConfig) => p.competencias))];
     if (allCompIds.length > 0) {
       const { competencias: permitidas, sinColecciones } = await competenciasDeGrupo(grupoId);
@@ -73,22 +88,31 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
       }
       const permitidasIds = new Set(permitidas.map((c) => c.id!));
       const fuera = allCompIds.filter((id: string) => !permitidasIds.has(id));
+
       if (fuera.length > 0) {
-        res.status(400).json({
-          status: 'error',
-          message: `${fuera.length} competencia(s) del plan no pertenecen a las colecciones de este grupo.`,
-        });
-        return;
+        // ¿Alguna de las que sobran sigue VIVA? Entonces es de otra materia (caso 1).
+        const vivasQuery = new Parse.Query<Competencia>('Competencia');
+        vivasQuery.equalTo('exists' as any, true as any);
+        vivasQuery.equalTo('active' as any, true as any);
+        vivasQuery.containedIn('objectId' as any, fuera as any);
+        vivasQuery.limit(1000);
+        const ajenas = await vivasQuery.find({ useMasterKey: true });
+        if (ajenas.length > 0) {
+          res.status(400).json({
+            status: 'error',
+            message: `${ajenas.length} competencia(s) del plan no pertenecen a las colecciones de este grupo.`,
+          });
+          return;
+        }
+        // Caso 2: ids muertos. Se podan.
+        for (const p of periodos) {
+          const antes = p.competencias.length;
+          p.competencias = p.competencias.filter((id: string) => permitidasIds.has(id));
+          podados += antes - p.competencias.length;
+        }
       }
     }
 
-    // Validar que las actividades existan Y que sean DE ESTE GRUPO.
-    //
-    // Antes solo se comprobaba la existencia: un plan podía referenciar la
-    // actividad de OTRO grupo y `computeActividadesScore` la omitiría del
-    // denominador — la nota cambiaría sin error ni log. Es el mismo agujero que
-    // ya se tapó arriba para las competencias; a las actividades no se les había
-    // aplicado el mismo razonamiento.
     const allActIds = [...new Set(periodos.flatMap((p: PeriodoConfig) => p.actividades))];
     if (allActIds.length > 0) {
       const actQuery = new Parse.Query<ActividadEvaluacionGrupo>('ActividadEvaluacionGrupo');
@@ -96,15 +120,30 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
       actQuery.equalTo('grupo' as any, grupo as any);
       actQuery.containedIn('objectId' as any, allActIds as any);
       actQuery.limit(1000);
-      const found = await actQuery.find({ useMasterKey: true });
-      if (found.length !== allActIds.length) {
-        const encontrados = new Set(found.map((a) => a.id));
-        const fuera = allActIds.filter((id: string) => !encontrados.has(id));
-        res.status(400).json({
-          status: 'error',
-          message: `${fuera.length} actividad(es) del plan no existen o no son de este grupo.`,
-        });
-        return;
+      const propias = await actQuery.find({ useMasterKey: true });
+      const propiasIds = new Set(propias.map((a) => a.id!));
+      const fuera = allActIds.filter((id: string) => !propiasIds.has(id));
+
+      if (fuera.length > 0) {
+        // ¿Alguna sigue VIVA pero es de OTRO grupo? (caso 1)
+        const ajenasQuery = new Parse.Query<ActividadEvaluacionGrupo>('ActividadEvaluacionGrupo');
+        ajenasQuery.equalTo('exists' as any, true as any);
+        ajenasQuery.containedIn('objectId' as any, fuera as any);
+        ajenasQuery.limit(1000);
+        const ajenas = await ajenasQuery.find({ useMasterKey: true });
+        if (ajenas.length > 0) {
+          res.status(400).json({
+            status: 'error',
+            message: `${ajenas.length} actividad(es) del plan son de otro grupo.`,
+          });
+          return;
+        }
+        // Caso 2: ids de actividades borradas. Se podan.
+        for (const p of periodos) {
+          const antes = p.actividades.length;
+          p.actividades = p.actividades.filter((id: string) => propiasIds.has(id));
+          podados += antes - p.actividades.length;
+        }
       }
     }
 
@@ -119,10 +158,13 @@ export async function createOrUpdatePlanEvaluacion(req: Request, res: Response):
       plan.setGrupo(grupo);
     }
 
+    // `periodos` ya viene podado de los ids muertos, si los había.
     plan.setPeriodos(periodos);
     await plan.save(null, { useMasterKey: true });
 
-    res.json({ status: 'ok', plan: plan.toSafeJSON() });
+    // `podados` se devuelve para que la UI pueda decirlo en vez de que el plan
+    // cambie de contenido en silencio al guardarlo.
+    res.json({ status: 'ok', plan: plan.toSafeJSON(), podados });
   } catch (error: any) {
     if (error?.code === Parse.Error.OBJECT_NOT_FOUND) {
       res.status(404).json({ status: 'error', message: 'Grupo no encontrado' });


### PR DESCRIPTION
## Descripción

**Esto arregla una consecuencia de mi propio cambio del PR #44.**

Allí añadí la validación de pertenencia al plan de evaluación (una actividad del plan debe ser de ese grupo). Pero rechazaba con **400 cualquier id que no resolviera a una actividad viva del grupo** — incluidos los ids **muertos**.

Y en producción los había:

```
⚠ Plan de FebJun26 → id 2bO4H7kFF4   "Lab 0: Presentación y registro"    exists: false
⚠ Plan de FebJun26 → id 5VeURhbvjY   "Lab 4: Fundamentos de JavaScript"  exists: false
```

Son actividades **de FebJun26** que se borraron (soft-delete) y cuyo id se quedó colgado en el plan. Con mi validación, **ese plan habría quedado imposible de guardar**: esos ids ni siquiera se pintan en la UI, así que un admin no podría quitarlos a mano.

## Los dos casos, que rompen cosas distintas

1. **El id apunta a algo VIVO que no le toca al grupo** (competencia de otra materia, actividad de otro grupo). Error real: el alumno no tendría celda para ella y el cálculo la omitiría del promedio, **moviendo la nota en silencio**. → **400**.

2. **El id no apunta a nada vivo**: basura previa del borrado en cascada. **No es culpa de quien guarda** → se **poda en silencio** y el plan queda sano.

`podados` viaja en la respuesta para que la UI pueda decirlo, en vez de que el plan cambie de contenido sin avisar.

## No cambia ninguna nota

Y conviene decirlo claro, porque al detectarlo yo mismo lo interpreté mal al principio: **la nota de FebJun26 nunca estuvo mal.** Al borrarse esas 2 actividades se borraron también las celdas de los alumnos, así que **no entraban ni al numerador ni al denominador**. La nota se calculaba sobre las 62 vivas, que es exactamente lo correcto. Los ids colgados eran inertes.

Verificado tras la limpieza — idéntico a antes:

```
ActividadEvaluacionAlumno: 1482  |  con ganado>0: 1267
CompetenciaAlumno:         198
```

## Tipo de cambio

- [x] `fix` — corrección de bug (SemVer: PATCH)

## ¿Cómo se probó?

- [x] `yarn test` — 195 tests. (El fallo en `deprecated/archived/…` es preexistente.)
- [x] `npx tsc --noEmit` sin errores.
- [x] `yarn build` OK.

## Limpieza — ya ejecutada

`scripts/limpiar-plan-ids-huerfanos.ts` (idempotente, `--dry-run`) saca la basura sin esperar a que alguien guarde el plan:

```
[limpiar]  FebJun26     ids muertos: 2 actividad(es), 0 competencia(s)
[limpio]   Prueba       ids muertos: 0, 0
[limpio]   Prueba 2     ids muertos: 0, 0
✓ 1 plan(es) limpiados.
```