### PR TITLE
chore(test): vitest deja de recoger los tests archivados de deprecated/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- **`yarn test` deja de salir siempre en rojo.** Sin configuración propia, vitest
+  recorría todo el repo y arrastraba los `.test.js` de `deprecated/` —ejercicios
+  de un curso de JS archivados ahí, ajenos al proyecto—, y uno de ellos importa un
+  archivo que no existe. La suite terminaba en rojo aunque los tests reales
+  pasaran, con lo que dejaba de servir como señal: cuando algo se rompiera de
+  verdad, el rojo se habría visto igual. `vitest.config.ts` acota la búsqueda a
+  `packages/`. De paso, los conteos que se venían reportando estaban inflados: de
+  los 195 tests, **139 eran del curso archivado**; la suite real son **56** en 5
+  archivos.
 - **Las Actividades de Evaluación (la plantilla) pertenecen a una colección** y
   dejan de ser una lista global. `copiarPlantilla` estampaba la plantilla ENTERA
   en cualquier grupo, fuera de su materia o no; ahora copia solo las de las

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    /**
+     * Sin esto, vitest recorre TODO el repo y arrastra los `.test.js` que viven
+     * bajo `deprecated/` — ejercicios de un curso de JS archivados ahí, ajenos al
+     * proyecto. Uno de ellos importa un archivo que no existe, así que `yarn test`
+     * terminaba SIEMPRE en rojo aunque los tests reales pasaran.
+     *
+     * Una suite que siempre sale roja deja de servir como señal: cuando algo se
+     * rompa de verdad, el rojo se verá igual que el de siempre. Por eso se acota
+     * a los tests del proyecto en vez de arreglar el ejercicio archivado.
+     */
+    include: ['packages/**/*.{test,spec}.{js,ts,tsx}'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'deprecated/**'],
+  },
+});


### PR DESCRIPTION
## Descripción

`yarn test` terminaba **siempre en rojo**, y no por el proyecto.

Sin configuración propia, vitest recorre todo el repo con su `include` por
defecto y arrastra los `.test.js` que viven bajo `deprecated/`: ejercicios de un
curso de JS archivados ahí desde `951d56b` (marzo), ajenos al proyecto. Uno de
ellos —`extra-files/validation.test.js`— importa `./validation`, que no existe,
así que falla al colectar.

El problema no es el archivo roto: es que **una suite que siempre sale roja deja
de servir como señal**. Cuando algo se rompa de verdad, el rojo se verá igual que
el de siempre y nadie lo va a mirar. Por eso se acota la búsqueda a `packages/`
en vez de parchear el ejercicio archivado — `deprecated/` está documentado en
`CLAUDE.md` como *"not used at runtime"* y no tiene por qué entrar a la suite.

De paso queda claro que **los conteos que veníamos reportando estaban inflados**:
de los 195 tests, **139 eran del curso archivado**. La suite real del proyecto son
**56 tests en 5 archivos** — los mismos 5 que existen fuera de `deprecated/`, así
que el cambio no esconde ningún test real.

## Tipo de cambio

- [x] `build` / `ci` / `chore` — tooling, dependencias, configuración

## ¿Cómo se probó?

Antes:

```
Test Files  1 failed | 34 passed (35)
     Tests  195 passed (195)
error Command failed with exit code 1.
```

Después:

```
Test Files  5 passed (5)
     Tests  56 passed (56)
```

Los 5 archivos recogidos son exactamente los 5 `*.test.*` que existen fuera de
`deprecated/` (`find . -path ./deprecated -prune -o -name "*.test.*" -print`):

- `packages/api/tests/contenidos-arbol.test.ts`
- `packages/api/tests/contenidos-busqueda.test.ts`
- `packages/api/tests/idor.test.ts`
- `packages/api/tests/url.test.ts`
- `packages/contenido-pipeline/index.test.js`

- [x] `yarn test` pasa
- [x] `npx tsc --noEmit` sin errores (web y api)
- [x] Build local OK (`yarn build`) — no toca el output

## Checklist

- [x] La rama sigue Conventional Branch
- [x] Los commits siguen Conventional Commits
- [x] Actualicé `CHANGELOG.md`
- [x] No hay commits directos a `main`; este cambio entra vía PR revisado