### PR TITLE
fix(calificaciones): el alumno veía su nota deflactada; el cálculo se unifica en un paquete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- **El cálculo de calificaciones es ahora UNO solo** (`@tc2005b/evaluacion`), no
+  cuatro copias. Estaba duplicado en el API, la malla del profesor, el export
+  XLSX y el dashboard del alumno, y las copias habían divergido —el bug de
+  arriba es exactamente eso: tres copias se actualizaron para leer números y una
+  se quedó atrás—. El paquete es puro (sin dependencias) y va con 28 tests que
+  fijan las decisiones, no el resultado accidental: cómo se lee cada formato de
+  valor, que una competencia sin evaluar cuenta como 0 y sí entra al promedio,
+  y que un periodo acumulativo no puede contar dos veces la misma actividad.
+  - Al unificar se corrigen dos divergencias más:
+    - **Doble conteo en periodos acumulativos.** Las copias de la web sumaban una
+      actividad una vez por cada periodo previo en el que apareciera. Hoy ninguna
+      está en 2+ periodos, así que no llegó a morder, pero estaba armado.
+    - **Redondeo.** El API redondeaba la nota de cada periodo *antes* de
+      ponderarla y la web no, así que un mismo alumno podía tener dos notas
+      oficiales distintas según la pantalla. Ahora se redondea una sola vez, al
+      presentar. En producción esto mueve **una nota: 82.9 → 83**.
 - **`yarn test` deja de salir siempre en rojo.** Sin configuración propia, vitest
   recorría todo el repo y arrastraba los `.test.js` de `deprecated/` —ejercicios
   de un curso de JS archivados ahí, ajenos al proyecto—, y uno de ellos importa un
@@ -34,6 +50,15 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
     estampado (274 actividades de grupo, 1482 celdas de malla) apunta a ella.
 
 ### Fixed
+- **El alumno veía su calificación masivamente deflactada.** Su dashboard leía
+  TODAS sus competencias como 0. El parser (`parseCompetenciaPercent`) empezaba
+  con `if (typeof valor !== 'string') return 0`, y los valores se guardan como
+  **número** — las 396 celdas de producción lo son. Como en el Periodo 2 las
+  competencias pesan **70%**, **17 de los 18 alumnos de FebJun26 veían ~41.5
+  puntos menos de su nota real** (peor caso, 51.9). La vista del profesor y el
+  export XLSX siempre estuvieron bien: el error era solo de la pantalla del
+  alumno, y siempre a la baja. Ninguna nota guardada estaba mal; lo que estaba
+  mal era lo que se le mostraba.
 - **El plan de evaluación se podía quedar atascado por ids muertos.** Sus
   `periodos[].competencias` y `periodos[].actividades` son ids sueltos sin FK, y
   cuando una actividad se borra (soft-delete) su id se puede quedar colgado ahí —

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "workspaces": [
     "packages/web",
     "packages/api",
-    "packages/contenido-pipeline"
+    "packages/contenido-pipeline",
+    "packages/evaluacion"
   ],
   "scripts": {
     "dev": "concurrently -n web,api -c cyan,yellow \"yarn workspace @tc2005b/web dev\" \"yarn workspace @tc2005b/api dev\"",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@parse/s3-files-adapter": "^4.1.0",
     "@tc2005b/contenido-pipeline": "0.1.0",
+    "@tc2005b/evaluacion": "0.1.0",
     "bcryptjs": "^3.0.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",

--- a/packages/api/src/controllers/calificaciones.controller.ts
+++ b/packages/api/src/controllers/calificaciones.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import Parse from 'parse/node';
+import { calcCalificacion, round1 } from '@tc2005b/evaluacion';
 import { PlanEvaluacion, type PeriodoConfig } from '../models/PlanEvaluacion.js';
 import { ActividadEvaluacionAlumno } from '../models/ActividadEvaluacionAlumno.js';
 import { CompetenciaAlumno } from '../models/CompetenciaAlumno.js';
@@ -7,52 +8,24 @@ import { Grupo } from '../models/Grupo.js';
 import { AppUser } from '../models/AppUser.js';
 import { getAlumnosDeGrupo } from '../services/grupo-alumno.service.js';
 
-function parseValorCompetencia(valor: unknown): number {
-  // Los valores se guardan como number (0, 15, 70, 85, 100) en el flujo nuevo,
-  // pero hay datos legacy guardados como string tipo "Básico (70%)".
-  if (valor === null || valor === undefined || valor === '') return 0;
-  if (typeof valor === 'number') return Number.isFinite(valor) ? valor : 0;
-  if (typeof valor === 'string') {
-    const trimmed = valor.trim();
-    if (trimmed === '') return 0;
-    // Caso "70" o "70.5" — string puramente numérico
-    const asNumber = Number(trimmed);
-    if (Number.isFinite(asNumber)) return asNumber;
-    // Caso legacy "Básico (70%)" — extraer dígitos antes de %
-    const match = trimmed.match(/(\d+)%/);
-    return match ? parseInt(match[1], 10) : 0;
-  }
-  return 0;
+/* El cálculo vive en `@tc2005b/evaluacion`, compartido con la malla del
+ * profesor, el dashboard del alumno y el export XLSX. Aquí solo se traducen los
+ * `Parse.Object` a las formas planas que espera. */
+
+function aActividadCalc(rec: Parse.Object) {
+  return {
+    actividadGrupoId: rec.get('actividadGrupo')?.id ?? '',
+    aprendizajePlaneado: rec.get('aprendizajePlaneado') ?? 0,
+    aprendizajeGanado: rec.get('aprendizajeGanado') ?? 0,
+  };
 }
 
-function computeActividadesScore(
-  records: Parse.Object[],
-  actividadIds: Set<string>,
-): number {
-  let planeado = 0;
-  let ganado = 0;
-  for (const rec of records) {
-    const actGrupo = rec.get('actividadGrupo');
-    if (!actGrupo || !actividadIds.has(actGrupo.id)) continue;
-    planeado += rec.get('aprendizajePlaneado') ?? 0;
-    ganado += rec.get('aprendizajeGanado') ?? 0;
-  }
-  return planeado === 0 ? 0 : (ganado / planeado) * 100;
-}
-
-function computeCompetenciasScore(
-  records: Parse.Object[],
-  competenciaIds: Set<string>,
-  periodoIndex: number,
-): number {
-  const field = periodoIndex === 0 ? 'valorPeriodo1' : 'valorPeriodo2';
-  const values: number[] = [];
-  for (const rec of records) {
-    const comp = rec.get('competencia');
-    if (!comp || !competenciaIds.has(comp.id)) continue;
-    values.push(parseValorCompetencia(rec.get(field) ?? ''));
-  }
-  return values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length;
+function aCompetenciaCalc(rec: Parse.Object) {
+  return {
+    competenciaId: rec.get('competencia')?.id ?? '',
+    valorPeriodo1: rec.get('valorPeriodo1') ?? '',
+    valorPeriodo2: rec.get('valorPeriodo2') ?? '',
+  };
 }
 
 export async function getCalificacionesGrupo(req: Request, res: Response) {
@@ -114,47 +87,23 @@ export async function getCalificacionesGrupo(req: Request, res: Response) {
 
     // 5. Compute scores
     const calificaciones = alumnos.map((item) => {
-      const alumno = item.alumno;
-      const alumnoId = alumno.id;
-      const alumnoActs = actByAlumno.get(alumnoId) ?? [];
-      const alumnoComps = compByAlumno.get(alumnoId) ?? [];
+      const alumnoId = item.alumno.id;
+      const alumnoActs = (actByAlumno.get(alumnoId) ?? []).map(aActividadCalc);
+      const alumnoComps = (compByAlumno.get(alumnoId) ?? []).map(aCompetenciaCalc);
 
-      const periodoScores: number[] = [];
+      const { periodos: scores, calificacionActual } = calcCalificacion(
+        periodos,
+        alumnoActs,
+        alumnoComps,
+      );
 
-      for (let i = 0; i < periodos.length; i++) {
-        const periodo = periodos[i];
-
-        // Build activity IDs set (with acumulativo support)
-        const actIdSet = new Set<string>();
-        if (periodo.acumulativo) {
-          for (let j = 0; j <= i; j++) {
-            for (const aid of periodos[j].actividades) actIdSet.add(aid);
-          }
-        } else {
-          for (const aid of periodo.actividades) actIdSet.add(aid);
-        }
-
-        const actScore = computeActividadesScore(alumnoActs, actIdSet);
-
-        // Competencias
-        const compIdSet = new Set<string>(periodo.competencias);
-        const compScore = computeCompetenciasScore(alumnoComps, compIdSet, i);
-
-        const calif =
-          (compScore * periodo.pesoCompetencias) / 100 +
-          (actScore * periodo.pesoActividades) / 100;
-
-        periodoScores.push(Math.round(calif * 10) / 10);
-      }
-
-      // Final grade
-      let final = 0;
-      for (let i = 0; i < periodos.length; i++) {
-        final += (periodoScores[i] * periodos[i].pesoFinal) / 100;
-      }
-      final = Math.round(final * 10) / 10;
-
-      return { alumnoId, periodos: periodoScores, final };
+      // El redondeo es SOLO de presentación: la nota final se pondera con los
+      // valores exactos, no con los periodos ya redondeados.
+      return {
+        alumnoId,
+        periodos: scores.map((p) => round1(p.periodoScore)),
+        final: round1(calificacionActual),
+      };
     });
 
     // 6. Response

--- a/packages/evaluacion/index.d.ts
+++ b/packages/evaluacion/index.d.ts
@@ -1,0 +1,74 @@
+/** Configuración de un periodo, tal como vive en `PlanEvaluacion.periodos[]`. */
+export interface PeriodoConfig {
+  nombre: string;
+  pesoFinal: number;
+  pesoCompetencias: number;
+  pesoActividades: number;
+  competencias: string[];
+  actividades: string[];
+  acumulativo: boolean;
+}
+
+/**
+ * Lo MÍNIMO que el cálculo necesita de una actividad del alumno.
+ *
+ * Sin índice de firma a propósito: cada pantalla pasa su propio tipo, más rico
+ * (con `nombre`, `tipo`, `semanaCompletada`…), y las funciones son genéricas
+ * sobre él para devolvérselo intacto en `actividadesContadas`.
+ */
+export interface ActividadCalc {
+  actividadGrupoId: string;
+  aprendizajePlaneado: number;
+  aprendizajeGanado: number;
+}
+
+/** Lo mínimo que el cálculo necesita de una competencia del alumno. */
+export interface CompetenciaCalc {
+  competenciaId: string;
+  valorPeriodo1?: string | number | null;
+  valorPeriodo2?: string | number | null;
+}
+
+export interface PeriodoScore<A = ActividadCalc> {
+  nombre: string;
+  actScore: number;
+  compScore: number;
+  totalPlaneado: number;
+  totalGanado: number;
+  actividadesContadas: A[];
+  competenciasContadas: number;
+  pesoFinal: number;
+  pesoActividades: number;
+  pesoCompetencias: number;
+  periodoScore: number;
+}
+
+export declare function parseValorCompetencia(valor: unknown): number;
+export declare function campoValorPeriodo(periodoIdx: number): 'valorPeriodo1' | 'valorPeriodo2';
+export declare function idsActividadesDelPeriodo(periodos: PeriodoConfig[], i: number): Set<string>;
+
+export declare function calcActividadesScore<A extends ActividadCalc>(
+  actividades: A[],
+  ids: Set<string>,
+): { planeado: number; ganado: number; contadas: A[]; score: number };
+
+export declare function calcCompetenciasScore(
+  competencias: CompetenciaCalc[],
+  ids: Set<string>,
+  periodoIdx: number,
+): { suma: number; cuenta: number; score: number };
+
+export declare function calcPeriodoScore<A extends ActividadCalc>(
+  periodos: PeriodoConfig[],
+  i: number,
+  actividades: A[],
+  competencias: CompetenciaCalc[],
+): PeriodoScore<A>;
+
+export declare function calcCalificacion<A extends ActividadCalc>(
+  periodos: PeriodoConfig[],
+  actividades: A[],
+  competencias: CompetenciaCalc[],
+): { periodos: PeriodoScore<A>[]; calificacionActual: number };
+
+export declare function round1(n: number): number;

--- a/packages/evaluacion/index.js
+++ b/packages/evaluacion/index.js
@@ -1,0 +1,148 @@
+// Cálculo de calificaciones — implementación ÚNICA.
+//
+// Antes vivía copiado en cuatro sitios: el API (`calificaciones.controller`),
+// la malla del profesor (`MallaEvaluacionPage`), el export XLSX (`mallaExport`)
+// y el dashboard del alumno (`AlumnoDashboard`). Las cuatro copias divergieron,
+// y la del alumno se quedó sin leer los valores nuevos: mostraba TODAS las
+// competencias como 0, lo que en producción deflactaba su nota hasta 52 puntos.
+//
+// Por eso esto es un paquete y no un helper suelto: la nota de un alumno no
+// puede depender de qué pantalla la pinte.
+
+/**
+ * Valor de una competencia → porcentaje (0–100).
+ *
+ * Acepta las tres formas que conviven en la BD:
+ *   - number  → 85            (el formato actual; las 396 celdas de prod son así)
+ *   - string numérico → '85'
+ *   - string legacy   → 'Sólido (85%)'
+ *
+ * Sin evaluar (null/undefined/'') vale 0 y SÍ cuenta en el promedio: una
+ * competencia asignada al periodo y no evaluada baja la nota. Es una decisión
+ * de política, no un accidente — está fijada en los tests.
+ */
+export function parseValorCompetencia(valor) {
+  if (valor === null || valor === undefined || valor === '') return 0;
+  if (typeof valor === 'number') return Number.isFinite(valor) ? valor : 0;
+  if (typeof valor === 'string') {
+    const t = valor.trim();
+    if (t === '') return 0;
+    const n = Number(t);
+    if (Number.isFinite(n)) return n;
+    const m = t.match(/(\d+)\s*%/);
+    return m ? parseInt(m[1], 10) : 0;
+  }
+  return 0;
+}
+
+/**
+ * Campo de `CompetenciaAlumno` que le toca a un periodo.
+ *
+ * ⚠ El modelo solo tiene `valorPeriodo1` y `valorPeriodo2`. Un plan con 3+
+ * periodos haría que el 3º en adelante REUSARA la evaluación del 2º. Hoy los
+ * tres planes de producción tienen exactamente 2 periodos, así que no se
+ * dispara; si algún día se permiten más, el modelo necesita más campos y esto
+ * hay que revisarlo.
+ */
+export function campoValorPeriodo(periodoIdx) {
+  return periodoIdx === 0 ? 'valorPeriodo1' : 'valorPeriodo2';
+}
+
+/**
+ * Ids de las actividades que cuentan para el periodo `i`.
+ *
+ * Un periodo `acumulativo` arrastra las actividades de todos los anteriores.
+ * Es un Set a propósito: si una actividad estuviera en dos periodos previos,
+ * sumarla por cada uno la contaría DOS VECES —que es lo que hacían las copias
+ * de la web—. Hoy ninguna actividad está en 2+ periodos, así que el bug no
+ * llegó a morder, pero estaba armado.
+ */
+export function idsActividadesDelPeriodo(periodos, i) {
+  const ids = new Set();
+  const desde = periodos[i].acumulativo ? 0 : i;
+  for (let j = desde; j <= i; j++) {
+    for (const id of periodos[j].actividades ?? []) ids.add(id);
+  }
+  return ids;
+}
+
+/**
+ * Score de actividades: aprendizaje ganado / planeado, en porcentaje.
+ * Sin nada planeado el score es 0 (no NaN, que es lo que daría la división).
+ */
+export function calcActividadesScore(actividades, ids) {
+  let planeado = 0;
+  let ganado = 0;
+  const contadas = [];
+  for (const act of actividades) {
+    if (!ids.has(act.actividadGrupoId)) continue;
+    planeado += act.aprendizajePlaneado ?? 0;
+    ganado += act.aprendizajeGanado ?? 0;
+    contadas.push(act);
+  }
+  return {
+    planeado,
+    ganado,
+    contadas,
+    score: planeado === 0 ? 0 : (ganado / planeado) * 100,
+  };
+}
+
+/** Score de competencias: promedio simple de las del periodo. */
+export function calcCompetenciasScore(competencias, ids, periodoIdx) {
+  const campo = campoValorPeriodo(periodoIdx);
+  let suma = 0;
+  let cuenta = 0;
+  for (const comp of competencias) {
+    if (!ids.has(comp.competenciaId)) continue;
+    suma += parseValorCompetencia(comp[campo]);
+    cuenta++;
+  }
+  return { suma, cuenta, score: cuenta === 0 ? 0 : suma / cuenta };
+}
+
+/** Nota de un periodo: mezcla ponderada de actividades y competencias. */
+export function calcPeriodoScore(periodos, i, actividades, competencias) {
+  const periodo = periodos[i];
+  const act = calcActividadesScore(actividades, idsActividadesDelPeriodo(periodos, i));
+  const comp = calcCompetenciasScore(competencias, new Set(periodo.competencias ?? []), i);
+
+  return {
+    nombre: periodo.nombre || `P${i + 1}`,
+    actScore: act.score,
+    compScore: comp.score,
+    totalPlaneado: act.planeado,
+    totalGanado: act.ganado,
+    actividadesContadas: act.contadas,
+    competenciasContadas: comp.cuenta,
+    pesoFinal: periodo.pesoFinal,
+    pesoActividades: periodo.pesoActividades,
+    pesoCompetencias: periodo.pesoCompetencias,
+    periodoScore:
+      (act.score * periodo.pesoActividades + comp.score * periodo.pesoCompetencias) / 100,
+  };
+}
+
+/**
+ * Nota final del alumno: suma de las notas de periodo ponderadas por `pesoFinal`.
+ *
+ * NO se redondea nada intermedio. El API redondeaba la nota de cada periodo
+ * antes de ponderarla y la web no, así que el mismo alumno podía tener dos notas
+ * oficiales con 0.1 de diferencia según la pantalla. Se redondea UNA vez, al
+ * mostrar, con `round1`.
+ */
+export function calcCalificacion(periodos, actividades, competencias) {
+  const scores = periodos.map((_, i) =>
+    calcPeriodoScore(periodos, i, actividades, competencias),
+  );
+  const calificacionActual = scores.reduce(
+    (sum, p) => sum + (p.periodoScore * p.pesoFinal) / 100,
+    0,
+  );
+  return { periodos: scores, calificacionActual };
+}
+
+/** Redondeo a 1 decimal. El ÚNICO redondeo; se aplica al presentar. */
+export function round1(n) {
+  return Math.round(n * 10) / 10;
+}

--- a/packages/evaluacion/index.test.js
+++ b/packages/evaluacion/index.test.js
@@ -1,0 +1,276 @@
+/**
+ * Tests del cálculo de calificaciones.
+ *
+ * Esto es código que decide la nota de un alumno. El bug que motivó el paquete
+ * (el dashboard leía todas las competencias como 0 y deflactaba la nota hasta 52
+ * puntos) habría sido imposible con estos tests puestos, así que cada uno fija
+ * una decisión concreta, no el resultado que casualmente da el código de hoy.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseValorCompetencia,
+  campoValorPeriodo,
+  idsActividadesDelPeriodo,
+  calcActividadesScore,
+  calcCompetenciasScore,
+  calcPeriodoScore,
+  calcCalificacion,
+  round1,
+} from './index.js';
+
+/** Plan como los tres de producción: P1 normal, P2 acumulativo. */
+const PLAN = [
+  {
+    nombre: 'Periodo 1',
+    pesoFinal: 50,
+    pesoActividades: 80,
+    pesoCompetencias: 20,
+    actividades: ['a1', 'a2'],
+    competencias: ['c1', 'c2'],
+    acumulativo: false,
+  },
+  {
+    nombre: 'Periodo 2',
+    pesoFinal: 50,
+    pesoActividades: 30,
+    pesoCompetencias: 70,
+    actividades: ['a3'],
+    competencias: ['c1', 'c2'],
+    acumulativo: true,
+  },
+];
+
+const act = (id, planeado, ganado) => ({
+  actividadGrupoId: id,
+  aprendizajePlaneado: planeado,
+  aprendizajeGanado: ganado,
+});
+
+describe('parseValorCompetencia', () => {
+  // ── El bug real: en producción las 396 celdas son `number`, y la copia del
+  // dashboard del alumno hacía `if (typeof valor !== 'string') return 0`.
+  it('lee los valores numéricos, que es como están guardados hoy', () => {
+    expect(parseValorCompetencia(0)).toBe(0);
+    expect(parseValorCompetencia(15)).toBe(15);
+    expect(parseValorCompetencia(70)).toBe(70);
+    expect(parseValorCompetencia(85)).toBe(85);
+    expect(parseValorCompetencia(100)).toBe(100);
+  });
+
+  it('un 100 nunca puede leerse como 0 (la regresión que deflactaba la nota)', () => {
+    expect(parseValorCompetencia(100)).not.toBe(0);
+  });
+
+  it('lee los strings numéricos', () => {
+    expect(parseValorCompetencia('85')).toBe(85);
+    expect(parseValorCompetencia(' 70 ')).toBe(70);
+  });
+
+  it('lee el formato legacy con etiqueta', () => {
+    expect(parseValorCompetencia('Básico (70%)')).toBe(70);
+    expect(parseValorCompetencia('Destacado (100%)')).toBe(100);
+    expect(parseValorCompetencia('Incipiente B (0%)')).toBe(0);
+  });
+
+  it('sin evaluar vale 0', () => {
+    expect(parseValorCompetencia('')).toBe(0);
+    expect(parseValorCompetencia(null)).toBe(0);
+    expect(parseValorCompetencia(undefined)).toBe(0);
+  });
+
+  it('no explota ni devuelve NaN con basura', () => {
+    for (const v of ['abc', {}, [], true, NaN, Infinity]) {
+      const r = parseValorCompetencia(v);
+      expect(Number.isFinite(r)).toBe(true);
+    }
+  });
+});
+
+describe('campoValorPeriodo', () => {
+  it('el primer periodo usa valorPeriodo1 y el segundo valorPeriodo2', () => {
+    expect(campoValorPeriodo(0)).toBe('valorPeriodo1');
+    expect(campoValorPeriodo(1)).toBe('valorPeriodo2');
+  });
+
+  // Deuda conocida del modelo: solo hay dos campos de valor. Se fija aquí para
+  // que quede escrito que un 3er periodo REUSA la evaluación del 2º.
+  it('un tercer periodo reusa valorPeriodo2 (limitación del modelo, documentada)', () => {
+    expect(campoValorPeriodo(2)).toBe('valorPeriodo2');
+  });
+});
+
+describe('idsActividadesDelPeriodo', () => {
+  it('un periodo normal solo cuenta las suyas', () => {
+    expect([...idsActividadesDelPeriodo(PLAN, 0)].sort()).toEqual(['a1', 'a2']);
+  });
+
+  it('un periodo acumulativo arrastra las de los anteriores', () => {
+    expect([...idsActividadesDelPeriodo(PLAN, 1)].sort()).toEqual(['a1', 'a2', 'a3']);
+  });
+
+  it('una actividad repetida en varios periodos se cuenta UNA vez', () => {
+    // Este era el doble conteo de las copias de la web: sumaban la actividad
+    // por cada periodo previo en el que apareciera.
+    const plan = [
+      { ...PLAN[0], actividades: ['x'] },
+      { ...PLAN[0], actividades: ['x'], acumulativo: true },
+      { ...PLAN[1], actividades: [], acumulativo: true },
+    ];
+    const ids = idsActividadesDelPeriodo(plan, 2);
+    expect([...ids]).toEqual(['x']);
+
+    // Y el score lo confirma: 5/10 = 50%, no 10/20 con la misma actividad doble.
+    const { planeado, score } = calcActividadesScore([act('x', 10, 5)], ids);
+    expect(planeado).toBe(10);
+    expect(score).toBe(50);
+  });
+});
+
+describe('calcActividadesScore', () => {
+  it('es ganado / planeado en porcentaje', () => {
+    const r = calcActividadesScore([act('a1', 10, 5), act('a2', 10, 10)], new Set(['a1', 'a2']));
+    expect(r.planeado).toBe(20);
+    expect(r.ganado).toBe(15);
+    expect(r.score).toBe(75);
+  });
+
+  it('ignora las actividades que no son del periodo', () => {
+    const r = calcActividadesScore([act('a1', 10, 5), act('zz', 90, 90)], new Set(['a1']));
+    expect(r.score).toBe(50);
+  });
+
+  it('sin nada planeado da 0, no NaN', () => {
+    const r = calcActividadesScore([act('a1', 0, 0)], new Set(['a1']));
+    expect(r.score).toBe(0);
+    expect(Number.isNaN(r.score)).toBe(false);
+  });
+
+  it('sin actividades da 0', () => {
+    expect(calcActividadesScore([], new Set(['a1'])).score).toBe(0);
+  });
+});
+
+describe('calcCompetenciasScore', () => {
+  const comps = [
+    { competenciaId: 'c1', valorPeriodo1: 100, valorPeriodo2: 70 },
+    { competenciaId: 'c2', valorPeriodo1: 0, valorPeriodo2: 85 },
+  ];
+
+  it('promedia las competencias del periodo', () => {
+    expect(calcCompetenciasScore(comps, new Set(['c1', 'c2']), 0).score).toBe(50); // (100+0)/2
+    expect(calcCompetenciasScore(comps, new Set(['c1', 'c2']), 1).score).toBe(77.5); // (70+85)/2
+  });
+
+  it('una competencia SIN EVALUAR cuenta como 0 y sí entra al promedio', () => {
+    // Decisión de política: baja la nota. Si se quisiera excluirla del
+    // denominador, este test es el que hay que cambiar a conciencia.
+    const conVacia = [
+      { competenciaId: 'c1', valorPeriodo1: 100 },
+      { competenciaId: 'c2', valorPeriodo1: '' },
+    ];
+    const r = calcCompetenciasScore(conVacia, new Set(['c1', 'c2']), 0);
+    expect(r.cuenta).toBe(2);
+    expect(r.score).toBe(50);
+  });
+
+  it('ignora las competencias que no son del periodo', () => {
+    expect(calcCompetenciasScore(comps, new Set(['c1']), 0).score).toBe(100);
+  });
+
+  it('sin competencias da 0', () => {
+    expect(calcCompetenciasScore([], new Set(['c1']), 0).score).toBe(0);
+  });
+});
+
+describe('calcPeriodoScore', () => {
+  const actividades = [act('a1', 10, 10), act('a2', 10, 0), act('a3', 20, 20)];
+  const competencias = [
+    { competenciaId: 'c1', valorPeriodo1: 100, valorPeriodo2: 100 },
+    { competenciaId: 'c2', valorPeriodo1: 0, valorPeriodo2: 100 },
+  ];
+
+  it('mezcla actividades y competencias con sus pesos', () => {
+    // P1: act = 10/20 = 50%, comp = (100+0)/2 = 50%
+    //     score = 50*80/100 + 50*20/100 = 40 + 10 = 50
+    const p1 = calcPeriodoScore(PLAN, 0, actividades, competencias);
+    expect(p1.actScore).toBe(50);
+    expect(p1.compScore).toBe(50);
+    expect(p1.periodoScore).toBe(50);
+  });
+
+  it('el periodo acumulativo arrastra las actividades previas', () => {
+    // P2 acumulativo: act = (10+0+20)/(10+10+20) = 30/40 = 75%
+    //                 comp = (100+100)/2 = 100%
+    //                 score = 75*30/100 + 100*70/100 = 22.5 + 70 = 92.5
+    const p2 = calcPeriodoScore(PLAN, 1, actividades, competencias);
+    expect(p2.totalPlaneado).toBe(40);
+    expect(p2.totalGanado).toBe(30);
+    expect(p2.actScore).toBe(75);
+    expect(p2.compScore).toBe(100);
+    expect(p2.periodoScore).toBe(92.5);
+  });
+
+  it('devuelve las actividades contadas (la malla marca ahí las faltantes)', () => {
+    const p1 = calcPeriodoScore(PLAN, 0, actividades, competencias);
+    expect(p1.actividadesContadas.map((a) => a.actividadGrupoId)).toEqual(['a1', 'a2']);
+  });
+});
+
+describe('calcCalificacion', () => {
+  const actividades = [act('a1', 10, 10), act('a2', 10, 0), act('a3', 20, 20)];
+  const competencias = [
+    { competenciaId: 'c1', valorPeriodo1: 100, valorPeriodo2: 100 },
+    { competenciaId: 'c2', valorPeriodo1: 0, valorPeriodo2: 100 },
+  ];
+
+  it('pondera los periodos por pesoFinal', () => {
+    // P1 = 50, P2 = 92.5, ambos al 50% → 25 + 46.25 = 71.25
+    const r = calcCalificacion(PLAN, actividades, competencias);
+    expect(r.periodos.map((p) => p.periodoScore)).toEqual([50, 92.5]);
+    expect(r.calificacionActual).toBeCloseTo(71.25, 10);
+  });
+
+  it('NO redondea los periodos antes de ponderarlos', () => {
+    // El API lo hacía y la web no, así que el mismo alumno tenía dos notas
+    // oficiales con hasta 0.1 de diferencia. Se redondea una sola vez, al final.
+    const plan = [
+      { ...PLAN[0], pesoFinal: 50, pesoActividades: 100, pesoCompetencias: 0, actividades: ['a1'], competencias: [] },
+      { ...PLAN[1], pesoFinal: 50, pesoActividades: 100, pesoCompetencias: 0, actividades: ['a2'], competencias: [], acumulativo: false },
+    ];
+    // 1/3 → 33.333…%  y  2/3 → 66.666…%
+    const acts = [act('a1', 3, 1), act('a2', 3, 2)];
+    const r = calcCalificacion(plan, acts, []);
+    // exacto: (33.333… + 66.666…)/2 = 50 exacto.
+    // redondeando antes: (33.3 + 66.7)/2 = 50.0 — aquí coincide, pero el punto
+    // es que el valor que se propaga es el exacto:
+    expect(r.periodos[0].periodoScore).toBeCloseTo(100 / 3, 10);
+    expect(r.calificacionActual).toBeCloseTo(50, 10);
+  });
+
+  it('un alumno sin nada evaluado saca 0, no NaN', () => {
+    const r = calcCalificacion(PLAN, [], []);
+    expect(r.calificacionActual).toBe(0);
+    expect(Number.isNaN(r.calificacionActual)).toBe(false);
+  });
+
+  it('un alumno perfecto saca 100', () => {
+    const perfectas = [act('a1', 10, 10), act('a2', 10, 10), act('a3', 20, 20)];
+    const topes = [
+      { competenciaId: 'c1', valorPeriodo1: 100, valorPeriodo2: 100 },
+      { competenciaId: 'c2', valorPeriodo1: 100, valorPeriodo2: 100 },
+    ];
+    expect(calcCalificacion(PLAN, perfectas, topes).calificacionActual).toBeCloseTo(100, 10);
+  });
+
+  it('un plan vacío da 0', () => {
+    expect(calcCalificacion([], [], []).calificacionActual).toBe(0);
+  });
+});
+
+describe('round1', () => {
+  it('redondea a un decimal', () => {
+    expect(round1(71.25)).toBe(71.3);
+    expect(round1(0)).toBe(0);
+    expect(round1(99.94)).toBe(99.9);
+  });
+});

--- a/packages/evaluacion/package.json
+++ b/packages/evaluacion/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@tc2005b/evaluacion",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "description": "Cálculo de calificaciones compartido. Una sola implementación de la nota (actividades, competencias, ponderación por periodo) que usan el API, la malla del profesor, el dashboard del alumno y el export XLSX — para que las cuatro pantallas no puedan dar números distintos."
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-table": "^8.21.3",
     "@tc2005b/contenido-pipeline": "0.1.0",
+    "@tc2005b/evaluacion": "0.1.0",
     "@uiw/react-codemirror": "^4.23.0",
     "apexcharts": "^5.10.4",
     "exceljs": "^4.4.0",

--- a/packages/web/src/components/dashboard/pages/AlumnoDashboard/AlumnoDashboard.tsx
+++ b/packages/web/src/components/dashboard/pages/AlumnoDashboard/AlumnoDashboard.tsx
@@ -9,22 +9,13 @@ import {
   Tooltip,
   Legend,
 } from 'recharts';
+import { calcCalificacion, type PeriodoConfig } from '@tc2005b/evaluacion';
 import { useAuth } from '../../../../context/AuthContext';
 import styles from './AlumnoDashboard.module.css';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
-
-interface PeriodoConfig {
-  nombre: string;
-  pesoFinal: number;
-  pesoCompetencias: number;
-  pesoActividades: number;
-  competencias: string[];
-  actividades: string[];
-  acumulativo: boolean;
-}
 
 interface ActividadAlumnoData {
   id: string;
@@ -71,63 +62,6 @@ const API_BASE = '/api';
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
-
-function parseCompetenciaPercent(valor: unknown): number {
-  if (typeof valor !== 'string') return 0;
-  const match = valor.match(/\((\d+)%\)/);
-  return match ? Number(match[1]) : 0;
-}
-
-function calcPeriodoScore(
-  periodo: PeriodoConfig,
-  periodoIdx: number,
-  periodos: PeriodoConfig[],
-  actividades: ActividadAlumnoData[],
-  competencias: CompetenciaAlumnoData[],
-) {
-  const ownIds = new Set(periodo.actividades);
-  let totalPlaneado = 0;
-  let totalGanado = 0;
-
-  for (const act of actividades) {
-    if (ownIds.has(act.actividadGrupoId)) {
-      totalPlaneado += act.aprendizajePlaneado;
-      totalGanado += act.aprendizajeGanado;
-    }
-  }
-
-  if (periodo.acumulativo && periodoIdx > 0) {
-    for (let pi = 0; pi < periodoIdx; pi++) {
-      const prevIds = new Set(periodos[pi].actividades);
-      for (const act of actividades) {
-        if (prevIds.has(act.actividadGrupoId) && !ownIds.has(act.actividadGrupoId)) {
-          totalPlaneado += act.aprendizajePlaneado;
-          totalGanado += act.aprendizajeGanado;
-        }
-      }
-    }
-  }
-
-  const actScore = totalPlaneado > 0 ? (totalGanado / totalPlaneado) * 100 : 0;
-
-  const compIds = new Set(periodo.competencias);
-  let compSum = 0;
-  let compCount = 0;
-  const valorField = periodoIdx === 0 ? 'valorPeriodo1' : 'valorPeriodo2';
-  for (const comp of competencias) {
-    if (compIds.has(comp.competenciaId)) {
-      const pct = parseCompetenciaPercent(comp[valorField]);
-      compSum += pct;
-      compCount++;
-    }
-  }
-  const compScore = compCount > 0 ? compSum / compCount : 0;
-
-  const periodoScore =
-    (actScore * periodo.pesoActividades + compScore * periodo.pesoCompetencias) / 100;
-
-  return { actScore, compScore, periodoScore, totalPlaneado, totalGanado };
-}
 
 function buildChartData(actividades: ActividadAlumnoData[]): ChartPoint[] {
   if (actividades.length === 0) return [];
@@ -298,19 +232,9 @@ export default function AlumnoDashboard() {
 
   /* ---------- Computed ---------- */
 
-  const periodoScores = useMemo(
-    () =>
-      periodos.map((p, i) => ({
-        ...calcPeriodoScore(p, i, periodos, actividades, competencias),
-        nombre: p.nombre || `Periodo ${i + 1}`,
-        pesoFinal: p.pesoFinal,
-      })),
+  const { periodos: periodoScores, calificacionActual } = useMemo(
+    () => calcCalificacion(periodos, actividades, competencias),
     [periodos, actividades, competencias],
-  );
-
-  const calificacionActual = useMemo(
-    () => periodoScores.reduce((sum, ps) => sum + (ps.periodoScore * ps.pesoFinal) / 100, 0),
-    [periodoScores],
   );
 
   const chartData = useMemo(() => buildChartData(actividades), [actividades]);

--- a/packages/web/src/components/dashboard/pages/MallaEvaluacionPage/MallaEvaluacionPage.tsx
+++ b/packages/web/src/components/dashboard/pages/MallaEvaluacionPage/MallaEvaluacionPage.tsx
@@ -9,21 +9,12 @@ import TruncatedText from '../../atoms/TruncatedText/TruncatedText';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
 import type { ActividadTipo } from '@/types/calendario';
 import { exportMallaAlumnoXlsx } from '../../../../utils/mallaExport';
+import { calcCalificacion, type PeriodoConfig } from '@tc2005b/evaluacion';
 import styles from './MallaEvaluacionPage.module.css';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
 /* ------------------------------------------------------------------ */
-
-interface PeriodoConfig {
-  nombre: string;
-  pesoFinal: number;
-  pesoCompetencias: number;
-  pesoActividades: number;
-  competencias: string[];
-  actividades: string[];
-  acumulativo: boolean;
-}
 
 interface ActividadData {
   id: string;
@@ -1214,70 +1205,25 @@ export default function MallaEvaluacionPage() {
 
   /* ---------- Calificación acumulada actual ---------- */
 
-  function parseCompetenciaPercent(valor: string | number): number {
-    if (typeof valor === 'number') return valor;
-    if (!valor) return 0;
-    const match = valor.match(/\((\d+)%\)/);
-    return match ? Number(match[1]) : 0;
-  }
+  // El cálculo es el compartido (`@tc2005b/evaluacion`); aquí solo se derivan
+  // las actividades faltantes de las que el propio cálculo contó.
+  const { periodos: scores, calificacionActual } = calcCalificacion(
+    periodos,
+    hasAlumnoData ? actividadesAlumno : [],
+    hasAlumnoData ? competenciasAlumno : [],
+  );
 
-  function calcPeriodoScore(periodo: PeriodoConfig, periodoIdx: number) {
-    // Actividades: ganado / planeado
-    const ownIds = new Set(periodo.actividades);
-    let totalPlaneado = 0;
-    let totalGanado = 0;
-    const actSource = hasAlumnoData ? actividadesAlumno : [];
-    const faltantes: { nombre: string; tipo: string; ganado: number; planeado: number }[] = [];
-
-    for (const act of actSource) {
-      if (ownIds.has(act.actividadGrupoId)) {
-        totalPlaneado += act.aprendizajePlaneado;
-        totalGanado += act.aprendizajeGanado;
-        if (act.semanaCompletada === 0) {
-          faltantes.push({ nombre: act.nombre, tipo: act.tipo, ganado: act.aprendizajeGanado, planeado: act.aprendizajePlaneado });
-        }
-      }
-    }
-    // Acumulativo: sumar periodos anteriores
-    if (periodo.acumulativo && periodoIdx > 0) {
-      for (let pi = 0; pi < periodoIdx; pi++) {
-        const prevIds = new Set(periodos[pi].actividades);
-        for (const act of actSource) {
-          if (prevIds.has(act.actividadGrupoId) && !ownIds.has(act.actividadGrupoId)) {
-            totalPlaneado += act.aprendizajePlaneado;
-            totalGanado += act.aprendizajeGanado;
-            if (act.semanaCompletada === 0) {
-              faltantes.push({ nombre: act.nombre, tipo: act.tipo, ganado: act.aprendizajeGanado, planeado: act.aprendizajePlaneado });
-            }
-          }
-        }
-      }
-    }
-    const actScore = totalPlaneado > 0 ? (totalGanado / totalPlaneado) * 100 : 0;
-
-    // Competencias: promedio de valores del periodo
-    const compIds = new Set(periodo.competencias);
-    const compSource = hasAlumnoData ? competenciasAlumno : [];
-    let compSum = 0;
-    let compCount = 0;
-    const valorField = periodoIdx === 0 ? 'valorPeriodo1' : 'valorPeriodo2';
-    for (const comp of compSource) {
-      if (compIds.has(comp.competenciaId)) {
-        const pct = parseCompetenciaPercent(comp[valorField]);
-        compSum += pct;
-        compCount++;
-      }
-    }
-    const compScore = compCount > 0 ? compSum / compCount : 0;
-
-    // Ponderado del periodo
-    const periodoScore = (actScore * periodo.pesoActividades + compScore * periodo.pesoCompetencias) / 100;
-
-    return { actScore, compScore, periodoScore, totalPlaneado, totalGanado, faltantes };
-  }
-
-  const periodoScores = periodos.map((p, i) => ({ ...calcPeriodoScore(p, i), nombre: p.nombre || `P${i + 1}`, pesoFinal: p.pesoFinal }));
-  const calificacionActual = periodoScores.reduce((sum, ps) => sum + (ps.periodoScore * ps.pesoFinal) / 100, 0);
+  const periodoScores = scores.map((p) => ({
+    ...p,
+    faltantes: p.actividadesContadas
+      .filter((act) => act.semanaCompletada === 0)
+      .map((act) => ({
+        nombre: act.nombre,
+        tipo: act.tipo,
+        ganado: act.aprendizajeGanado,
+        planeado: act.aprendizajePlaneado,
+      })),
+  }));
 
   /* ---------- Render ---------- */
 

--- a/packages/web/src/utils/mallaExport.ts
+++ b/packages/web/src/utils/mallaExport.ts
@@ -7,6 +7,7 @@
  * import dinámico para no engordar el bundle principal.
  */
 import type * as ExcelJS from 'exceljs';
+import { calcCalificacion, parseValorCompetencia, round1, type PeriodoConfig } from '@tc2005b/evaluacion';
 import { APP_NAME } from '../config/app';
 
 const API_BASE = '/api';
@@ -15,15 +16,7 @@ const API_BASE = '/api';
 /*  Tipos                                                              */
 /* ------------------------------------------------------------------ */
 
-export interface ExportPeriodoConfig {
-  nombre: string;
-  pesoFinal: number;
-  pesoCompetencias: number;
-  pesoActividades: number;
-  competencias: string[];
-  actividades: string[];
-  acumulativo: boolean;
-}
+export type ExportPeriodoConfig = PeriodoConfig;
 
 export interface ExportActividad {
   id: string;
@@ -127,92 +120,44 @@ const BORDER: Partial<ExcelJS.Borders> = { top: THIN, left: THIN, bottom: THIN, 
 /* ------------------------------------------------------------------ */
 
 /**
- * Normaliza el valor guardado de una competencia ('85', 85 o 'Sólido (85%)')
- * a una etiqueta legible y su porcentaje.
+ * Valor guardado de una competencia → etiqueta legible + porcentaje, SOLO para
+ * presentación (la etiqueta de la celda y su color de relleno).
+ *
+ * `pct: null` distingue "sin evaluar" de un 0 real, que se pintan distinto. Para
+ * la NOTA no se usa esto: se usa `parseValorCompetencia` del paquete compartido,
+ * donde sin evaluar y 0 valen lo mismo.
  */
 export function evalDisplay(val: string | number | null | undefined): { label: string; pct: number | null } {
   if (val === null || val === undefined || val === '') return { label: 'Sin evaluar', pct: null };
-  if (typeof val === 'number') return { label: NUMBER_TO_LABEL[val] ?? `${val}%`, pct: val };
+  const pct = parseValorCompetencia(val);
+  if (typeof val === 'number') return { label: NUMBER_TO_LABEL[val] ?? `${val}%`, pct };
   const direct = Number(val);
   if (!isNaN(direct) && val.trim() !== '') {
-    return { label: NUMBER_TO_LABEL[direct] ?? `${direct}%`, pct: direct };
+    return { label: NUMBER_TO_LABEL[direct] ?? `${direct}%`, pct };
   }
   const m = val.match(/\((\d+)\s*%\)/);
   return { label: val, pct: m ? Number(m[1]) : null };
 }
 
-interface PeriodoResumen {
-  nombre: string;
-  actScore: number;
-  compScore: number;
-  periodoScore: number;
-  totalPlaneado: number;
-  totalGanado: number;
-  pesoFinal: number;
-  pesoActividades: number;
-  pesoCompetencias: number;
-  contribucion: number;
-}
-
-/** Réplica del cálculo de calificación acumulada de MallaEvaluacionPage. */
+/** Resumen de calificación del alumno. El cálculo es el compartido. */
 function calcResumen(
   periodos: ExportPeriodoConfig[],
   actividades: ExportActividad[],
   competencias: ExportCompetencia[],
-): { periodos: PeriodoResumen[]; calificacionActual: number } {
-  const res = periodos.map((periodo, periodoIdx) => {
-    const ownIds = new Set(periodo.actividades);
-    let totalPlaneado = 0;
-    let totalGanado = 0;
-    for (const act of actividades) {
-      if (ownIds.has(act.actividadGrupoId)) {
-        totalPlaneado += act.aprendizajePlaneado;
-        totalGanado += act.aprendizajeGanado;
-      }
-    }
-    if (periodo.acumulativo && periodoIdx > 0) {
-      for (let pi = 0; pi < periodoIdx; pi++) {
-        const prevIds = new Set(periodos[pi].actividades);
-        for (const act of actividades) {
-          if (prevIds.has(act.actividadGrupoId) && !ownIds.has(act.actividadGrupoId)) {
-            totalPlaneado += act.aprendizajePlaneado;
-            totalGanado += act.aprendizajeGanado;
-          }
-        }
-      }
-    }
-    const actScore = totalPlaneado > 0 ? (totalGanado / totalPlaneado) * 100 : 0;
-
-    const compIds = new Set(periodo.competencias);
-    let compSum = 0;
-    let compCount = 0;
-    const valorField = periodoIdx === 0 ? 'valorPeriodo1' : 'valorPeriodo2';
-    for (const comp of competencias) {
-      if (compIds.has(comp.competenciaId)) {
-        compSum += evalDisplay(comp[valorField]).pct ?? 0;
-        compCount++;
-      }
-    }
-    const compScore = compCount > 0 ? compSum / compCount : 0;
-    const periodoScore = (actScore * periodo.pesoActividades + compScore * periodo.pesoCompetencias) / 100;
-
-    return {
-      nombre: periodo.nombre || `P${periodoIdx + 1}`,
-      actScore,
-      compScore,
-      periodoScore,
-      totalPlaneado,
-      totalGanado,
-      pesoFinal: periodo.pesoFinal,
-      pesoActividades: periodo.pesoActividades,
-      pesoCompetencias: periodo.pesoCompetencias,
-      contribucion: (periodoScore * periodo.pesoFinal) / 100,
-    };
-  });
-  return { periodos: res, calificacionActual: res.reduce((s, p) => s + p.contribucion, 0) };
+) {
+  const { periodos: scores, calificacionActual } = calcCalificacion(
+    periodos,
+    actividades,
+    competencias,
+  );
+  return {
+    periodos: scores.map((p) => ({
+      ...p,
+      contribucion: (p.periodoScore * p.pesoFinal) / 100,
+    })),
+    calificacionActual,
+  };
 }
-
-const round1 = (n: number) => Math.round(n * 10) / 10;
 
 function gradeFill(pct: number): string {
   return pct < 50 ? COLORS.gradeRed : pct < 70 ? COLORS.gradeOrange : COLORS.gradeGreen;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,17 +2592,17 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
-"@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33":
-  version "4.19.8"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz#99b960322a4d576b239a640ab52ef191989b036f"
-  integrity sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==
+"@types/express-serve-static-core@^4.17.30", "@types/express-serve-static-core@^4.17.33", "@types/express-serve-static-core@^4.17.43":
+  version "4.19.9"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz#b746a8bb6c389af7a31141397bb539f775b0ae84"
+  integrity sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*", "@types/express@^4.17.13", "@types/express@^4.17.20":
+"@types/express@*", "@types/express@4.17.21", "@types/express@^4.17.13", "@types/express@^4.17.20", "@types/express@^4.17.21":
   version "4.17.25"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.25.tgz#070c8c73a6fee6936d65c195dbbfb7da5026649b"
   integrity sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==
@@ -2611,16 +2611,6 @@
     "@types/express-serve-static-core" "^4.17.33"
     "@types/qs" "*"
     "@types/serve-static" "^1"
-
-"@types/express@4.17.21":
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
-  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
-  dependencies:
-    "@types/body-parser" "*"
-    "@types/express-serve-static-core" "^4.17.33"
-    "@types/qs" "*"
-    "@types/serve-static" "*"
 
 "@types/hast@^3.0.0":
   version "3.0.4"
@@ -2757,15 +2747,7 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-static@*":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-2.2.0.tgz#d4a447503ead0d1671132d1ab6bd58b805d8de6a"
-  integrity sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==
-  dependencies:
-    "@types/http-errors" "*"
-    "@types/node" "*"
-
-"@types/serve-static@^1":
+"@types/serve-static@^1", "@types/serve-static@^1.15.5":
   version "1.15.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.10.tgz#768169145a778f8f5dfcb6360aead414a3994fee"
   integrity sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==


### PR DESCRIPTION
## Descripción

Buscando dónde poner tests del cálculo de calificaciones apareció un bug **vivo en producción**.

### El bug

El dashboard del alumno leía **todas sus competencias como 0**:

```ts
function parseCompetenciaPercent(valor: unknown): number {
  if (typeof valor !== 'string') return 0;   // ← todo número cae aquí
  const match = valor.match(/\((\d+)%\)/);
  return match ? Number(match[1]) : 0;
}
```

Los valores se guardan como **número**. Las 396 celdas de `CompetenciaAlumno` en producción lo son: `{"number": 396}`. Así que el parser devolvía 0 para todas.

Como en el Periodo 2 las competencias pesan **70%**, el impacto medido contra la BD real:

| Grupo | Alumnos afectados | El alumno veía MENOS de lo real |
|---|---|---|
| **FebJun26** | **17 de 18** | **−41.5 pts** promedio, **−51.9** peor caso |
| Prueba | 2 de 2 | −29.4 pts |
| Prueba 2 | 1 de 2 | −9.1 pts |

**Ninguna nota guardada estaba mal.** La vista del profesor (API) y el export XLSX siempre calcularon bien. El error era solo de la pantalla del alumno, y siempre **a la baja**.

### La causa de fondo

El cálculo estaba copiado en **cuatro** sitios: `calificaciones.controller.ts`, `MallaEvaluacionPage`, `mallaExport.ts` y `AlumnoDashboard`. Las copias divergieron: tres se actualizaron para leer números y una se quedó atrás. Arreglar solo el parser dejaría el mismo terreno para el siguiente.

Se extrae a **`@tc2005b/evaluacion`** — paquete puro, sin dependencias, mismo patrón que `@tc2005b/contenido-pipeline`— y las cuatro pantallas lo consumen. La nota de un alumno no puede depender de qué pantalla la pinte.

Los **28 tests** fijan *decisiones*, no el resultado que casualmente da el código de hoy:
- cómo se lee cada formato de valor (número, string numérico, legacy `Básico (70%)`, sin evaluar);
- que un `100` **nunca** puede leerse como `0` (la regresión, explícita);
- que una competencia **sin evaluar cuenta como 0 y sí entra al promedio** (es política, baja la nota — si algún día se quiere excluir del denominador, ese test es el que hay que cambiar a conciencia);
- que un periodo acumulativo **no puede contar dos veces** la misma actividad.

### Dos divergencias más, corregidas al unificar

- **Doble conteo en acumulativos.** Las tres copias de la web sumaban una actividad una vez *por cada periodo previo* en el que apareciera; el API usaba un `Set`. Hoy ninguna actividad está en 2+ periodos, así que **no llegó a morder** — pero estaba armado.
- **Redondeo.** El API redondeaba la nota de cada periodo *antes* de ponderarla; la web no. O sea que un mismo alumno ya tenía **dos notas oficiales distintas según la pantalla**. Ahora se redondea una sola vez, al presentar.

### Qué cambia en producción

Verificado alumno por alumno contra la BD real:

```
FebJun26 (18 alumnos)
  vista del PROFESOR (API): 1 nota cambia, máx 0.1 pts   ← 82.9 → 83 (redondeo)
  vista del ALUMNO:        17 notas cambian, máx 51.9 pts ← el bug corregido
Prueba / Prueba 2
  vista del PROFESOR:       0 notas cambian
  vista del ALUMNO:         3 notas cambian
```

La única nota que se mueve para el profesor es **82.9 → 83**: el valor exacto era ~82.95 y el redondeo intermedio lo truncaba. Sube.

⚠️ Al desplegar, **20 alumnos verán subir su calificación** de golpe. Es la nota correcta —la que tú ya veías—, pero conviene saberlo por si alguno pregunta.

## Tipo de cambio

- [x] `fix` — corrección de bug (SemVer: PATCH)

## ¿Cómo se probó?

- [x] `yarn test` pasa — **84 tests** (56 previos + 28 nuevos), 6 archivos
- [x] `npx tsc --noEmit` sin errores (web y api)
- [x] Build local OK (`yarn build`)
- [x] Regresión contra la BD de producción, alumno por alumno: la única nota que se mueve en la vista del profesor es la de redondeo (82.9 → 83)
- [x] `grep` confirma que no queda ninguna copia suelta del cálculo

## Checklist

- [x] La rama sigue Conventional Branch
- [x] Los commits siguen Conventional Commits
- [x] Actualicé `CHANGELOG.md`
- [x] No hay commits directos a `main`; este cambio entra vía PR revisado