### PR TITLE
feat(contenidos): el importador de Docusaurus acepta cualquier sitio (--raiz) e importa TC2008B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **TC2008B entra al CMS** como colección `tc2008b` (Modelación de sistemas
+  multiagentes con gráficas computacionales), importada desde su Docusaurus:
+  15 páginas, 4 categorías, 379 recursos y 393 enlaces reescritos, con **0 sin
+  resolver** en el reporte de paridad. De paso se corrigieron en el origen tres
+  enlaces del README de medio término que apuntaban a `4_half_term/…` desde
+  *dentro* de `4_half_term/`: estaban rotos también en el sitio publicado.
+
 ### Changed
+- **El importador de Docusaurus dejó de depender de `packages/docusaurus`.** El
+  corte de US-7 retiró ese paquete del repo, pero el script seguía leyendo su
+  ruta hardcodeada: quedaba inservible para cualquier instancia nueva. Ahora
+  recibe `--raiz <ruta>` —la carpeta con `docs/` y `static/`, viva donde viva— y
+  resuelve solo el layout: `<raiz>/docs/<slug>` si existe (el viejo monorepo
+  multi-instancia) y si no `<raiz>/docs` (un sitio por materia, que es como está
+  armado el resto); `--docs <subruta>` lo fuerza. Dos ajustes que salieron de
+  importar un sitio suelto:
+  - Los **enlaces absolutos** se prueban con y sin el prefijo del `routeBasePath`
+    (`/docs`) y del slug, porque ahí la instancia cuelga de la raíz de la URL y no
+    de una subcarpeta.
+  - Si **no hay `static/`** se avisa una vez, en vez de listar los assets
+    absolutos uno por uno en `SIN RESOLVER` sin decir por qué.
+- **`--publicar`** deja la colección publicada al importarla. El default sigue
+  siendo **borrador**: publicar es la decisión que quiere un humano enfrente.
 - **El cálculo de calificaciones es ahora UNO solo** (`@tc2005b/evaluacion`), no
   cuatro copias. Estaba duplicado en el API, la malla del profesor, el export
   XLSX y el dashboard del alumno, y las copias habían divergido —el bug de

--- a/packages/api/data/redirects-docs.json
+++ b/packages/api/data/redirects-docs.json
@@ -68,5 +68,20 @@
   "/docs/tc2007b/modulo_3_moviles/mongo/tutorials/intro_mongodb/mongoose_crash_course": "/contenidos/tc2007b/modulo-3-moviles/mongo/tutorials/intro-mongodb/mongoose-crash-course",
   "/docs/tc2007b/modulo_3_moviles/backend/tutorials/buckets3": "/contenidos/tc2007b/modulo-3-moviles/backend/tutorials/buckets3/readme",
   "/docs/tc2007b/modulo_4_ingenieria/intro": "/contenidos/tc2007b/modulo-4-ingenieria/intro",
-  "/docs/tc2007b/modulo_5_admin/intro": "/contenidos/tc2007b/modulo-5-admin/intro"
+  "/docs/tc2007b/modulo_5_admin/intro": "/contenidos/tc2007b/modulo-5-admin/intro",
+  "/docs/tc2008b/intro": "/contenidos/tc2008b/intro",
+  "/docs/tc2008b/entregables": "/contenidos/tc2008b/entregables",
+  "/docs/tc2008b/tutorials/intro_unity/lab1/1_starting_unity": "/contenidos/tc2008b/tutorials/intro-unity/lab1/1-starting-unity",
+  "/docs/tc2008b/tutorials/intro_unity/lab1/2_physics_unity": "/contenidos/tc2008b/tutorials/intro-unity/lab1/2-physics-unity",
+  "/docs/tc2008b/tutorials/intro_unity/lab1/3_prefabs_local_multiplayer_unity": "/contenidos/tc2008b/tutorials/intro-unity/lab1/3-prefabs-local-multiplayer-unity",
+  "/docs/tc2008b/tutorials/intro_unity/api_calls_unity": "/contenidos/tc2008b/tutorials/intro-unity/api-calls-unity",
+  "/docs/tc2008b/tutorials/intro_unity/time_manager": "/contenidos/tc2008b/tutorials/intro-unity/time-manager",
+  "/docs/tc2008b/tutorials/intro_unity/project_structure": "/contenidos/tc2008b/tutorials/intro-unity/project-structure",
+  "/docs/tc2008b/tutorials/intro_unity/materials_textures": "/contenidos/tc2008b/tutorials/intro-unity/materials-textures",
+  "/docs/tc2008b/tutorials/intro_unity/genetic_algorithms": "/contenidos/tc2008b/tutorials/intro-unity/genetic-algorithms",
+  "/docs/tc2008b/tutorials/intro_unity/tilemaps": "/contenidos/tc2008b/tutorials/intro-unity/tilemaps",
+  "/docs/tc2008b/half_term": "/contenidos/tc2008b/half-term/readme",
+  "/docs/tc2008b/half_term/easy": "/contenidos/tc2008b/half-term/easy",
+  "/docs/tc2008b/half_term/medium": "/contenidos/tc2008b/half-term/medium",
+  "/docs/tc2008b/half_term/lunatic": "/contenidos/tc2008b/half-term/lunatic"
 }

--- a/packages/api/scripts/importar-docusaurus.ts
+++ b/packages/api/scripts/importar-docusaurus.ts
@@ -1,8 +1,8 @@
 /**
  * Importador Docusaurus → CMS "Contenidos" (US-6, design §6).
  *
- * Traduce una instancia (packages/docusaurus/docs/<slug>) a una Coleccion
- * preservando el contenido y la navegación por índice:
+ * Traduce una instancia de Docusaurus a una Coleccion nueva, preservando el
+ * contenido y la navegación por índice:
  *   carpeta + _category_.json → Documento tipo categoria (label, position)
  *   archivo .md + sidebar_position → Documento md PUBLICADO (v1, render+toc)
  *   imágenes relativas junto al .md → Recurso del documento (recurso:)
@@ -15,11 +15,17 @@
  *
  * Uso (requiere el API corriendo, como los demás scripts):
  *   cd packages/api
- *   ./node_modules/.bin/tsx scripts/importar-docusaurus.ts --slug tc2005b --clave TC2005B \
- *       --nombre "Construcción de software y toma de decisiones" [--dry-run]
+ *   ./node_modules/.bin/tsx scripts/importar-docusaurus.ts --raiz ~/ruta/al/sitio \
+ *       --slug tc2008b --clave TC2008B --nombre "Modelación de sistemas…" [--dry-run]
+ *
+ * --raiz es la raíz del sitio Docusaurus (la carpeta con docs/ y static/): ya
+ * no vive en este repo, el corte de US-7 retiró packages/docusaurus. La
+ * instancia se busca en <raiz>/docs/<slug> y, si no está, en <raiz>/docs
+ * (sitio de una sola materia); --docs <subruta> lo fuerza.
  *
  * La colección NO debe existir (idempotencia simple: bórrala del admin para
  * reintentar). --dry-run no escribe nada y imprime el reporte de paridad.
+ * --publicar la deja publicada en vez de borrador.
  */
 import fs from 'fs';
 import path from 'path';
@@ -34,7 +40,6 @@ import { DocumentoVersion } from '../src/models/DocumentoVersion.js';
 import { Recurso } from '../src/models/Recurso.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const RAIZ_DOCUSAURUS = path.resolve(__dirname, '../../docusaurus');
 // Fuera de src/: tsc no copia .json a dist y producción corre desde dist/.
 // src/middlewares y dist/middlewares resuelven ambos a esta misma ruta.
 const RUTA_REDIRECTS = path.resolve(__dirname, '../data/redirects-docs.json');
@@ -45,14 +50,38 @@ function arg(nombre: string): string | undefined {
   return i >= 0 ? process.argv[i + 1] : undefined;
 }
 const dryRun = process.argv.includes('--dry-run');
+// Por defecto la colección queda en BORRADOR: el admin valida la paridad y la
+// publica. --publicar la deja visible de una (sigue sin verla nadie hasta que
+// se asigne a un grupo).
+const publicar = process.argv.includes('--publicar');
 const slugColeccion = arg('slug');
 const claveColeccion = (arg('clave') ?? slugColeccion ?? '').toUpperCase();
 const nombreColeccion = arg('nombre') ?? claveColeccion;
+const raizArg = arg('raiz');
 
 if (!slugColeccion) {
   console.error('Falta --slug <instancia> (p. ej. tc2005b)');
   process.exit(1);
 }
+if (!raizArg) {
+  console.error('Falta --raiz <ruta>: la raíz del sitio Docusaurus (la carpeta con docs/ y static/).');
+  process.exit(1);
+}
+
+/** Raíz del sitio Docusaurus. Ya no vive en el repo — el corte de US-7 la retiró. */
+const RAIZ_DOCUSAURUS = path.resolve(process.cwd(), raizArg);
+/**
+ * Carpeta de la instancia. Hay dos layouts en la práctica:
+ *   multi-instancia (el viejo packages/docusaurus) → <raiz>/docs/<slug>
+ *   sitio suelto (un repo por materia)             → <raiz>/docs
+ * Se detecta cuál aplica; --docs <subruta> fuerza la carpeta si hiciera falta.
+ */
+const DIR_DOCS = arg('docs')
+  ? path.resolve(RAIZ_DOCUSAURUS, arg('docs')!)
+  : fs.existsSync(path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion))
+    ? path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion)
+    : path.join(RAIZ_DOCUSAURUS, 'docs');
+const DIR_STATIC = path.join(RAIZ_DOCUSAURUS, 'static');
 
 /* ── Utilidades de nombres ── */
 const EXT_ASSET = new Set([
@@ -310,22 +339,33 @@ async function reescribirCuerpo(
   const comentarios = rangosComentarios(cuerpo);
 
   const resolverInterno = (url: string): string | null => {
-    const base = url.startsWith('/')
-      ? path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!, decodeURIComponent(url))
-      : path.resolve(dirMd, decodeURIComponent(url));
+    const decodificada = decodeURIComponent(url);
+    // Las absolutas son rutas de URL, no de disco: la instancia puede colgar
+    // del routeBasePath (/docs) y/o del slug, así que probamos con y sin.
+    const bases = (
+      url.startsWith('/')
+        ? [
+            decodificada,
+            decodificada.replace(/^\/docs(?=\/|$)/, ''),
+            decodificada.replace(new RegExp(`^/${slugColeccion}(?=/|$)`), ''),
+          ].map((u) => path.join(DIR_DOCS, u))
+        : [path.resolve(dirMd, decodificada)]
+    );
     // Candidatos: el archivo tal cual, .md/.mdx implícitos, o el índice de
     // carpeta (README/readme/index — el repo usa ambos cases).
-    const candidatos = [
-      base,
-      `${base}.md`,
-      `${base}.mdx`,
-      path.join(base, 'README.md'),
-      path.join(base, 'readme.md'),
-      path.join(base, 'index.md'),
-    ];
-    for (const c of candidatos) {
-      const destino = pathCmsPorArchivo.get(c);
-      if (destino) return destino;
+    for (const base of bases) {
+      const candidatos = [
+        base,
+        `${base}.md`,
+        `${base}.mdx`,
+        path.join(base, 'README.md'),
+        path.join(base, 'readme.md'),
+        path.join(base, 'index.md'),
+      ];
+      for (const c of candidatos) {
+        const destino = pathCmsPorArchivo.get(c);
+        if (destino) return destino;
+      }
     }
     return null;
   };
@@ -354,7 +394,7 @@ async function reescribirCuerpo(
     // 1) Asset (relativo junto al .md, o absoluto de static/)
     if (EXT_ASSET.has(ext)) {
       const abs = url.startsWith('/')
-        ? path.join(RAIZ_DOCUSAURUS, 'static', decodeURIComponent(url))
+        ? path.join(DIR_STATIC, decodeURIComponent(url))
         : path.resolve(dirMd, decodeURIComponent(url));
       const ref = await subirRecurso(abs, coleccion, url.startsWith('/') ? null : documento);
       if (ref) {
@@ -462,14 +502,22 @@ async function simularCuerpos(nodos: NodoImport[]): Promise<void> {
 
 /* ── Main ── */
 async function main() {
-  const dirInstancia = path.join(RAIZ_DOCUSAURUS, 'docs', slugColeccion!);
+  const dirInstancia = DIR_DOCS;
   if (!fs.existsSync(dirInstancia)) {
     console.error(`No existe la instancia: ${dirInstancia}`);
+    console.error('Revisa --raiz (raíz del sitio) o pasa --docs <subruta> si la instancia no está en docs/.');
     process.exit(1);
+  }
+  // Sin static/ los assets absolutos (/img/…) no resuelven: se listarían de a
+  // uno en SIN RESOLVER sin decir por qué. Mejor avisar una vez, aquí.
+  if (!fs.existsSync(DIR_STATIC)) {
+    console.warn(`⚠️  No existe ${DIR_STATIC}: los assets absolutos (/img/…) no van a resolver.\n`);
   }
 
   if (dryRun) console.log('=== DRY RUN — no se escribirá nada (no requiere servidor) ===\n');
+  console.log(`Raíz:       ${RAIZ_DOCUSAURUS}`);
   console.log(`Instancia:  ${dirInstancia}`);
+  console.log(`Static:     ${DIR_STATIC}`);
   console.log(`Colección:  ${slugColeccion} (${claveColeccion} — ${nombreColeccion})\n`);
 
   if (!dryRun) {
@@ -499,7 +547,7 @@ async function main() {
     coleccion.setNombre(nombreColeccion);
     coleccion.setSlug(slugColeccion!);
     coleccion.setClave(claveColeccion);
-    coleccion.setPublicada(false); // el admin la publica al validar la paridad
+    coleccion.setPublicada(publicar); // sin --publicar: el admin la publica al validar la paridad
     await coleccion.save(null, { useMasterKey: true });
 
     await crearDocumentos(arbol, coleccion, null);
@@ -528,7 +576,13 @@ async function main() {
   console.log(`SIN RESOLVER:          ${reporte.sinResolver.length}`);
   for (const x of reporte.sinResolver) console.log(`  ✗ ${x}`);
   console.log('==============================\n');
-  console.log(dryRun ? 'Dry-run terminado.' : `Importación terminada: la colección "${slugColeccion}" quedó como BORRADOR (publícala tras validar).`);
+  console.log(
+    dryRun
+      ? 'Dry-run terminado.'
+      : publicar
+        ? `Importación terminada: la colección "${slugColeccion}" quedó PUBLICADA (solo la ven los grupos que la tengan asignada).`
+        : `Importación terminada: la colección "${slugColeccion}" quedó como BORRADOR (publícala tras validar).`,
+  );
   process.exit(0);
 }
 


### PR DESCRIPTION
## Descripción

El corte de US-7 retiró `packages/docusaurus` del repo, pero `importar-docusaurus.ts`
seguía leyendo esa ruta **hardcodeada**. En la práctica el importador quedó inservible
para cualquier instancia nueva: apuntaba a una carpeta que el repo ya no define (lo que
queda en disco es un residuo local anterior al corte, no versionado).

Ahora el script recibe **`--raiz <ruta>`** (la carpeta con `docs/` y `static/`, viva donde
viva) y resuelve el layout solo:

- `<raiz>/docs/<slug>` si existe → el viejo monorepo multi-instancia (tc2005b, tc2007b).
- `<raiz>/docs` si no → un sitio Docusaurus por materia, que es como está armado el resto.
- `--docs <subruta>` lo fuerza si algún día no aplica ninguno de los dos.

Dos ajustes que salieron de importar un sitio suelto:

- Los **enlaces absolutos** se prueban con y sin el prefijo del `routeBasePath` (`/docs`) y
  del slug: ahí la instancia cuelga de la raíz de la URL, no de una subcarpeta.
- Si **falta `static/`** se avisa una vez, en vez de listar cada asset absoluto en
  `SIN RESOLVER` sin explicar la causa.

Se agrega **`--publicar`** para dejar la colección publicada al importar. El default sigue
siendo **borrador**: publicar es una decisión que quiere un humano enfrente.

Con esto se importó **TC2008B** como colección `tc2008b`. También se corrigieron, en el
repo origen, tres enlaces del README de medio término que apuntaban a `4_half_term/…`
desde *dentro* de `4_half_term/`: estaban rotos también en el sitio publicado de Docusaurus.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

`--dry-run` contra la instancia real (no escribe nada, no requiere servidor) y luego el
import real, verificando el resultado **contra la BD**, no contra el reporte del script:

- Reporte de paridad: 4 categorías, 15 páginas, 379 recursos, 393 enlaces reescritos
  (12 internos), **`SIN RESOLVER: 0`**.
- En la BD: `Coleccion tc2008b` (`publicada: true`), 19 documentos (15 `md` + 4 `categoria`),
  **0 páginas sin versión publicada**, 379 `Recurso`. El árbol y el orden reproducen el
  sidebar de Docusaurus. Una página de muestra rinde HTML + TOC y conserva sus refs
  `recurso:` y sus enlaces `/contenidos/`.
- Los 8 "ignorados" son carpetas `img/` sin `.md`: es lo correcto, son assets y no categorías.

Nota: los 15 redirects `/docs/tc2008b/… → /contenidos/tc2008b/…` que se suman a
`redirects-docs.json` son **inertes** — ese Docusaurus nunca se sirvió bajo
`groups.meeplab.com/docs/tc2008b` (vivía en su propio GitHub Pages). Se dejan porque el
mapa es aditivo y no hacen daño.

- [x] `yarn test` pasa (84 tests, 6 archivos)
- [x] `cd packages/api && npx tsc --noEmit` sin errores
- [ ] Build local OK — no aplica (no cambia el output)

## Checklist

- [x] La rama sigue Conventional Branch (`feature/…`)
- [x] Los commits siguen Conventional Commits
- [x] CHANGELOG.md actualizado