### PR TITLE
feat(contenidos): ocultar y volver a mostrar páginas y carpetas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Las páginas del CMS se pueden ocultar y volver a mostrar**, para escribir el
+  curso completo de antemano e irlo liberando conforme avanza. El ojo aparece en
+  las acciones de cada página del árbol y como botón **Ocultar/Mostrar** en el
+  encabezado del editor. Ocultar **no toca el contenido**: la versión publicada
+  queda intacta y volver a mostrarla la devuelve igual, sin versión nueva.
+  - La visibilidad es su **propio endpoint** (`PUT /admin/documentos/:id/publicacion`),
+    separado de `/publicar`. Fundirlos habría hecho que "mostrar" desde el árbol
+    publicara de rebote un borrador a medio escribir.
+  - Las **categorías no se ocultan**: ya se mostraban solo si tenían alguna página
+    publicada debajo, así que ocultar sus páginas las esconde solas. Se rechaza en
+    el API y ni siquiera se ofrece el ojo, en vez de prometer un control que no existe.
+  - En el árbol, el punto gris ya no dice "Borrador" sino **"Oculta"**: chocaba con
+    el *otro* borrador (los cambios sin publicar de una versión), y con esta función
+    los dos conceptos convivían en la misma pantalla.
 - **TC2008B entra al CMS** como colección `tc2008b` (Modelación de sistemas
   multiagentes con gráficas computacionales), importada desde su Docusaurus:
   15 páginas, 4 categorías, 379 recursos y 393 enlaces reescritos, con **0 sin
@@ -73,6 +87,12 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
     estampado (274 actividades de grupo, 1482 celdas de malla) apunta a ella.
 
 ### Fixed
+- **Una página oculta se podía quedar atrapada en invisible.** `POST /publicar`
+  empezaba con `if (!borrador) → 400 'No hay cambios de borrador que publicar'`, así
+  que una página que se ocultara **sin editarle nada** no tenía forma de volver:
+  Publicar la rechazaba porque no había borrador que publicar. Ahora, sin borrador
+  pero con versión y oculta, publicar **la re-expone** con su versión actual en vez
+  de fallar. Publicar-contenido y publicar-visibilidad estaban fundidos en uno.
 - **El alumno veía su calificación masivamente deflactada.** Su dashboard leía
   TODAS sus competencias como 0. El parser (`parseCompetenciaPercent`) empezaba
   con `if (typeof valor !== 'string') return 0`, y los valores se guardan como

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,29 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- **Las páginas del CMS se pueden ocultar y volver a mostrar**, para escribir el
-  curso completo de antemano e irlo liberando conforme avanza. El ojo aparece en
-  las acciones de cada página del árbol y como botón **Ocultar/Mostrar** en el
-  encabezado del editor. Ocultar **no toca el contenido**: la versión publicada
-  queda intacta y volver a mostrarla la devuelve igual, sin versión nueva.
+- **Las páginas y las carpetas del CMS se pueden ocultar y volver a mostrar**, para
+  escribir el curso completo de antemano e irlo liberando conforme avanza. El ojo
+  aparece en las acciones de cada nodo del árbol, y las páginas además tienen un
+  botón **Ocultar/Mostrar** en el encabezado del editor. Ocultar **no toca el
+  contenido**: la versión publicada queda intacta y volver a mostrar la devuelve
+  igual, sin versión nueva.
+  - **Ocultar una carpeta se lleva todo su subárbol** —incluidas sus páginas
+    publicadas— pero **no despublica ninguna**: al volver a mostrarla, cada página
+    regresa al estado en el que estaba. Ocultar la carpeta y despublicar sus páginas
+    una por una no son lo mismo, y solo lo primero es reversible sin perder el detalle.
+  - La carpeta usa un campo **propio** (`Documento.oculto`) y no `publicado`. Una
+    categoría no tiene publicación propia: se muestra si tiene alguna página publicada
+    debajo — de hecho **las 54 categorías vivas tienen `publicado: false`** y se ven
+    igual. Reusar ese campo como candado las habría **escondido todas** entre el deploy
+    y la migración. `oculto` ausente = visible, así que esto **no necesita migración**.
   - La visibilidad es su **propio endpoint** (`PUT /admin/documentos/:id/publicacion`),
     separado de `/publicar`. Fundirlos habría hecho que "mostrar" desde el árbol
     publicara de rebote un borrador a medio escribir.
-  - Las **categorías no se ocultan**: ya se mostraban solo si tenían alguna página
-    publicada debajo, así que ocultar sus páginas las esconde solas. Se rechaza en
-    el API y ni siquiera se ofrece el ojo, en vez de prometer un control que no existe.
   - En el árbol, el punto gris ya no dice "Borrador" sino **"Oculta"**: chocaba con
     el *otro* borrador (los cambios sin publicar de una versión), y con esta función
-    los dos conceptos convivían en la misma pantalla.
+    los dos conceptos convivían en la misma pantalla. Y una página publicada **dentro
+    de una carpeta oculta** se pinta apagada: el punto dice lo que el alumno ve, no lo
+    que el flag dice.
 - **TC2008B entra al CMS** como colección `tc2008b` (Modelación de sistemas
   multiagentes con gráficas computacionales), importada desde su Docusaurus:
   15 páginas, 4 categorías, 379 recursos y 393 enlaces reescritos, con **0 sin

--- a/packages/api/src/controllers/cms-versiones.controller.ts
+++ b/packages/api/src/controllers/cms-versiones.controller.ts
@@ -100,15 +100,21 @@ export async function publicarDocumento(req: Request, res: Response): Promise<vo
 /**
  * PUT /admin/documentos/:docId/publicacion — { publicado: boolean }
  *
- * VISIBILIDAD, no contenido: enciende o apaga `Documento.publicado` sin tocar
- * la versión ni el borrador. Es lo que permite tener el curso escrito de
- * antemano e irlo liberando: al ocultar una página, `construirArbolVisible` la
- * poda del árbol del alumno, y su versión publicada queda intacta —volver a
- * mostrarla devuelve exactamente el mismo contenido, sin versión nueva—.
+ * VISIBILIDAD, no contenido: enciende o apaga el nodo en el árbol del alumno sin
+ * tocar la versión ni el borrador. Es lo que permite tener el curso escrito de
+ * antemano e irlo liberando. La versión publicada queda intacta: volver a
+ * mostrar devuelve exactamente el mismo contenido, sin versión nueva.
  *
  * Deliberadamente separado de /publicar: ese sí congela el borrador en una
  * versión, y desde el árbol "mostrar" no debe publicar de rebote una edición a
  * medio hacer.
+ *
+ * Según el tipo, el interruptor es distinto —y esto es a propósito—:
+ *   página    → `publicado` (es su estado propio de publicación).
+ *   categoría → `oculto`, un candado sobre TODO su subárbol. Una categoría no
+ *               tiene publicación propia: se ve si tiene alguna página publicada
+ *               debajo. Ocultarla NO despublica sus páginas, así que al volver a
+ *               mostrarla cada una regresa al estado en el que estaba.
  */
 export async function setPublicacionDocumento(req: Request, res: Response): Promise<void> {
   const { docId } = req.params;
@@ -127,13 +133,10 @@ export async function setPublicacionDocumento(req: Request, res: Response): Prom
     }
     const { documento } = encontrado;
 
-    // Las categorías no tienen estado propio: se ven si tienen alguna página
-    // publicada debajo. Ocultar sus páginas ya las esconde a ellas.
     if (documento.getTipo() === 'categoria') {
-      res.status(400).json({
-        status: 'error',
-        message: 'Las categorías no se publican: se muestran solo si tienen alguna página publicada debajo',
-      });
+      documento.setOculto(!publicado);
+      await documento.save(null, { useMasterKey: true });
+      res.json({ status: 'ok', documento: documento.toSafeJSON() });
       return;
     }
 
@@ -148,6 +151,9 @@ export async function setPublicacionDocumento(req: Request, res: Response): Prom
     }
 
     documento.setPublicado(publicado);
+    // Una página escondida por el candado y luego publicada a mano se quedaría
+    // invisible sin decir por qué: el candado de página se levanta al mostrarla.
+    if (publicado && documento.getOculto()) documento.setOculto(false);
     await documento.save(null, { useMasterKey: true });
 
     res.json({ status: 'ok', documento: documento.toSafeJSON() });

--- a/packages/api/src/controllers/cms-versiones.controller.ts
+++ b/packages/api/src/controllers/cms-versiones.controller.ts
@@ -50,6 +50,21 @@ export async function publicarDocumento(req: Request, res: Response): Promise<vo
 
     const borrador = documento.getBorrador();
     if (!borrador) {
+      // Sin borrador pero oculta: es una RE-exposición, no una versión nueva.
+      // Sin esto, despublicar una página sin editarla la dejaba atrapada:
+      // "Publicar" respondía 400 y no había forma de volver a mostrarla.
+      const versionActual = documento.getVersion();
+      if (versionActual && !documento.getPublicado()) {
+        documento.setPublicado(true);
+        await documento.save(null, { useMasterKey: true });
+        res.json({
+          status: 'ok',
+          documento: documento.toSafeJSON(),
+          version: versionActual.getNumero(),
+          reexpuesta: true,
+        });
+        return;
+      }
       res.status(400).json({ status: 'error', message: 'No hay cambios de borrador que publicar' });
       return;
     }
@@ -79,6 +94,65 @@ export async function publicarDocumento(req: Request, res: Response): Promise<vo
     res.json({ status: 'ok', documento: documento.toSafeJSON(), version: numeroNuevo });
   } catch (error) {
     res.status(500).json({ status: 'error', message: 'Error al publicar documento' });
+  }
+}
+
+/**
+ * PUT /admin/documentos/:docId/publicacion — { publicado: boolean }
+ *
+ * VISIBILIDAD, no contenido: enciende o apaga `Documento.publicado` sin tocar
+ * la versión ni el borrador. Es lo que permite tener el curso escrito de
+ * antemano e irlo liberando: al ocultar una página, `construirArbolVisible` la
+ * poda del árbol del alumno, y su versión publicada queda intacta —volver a
+ * mostrarla devuelve exactamente el mismo contenido, sin versión nueva—.
+ *
+ * Deliberadamente separado de /publicar: ese sí congela el borrador en una
+ * versión, y desde el árbol "mostrar" no debe publicar de rebote una edición a
+ * medio hacer.
+ */
+export async function setPublicacionDocumento(req: Request, res: Response): Promise<void> {
+  const { docId } = req.params;
+  const { publicado } = req.body ?? {};
+
+  if (typeof publicado !== 'boolean') {
+    res.status(400).json({ status: 'error', message: 'publicado debe ser booleano' });
+    return;
+  }
+
+  try {
+    const encontrado = await buscarDocumento(docId);
+    if (!encontrado) {
+      res.status(404).json({ status: 'error', message: 'Documento no encontrado' });
+      return;
+    }
+    const { documento } = encontrado;
+
+    // Las categorías no tienen estado propio: se ven si tienen alguna página
+    // publicada debajo. Ocultar sus páginas ya las esconde a ellas.
+    if (documento.getTipo() === 'categoria') {
+      res.status(400).json({
+        status: 'error',
+        message: 'Las categorías no se publican: se muestran solo si tienen alguna página publicada debajo',
+      });
+      return;
+    }
+
+    // Mostrar algo que nunca se publicó dejaría al visor con un documento sin
+    // versión que servir (resolverPaginaPublicada devolvería 404).
+    if (publicado && !documento.getVersion()) {
+      res.status(400).json({
+        status: 'error',
+        message: 'La página no tiene ninguna versión publicada todavía: publícala desde el editor',
+      });
+      return;
+    }
+
+    documento.setPublicado(publicado);
+    await documento.save(null, { useMasterKey: true });
+
+    res.json({ status: 'ok', documento: documento.toSafeJSON() });
+  } catch {
+    res.status(500).json({ status: 'error', message: 'Error al cambiar la publicación del documento' });
   }
 }
 

--- a/packages/api/src/controllers/contenidos-lectura.controller.ts
+++ b/packages/api/src/controllers/contenidos-lectura.controller.ts
@@ -63,6 +63,7 @@ async function getDocumentosPlanos(coleccionId: string): Promise<DocPlano[]> {
     orden: d.getOrden(),
     padreId: d.getPadre()?.id ?? null,
     publicado: d.getPublicado(),
+    oculto: d.getOculto(),
   }));
 }
 

--- a/packages/api/src/models/Documento.ts
+++ b/packages/api/src/models/Documento.ts
@@ -98,6 +98,25 @@ export class Documento extends BaseModel {
     this.set('publicado', publicado);
   }
 
+  /**
+   * Oculto explícitamente: el nodo Y TODO lo que cuelga de él desaparecen del
+   * visor, sin tocar el `publicado` de cada página (volver a mostrar la carpeta
+   * devuelve a cada una a su estado anterior).
+   *
+   * Campo propio y no `publicado` porque una categoría NO tiene estado propio de
+   * publicación: se muestra si tiene alguna página publicada debajo. De hecho las
+   * 54 categorías vivas tienen `publicado: false` y se ven igual — reusar ese
+   * campo como candado las habría escondido todas de golpe.
+   *
+   * Ausente = visible: por eso esto no necesita migración.
+   */
+  getOculto(): boolean {
+    return this.get('oculto') === true;
+  }
+  setOculto(oculto: boolean): void {
+    this.set('oculto', oculto);
+  }
+
   toSafeJSON(): Record<string, unknown> {
     return {
       id: this.id,
@@ -109,6 +128,7 @@ export class Documento extends BaseModel {
       orden: this.getOrden(),
       plantilla: this.getPlantilla() ?? null,
       publicado: this.getPublicado(),
+      oculto: this.getOculto(),
       // Solo ids de versiones: el cuerpo se pide explícitamente.
       versionId: this.getVersion()?.id ?? null,
       borradorId: this.getBorrador()?.id ?? null,

--- a/packages/api/src/routes/contenidos.routes.ts
+++ b/packages/api/src/routes/contenidos.routes.ts
@@ -19,6 +19,7 @@ import {
 } from '../controllers/cms-documentos.controller.js';
 import {
   publicarDocumento,
+  setPublicacionDocumento,
   listVersiones,
   getVersion,
   restaurarVersion,
@@ -75,6 +76,8 @@ router.put('/admin/documentos/:docId/borrador', saveBorrador);
 
 // Publicar + historial de versiones (US-2)
 router.post('/admin/documentos/:docId/publicar', publicarDocumento);
+// Visibilidad (publicar/ocultar sin tocar versiones): liberar contenido por etapas.
+router.put('/admin/documentos/:docId/publicacion', setPublicacionDocumento);
 router.get('/admin/documentos/:docId/versiones', listVersiones);
 router.get('/admin/documentos/:docId/versiones/:versionId', getVersion);
 router.post('/admin/documentos/:docId/versiones/:versionId/restaurar', restaurarVersion);

--- a/packages/api/src/services/contenidos-arbol.ts
+++ b/packages/api/src/services/contenidos-arbol.ts
@@ -12,6 +12,8 @@ export interface DocPlano {
   orden: number;
   padreId: string | null;
   publicado: boolean;
+  /** Oculto explícitamente: se poda el nodo y todo su subárbol. */
+  oculto?: boolean;
 }
 
 export interface NodoVisor {
@@ -26,11 +28,17 @@ export interface NodoVisor {
  * Árbol visible: páginas publicadas + las categorías que conducen a alguna;
  * las ramas sin ninguna página publicada se PODAN (una categoría vacía no
  * debe revelar estructura).
+ *
+ * `oculto` es un candado explícito por encima de todo eso: poda el nodo y su
+ * subárbol entero, sin importar qué haya debajo. Es lo que permite esconder una
+ * carpeta completa SIN despublicar sus páginas una por una — al quitar el
+ * candado, cada página vuelve al estado en que estaba.
  */
 export function construirArbolVisible(documentos: DocPlano[]): NodoVisor[] {
   interface NodoTmp extends NodoVisor {
     esCategoria: boolean;
     publicado: boolean;
+    oculto: boolean;
     orden: number;
     hijosTmp: NodoTmp[];
   }
@@ -44,6 +52,7 @@ export function construirArbolVisible(documentos: DocPlano[]): NodoVisor[] {
       orden: d.orden,
       esCategoria: d.tipo === 'categoria',
       publicado: d.publicado,
+      oculto: d.oculto === true,
       hijos: [],
       hijosTmp: [],
     });
@@ -59,6 +68,9 @@ export function construirArbolVisible(documentos: DocPlano[]): NodoVisor[] {
   const podar = (lista: NodoTmp[]): NodoVisor[] =>
     lista
       .sort((a, b) => a.orden - b.orden)
+      // El candado gana sobre todo lo demás: al descartar el nodo, su subárbol
+      // se va con él (ya no se recorre).
+      .filter((n) => !n.oculto)
       .map((n) => ({ nodo: n, hijos: podar(n.hijosTmp) }))
       .filter(({ nodo, hijos }) => (nodo.esCategoria ? hijos.length > 0 : nodo.publicado))
       .map(({ nodo, hijos }) => ({ id: nodo.id, titulo: nodo.titulo, slug: nodo.slug, tipo: nodo.tipo, hijos }));

--- a/packages/api/tests/contenidos-arbol.test.ts
+++ b/packages/api/tests/contenidos-arbol.test.ts
@@ -51,6 +51,38 @@ describe('construirArbolVisible (poda de seguridad)', () => {
     expect(arbol[0].hijos[0].hijos.map((n) => n.slug)).toEqual(['lab1']);
   });
 
+  it('una categoría OCULTA se lleva su subárbol, aunque sus páginas sigan publicadas', () => {
+    const arbol = construirArbolVisible([
+      doc({ id: 'cat', slug: 'unidad-3', tipo: 'categoria', oculto: true }),
+      doc({ id: 'p', slug: 'lab1', padreId: 'cat', publicado: true }),
+      doc({ id: 'sub', slug: 'tema', tipo: 'categoria', padreId: 'cat' }),
+      doc({ id: 'q', slug: 'lab2', padreId: 'sub', publicado: true }),
+      doc({ id: 'otra', slug: 'visible', publicado: true }),
+    ]);
+    expect(arbol.map((n) => n.slug)).toEqual(['visible']);
+  });
+
+  it('ocultar la carpeta NO despublica sus páginas: al quitar el candado vuelven como estaban', () => {
+    // Mismo conjunto, con la categoría ya sin candado: `publicado` de cada
+    // página no se tocó, así que el árbol vuelve exactamente al estado previo.
+    const paginas: DocPlano[] = [
+      doc({ id: 'cat', slug: 'unidad-3', tipo: 'categoria', oculto: false }),
+      doc({ id: 'p', slug: 'lab1', padreId: 'cat', publicado: true }),
+      doc({ id: 'q', slug: 'wip', padreId: 'cat', publicado: false }),
+    ];
+    const arbol = construirArbolVisible(paginas);
+    expect(arbol.map((n) => n.slug)).toEqual(['unidad-3']);
+    expect(arbol[0].hijos.map((n) => n.slug)).toEqual(['lab1']);
+  });
+
+  it('una página oculta se poda aunque esté publicada (el candado gana)', () => {
+    const arbol = construirArbolVisible([
+      doc({ id: 'a', slug: 'visible', publicado: true }),
+      doc({ id: 'b', slug: 'candada', publicado: true, oculto: true }),
+    ]);
+    expect(arbol.map((n) => n.slug)).toEqual(['visible']);
+  });
+
   it('respeta el orden de hermanos', () => {
     const arbol = construirArbolVisible([
       doc({ id: 'b', slug: 'segundo', orden: 1 }),
@@ -98,5 +130,15 @@ describe('resolverPath (404 del visor)', () => {
   it('devuelve null para una categoría (no es página navegable) y para path vacío', () => {
     expect(resolverPath(arbol, ['backend'])).toBeNull();
     expect(resolverPath(arbol, [])).toBeNull();
+  });
+
+  it('devuelve null para una página publicada dentro de una carpeta OCULTA (no basta con esconderla del árbol)', () => {
+    const conCandado = construirArbolVisible([
+      doc({ id: 'cat', slug: 'backend', tipo: 'categoria', oculto: true }),
+      doc({ id: 'lab1', slug: 'lab1', padreId: 'cat', publicado: true }),
+    ]);
+    // El enlace directo es el que de verdad importa: un alumno con la URL vieja
+    // no debe poder entrar por la puerta de atrás.
+    expect(resolverPath(conCandado, ['backend', 'lab1'])).toBeNull();
   });
 });

--- a/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
@@ -45,6 +45,15 @@ interface NodoProps {
   onTogglePublicacion: (nodo: NodoPlano) => void;
 }
 
+/**
+ * ¿El alumno lo ve? Una página, si está publicada. Una carpeta, si no tiene el
+ * candado —lo otro que la esconde (no tener páginas publicadas debajo) es
+ * derivado y aquí no se puede saber sin mirar el subárbol—.
+ */
+function esVisible(nodo: NodoPlano): boolean {
+  return nodo.esCategoria ? !nodo.oculto : nodo.publicado;
+}
+
 function Nodo({
   nodo, activo, expandido, profundidadProyectada, editando,
   onSeleccionar, onToggle, onEmpezarRename, onRenombrar, onCancelarRename,
@@ -119,23 +128,26 @@ function Nodo({
           <span className={styles.titulo}>{nodo.titulo}</span>
 
           <span className={styles.acciones}>
-            {/* Las categorías no se publican: se ven si tienen alguna página
-                publicada debajo. Darles un ojo prometería un control que no existe. */}
-            {!nodo.esCategoria && (
-              <button
-                type="button"
-                className={styles.accion}
-                title={
-                  nodo.publicado
-                    ? 'Ocultar a los alumnos (conserva el contenido)'
-                    : 'Mostrar a los alumnos'
-                }
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => { e.stopPropagation(); onTogglePublicacion(nodo); }}
-              >
-                <Icon name={nodo.publicado ? 'visibility' : 'visibility_off'} size="sm" />
-              </button>
-            )}
+            {/* El interruptor es distinto según el tipo (una carpeta no tiene
+                publicación propia: se esconde con un candado sobre su subárbol),
+                pero para quien lo usa es el mismo gesto: mostrar / ocultar. */}
+            <button
+              type="button"
+              className={styles.accion}
+              title={
+                nodo.esCategoria
+                  ? (nodo.oculto
+                      ? 'Mostrar la carpeta y lo que hay dentro'
+                      : 'Ocultar la carpeta completa (con todo lo que cuelga de ella)')
+                  : (nodo.publicado
+                      ? 'Ocultar a los alumnos (conserva el contenido)'
+                      : 'Mostrar a los alumnos')
+              }
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); onTogglePublicacion(nodo); }}
+            >
+              <Icon name={esVisible(nodo) ? 'visibility' : 'visibility_off'} size="sm" />
+            </button>
             <button
               type="button"
               className={styles.accion}
@@ -158,10 +170,28 @@ function Nodo({
 
           {!nodo.esCategoria && (
             <span
-              className={nodo.publicado ? styles.dotPub : styles.dotBorr}
+              // Publicada pero con una carpeta candada encima: el alumno NO la ve.
+              // El punto dice lo que el alumno ve, no lo que el flag dice.
+              className={nodo.publicado && !nodo.ancestroOculto ? styles.dotPub : styles.dotBorr}
               // "Oculta", no "Borrador": el borrador es OTRA cosa (los cambios
               // sin publicar de una versión). Confundirlos aquí sería fatal.
-              title={nodo.publicado ? 'Publicada — la ven los alumnos' : 'Oculta — no la ven los alumnos'}
+              title={
+                !nodo.publicado
+                  ? 'Oculta — no la ven los alumnos'
+                  : nodo.ancestroOculto
+                    ? 'Publicada, pero su carpeta está oculta: los alumnos no la ven'
+                    : 'Publicada — la ven los alumnos'
+              }
+            />
+          )}
+
+          {/* A una carpeta solo se le pinta el punto cuando está candada. Un punto
+              verde prometería que se ve, y una carpeta sin páginas publicadas no se
+              ve aunque no tenga candado. */}
+          {nodo.esCategoria && nodo.oculto && (
+            <span
+              className={styles.dotBorr}
+              title="Carpeta oculta — no la ven los alumnos, ni nada de lo que hay dentro"
             />
           )}
         </>
@@ -311,16 +341,23 @@ export default function ArbolContenidos({ coleccionId }: { coleccionId: string }
    * que le quita algo a alguien que quizá ya lo tenía abierto.
    */
   async function handleTogglePublicacion(nodo: NodoPlano) {
-    if (nodo.publicado) {
+    const visible = esVisible(nodo);
+    if (visible) {
       const ok = await confirmar({
-        titulo: `¿Ocultar «${nodo.titulo}»?`,
-        texto: 'Dejará de aparecer en el árbol de los alumnos. El contenido se conserva: '
-          + 'puedes volver a mostrarla cuando quieras y quedará igual.',
+        titulo: nodo.esCategoria ? `¿Ocultar la carpeta «${nodo.titulo}»?` : `¿Ocultar «${nodo.titulo}»?`,
+        texto: nodo.esCategoria
+          // Se dice explícitamente que arrastra el contenido: es lo único de esta
+          // acción que no se ve en pantalla al pulsarla.
+          ? 'Dejarán de aparecer para los alumnos la carpeta Y TODO lo que hay dentro, '
+            + 'incluidas sus páginas publicadas. No se despublica nada: al volver a '
+            + 'mostrarla, cada página regresa al estado en el que estaba.'
+          : 'Dejará de aparecer en el árbol de los alumnos. El contenido se conserva: '
+            + 'puedes volver a mostrarla cuando quieras y quedará igual.',
         confirmar: 'Ocultar',
       });
       if (!ok) return;
     }
-    const err = await cambiarPublicacion(nodo.id, !nodo.publicado);
+    const err = await cambiarPublicacion(nodo.id, !visible);
     if (err) setError(err);
   }
 

--- a/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/ArbolContenidos.tsx
@@ -42,12 +42,13 @@ interface NodoProps {
   onCancelarRename: () => void;
   onCambiarSlug: (nodo: NodoPlano) => void;
   onEliminar: (nodo: NodoPlano) => void;
+  onTogglePublicacion: (nodo: NodoPlano) => void;
 }
 
 function Nodo({
   nodo, activo, expandido, profundidadProyectada, editando,
   onSeleccionar, onToggle, onEmpezarRename, onRenombrar, onCancelarRename,
-  onCambiarSlug, onEliminar,
+  onCambiarSlug, onEliminar, onTogglePublicacion,
 }: NodoProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: nodo.id,
@@ -118,6 +119,23 @@ function Nodo({
           <span className={styles.titulo}>{nodo.titulo}</span>
 
           <span className={styles.acciones}>
+            {/* Las categorías no se publican: se ven si tienen alguna página
+                publicada debajo. Darles un ojo prometería un control que no existe. */}
+            {!nodo.esCategoria && (
+              <button
+                type="button"
+                className={styles.accion}
+                title={
+                  nodo.publicado
+                    ? 'Ocultar a los alumnos (conserva el contenido)'
+                    : 'Mostrar a los alumnos'
+                }
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={(e) => { e.stopPropagation(); onTogglePublicacion(nodo); }}
+              >
+                <Icon name={nodo.publicado ? 'visibility' : 'visibility_off'} size="sm" />
+              </button>
+            )}
             <button
               type="button"
               className={styles.accion}
@@ -141,7 +159,9 @@ function Nodo({
           {!nodo.esCategoria && (
             <span
               className={nodo.publicado ? styles.dotPub : styles.dotBorr}
-              title={nodo.publicado ? 'Publicada' : 'Borrador'}
+              // "Oculta", no "Borrador": el borrador es OTRA cosa (los cambios
+              // sin publicar de una versión). Confundirlos aquí sería fatal.
+              title={nodo.publicado ? 'Publicada — la ven los alumnos' : 'Oculta — no la ven los alumnos'}
             />
           )}
         </>
@@ -161,7 +181,10 @@ function Nodo({
  *   se puede colgar de una categoría.
  */
 export default function ArbolContenidos({ coleccionId }: { coleccionId: string }) {
-  const { arbol, documentos, coleccion, cargando, mover, renombrar, cambiarSlug, eliminar } = useColeccionArbol();
+  const {
+    arbol, documentos, coleccion, cargando,
+    mover, renombrar, cambiarSlug, eliminar, cambiarPublicacion,
+  } = useColeccionArbol();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const seleccionadoId = searchParams.get('doc');
@@ -283,6 +306,24 @@ export default function ArbolContenidos({ coleccionId }: { coleccionId: string }
     if (err) setError(err);
   }
 
+  /**
+   * Mostrar/ocultar a los alumnos. Solo se confirma al OCULTAR: es la dirección
+   * que le quita algo a alguien que quizá ya lo tenía abierto.
+   */
+  async function handleTogglePublicacion(nodo: NodoPlano) {
+    if (nodo.publicado) {
+      const ok = await confirmar({
+        titulo: `¿Ocultar «${nodo.titulo}»?`,
+        texto: 'Dejará de aparecer en el árbol de los alumnos. El contenido se conserva: '
+          + 'puedes volver a mostrarla cuando quieras y quedará igual.',
+        confirmar: 'Ocultar',
+      });
+      if (!ok) return;
+    }
+    const err = await cambiarPublicacion(nodo.id, !nodo.publicado);
+    if (err) setError(err);
+  }
+
   async function handleEliminar(nodo: NodoPlano) {
     if (nodo.tieneHijos) {
       setError(`"${nodo.titulo}" tiene páginas dentro. Muévelas o elimínalas primero.`);
@@ -382,6 +423,7 @@ export default function ArbolContenidos({ coleccionId }: { coleccionId: string }
                 onCancelarRename={() => setEditandoId(null)}
                 onCambiarSlug={handleCambiarSlug}
                 onEliminar={handleEliminar}
+                onTogglePublicacion={handleTogglePublicacion}
               />
             ))}
           </div>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/arbol-dnd.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/arbol-dnd.ts
@@ -7,6 +7,13 @@ export interface NodoPlano {
   slug: string;
   tipo: DocumentoData['tipo'];
   publicado: boolean;
+  /** Candado explícito: esconde el nodo y todo lo que cuelga de él. */
+  oculto: boolean;
+  /**
+   * Alguna carpeta por encima está candada. La página puede estar publicada y
+   * aun así no verse: sin esto, el árbol del admin afirmaría que el alumno la ve.
+   */
+  ancestroOculto: boolean;
   padreId: string | null;
   profundidad: number;
   /** Solo las categorías admiten hijos (lo valida también el servidor). */
@@ -20,23 +27,27 @@ export function aplanar(
   expandidos: Set<string>,
   profundidad = 0,
   padreId: string | null = null,
+  ancestroOculto = false,
 ): NodoPlano[] {
   const out: NodoPlano[] = [];
   for (const n of nodos) {
     const esCategoria = n.tipo === 'categoria';
+    const oculto = n.oculto === true;
     out.push({
       id: n.id,
       titulo: n.titulo,
       slug: n.slug,
       tipo: n.tipo,
       publicado: n.publicado,
+      oculto,
+      ancestroOculto,
       padreId,
       profundidad,
       esCategoria,
       tieneHijos: n.hijos.length > 0,
     });
     if (esCategoria && expandidos.has(n.id)) {
-      out.push(...aplanar(n.hijos, expandidos, profundidad + 1, n.id));
+      out.push(...aplanar(n.hijos, expandidos, profundidad + 1, n.id, ancestroOculto || oculto));
     }
   }
   return out;

--- a/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
+++ b/packages/web/src/components/dashboard/pages/EditorContenidoPage/EditorContenidoPage.tsx
@@ -8,6 +8,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { EditorView } from '@codemirror/view';
 import { renderMarkdown } from '@tc2005b/contenido-pipeline';
 import { useAuth } from '../../../../context/AuthContext';
+import { useColeccionArbol } from '../../../../context/ColeccionArbolContext';
 import Modal from '../../atoms/Modal/Modal';
 import Icon from '../../atoms/Icon/Icon';
 import DashButton from '../../atoms/DashButton/DashButton';
@@ -100,6 +101,9 @@ export default function EditorContenidoPage({
   const [mensajePublicar, setMensajePublicar] = useState('');
   const [publicando, setPublicando] = useState(false);
   const [publicarError, setPublicarError] = useState('');
+
+  const { cambiarPublicacion } = useColeccionArbol();
+  const [cambiandoVisibilidad, setCambiandoVisibilidad] = useState(false);
 
   const [historialOpen, setHistorialOpen] = useState(false);
   const [versiones, setVersiones] = useState<VersionInfo[]>([]);
@@ -392,6 +396,32 @@ export default function EditorContenidoPage({
     }
   }
 
+  /* ── Visibilidad (mostrar/ocultar a los alumnos) ──
+   * Distinto de Publicar: no congela el borrador en una versión, solo enciende
+   * o apaga la página en el árbol del alumno. Va por el contexto del árbol para
+   * que el punto del sidebar quede al día sin recargar. */
+  async function toggleVisibilidad() {
+    if (!docId || !documento) return;
+    const ocultar = documento.publicado;
+    if (ocultar) {
+      const ok = await confirmar({
+        titulo: `¿Ocultar «${documento.titulo}»?`,
+        texto: 'Dejará de aparecer para los alumnos. El contenido se conserva: '
+          + 'al volver a mostrarla quedará igual que ahora.',
+        confirmar: 'Ocultar',
+      });
+      if (!ok) return;
+    }
+    setCambiandoVisibilidad(true);
+    const err = await cambiarPublicacion(docId, !ocultar);
+    setCambiandoVisibilidad(false);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setDocumento({ ...documento, publicado: !ocultar });
+  }
+
   /* ── Publicar ── */
   function abrirPublicar() {
     setMensajePublicar('');
@@ -518,13 +548,25 @@ export default function EditorContenidoPage({
           <span className={styles.titulo} title={documento?.titulo}>{documento?.titulo ?? '…'}</span>
           <span className={styles.subtitulo}>
             {documento?.tipo === 'html' ? 'HTML crudo' : 'Markdown'}
-            {documento?.publicado ? ' · publicada' : ' · sin publicar'}
+            {documento?.publicado ? ' · publicada' : ' · oculta'}
           </span>
         </div>
         <span className={`${styles.estado} ${estado === 'error' ? styles.estadoError : ''}`}>
           <span className={`${styles.dot} ${styles[`dot-${estado}`]}`} />
           {ESTADO_LABEL[estado]}
         </span>
+        {/* Solo con una versión publicada detrás: mostrar una página que nunca se
+            publicó no tendría nada que servirle al alumno (el API lo rechaza). */}
+        {documento?.versionId && (
+          <DashButton
+            variant="outline"
+            onClick={toggleVisibilidad}
+            disabled={cambiandoVisibilidad}
+          >
+            <Icon name={documento.publicado ? 'visibility_off' : 'visibility'} size="sm" />
+            {documento.publicado ? ' Ocultar' : ' Mostrar'}
+          </DashButton>
+        )}
         <DashButton variant="outline" onClick={abrirHistorial}>🕘 Historial</DashButton>
         <DashButton onClick={abrirPublicar} disabled={estado === 'cargando' || estado === 'error'}>
           Publicar

--- a/packages/web/src/context/ColeccionArbolContext.tsx
+++ b/packages/web/src/context/ColeccionArbolContext.tsx
@@ -36,6 +36,12 @@ interface ColeccionArbolValue {
   cambiarSlug: (docId: string, slug: string) => Promise<string | null>;
   mover: (docId: string, padreId: string | null, orden: number) => Promise<string | null>;
   eliminar: (docId: string) => Promise<string | null>;
+  /**
+   * Mostrar/ocultar la página a los alumnos. Es SOLO visibilidad: no congela el
+   * borrador en una versión (eso es "Publicar", en el editor), así que ocultar y
+   * volver a mostrar devuelve el mismo contenido.
+   */
+  cambiarPublicacion: (docId: string, publicado: boolean) => Promise<string | null>;
 }
 
 const Ctx = createContext<ColeccionArbolValue | null>(null);
@@ -54,6 +60,7 @@ const VACIO: ColeccionArbolValue = {
   cambiarSlug: NO_OP,
   mover: NO_OP,
   eliminar: NO_OP,
+  cambiarPublicacion: NO_OP,
 };
 
 export function useColeccionArbol(): ColeccionArbolValue {
@@ -152,12 +159,19 @@ export function ColeccionArbolProvider({ children }: { children: React.ReactNode
     [mutar],
   );
 
+  const cambiarPublicacion = useCallback(
+    (docId: string, publicado: boolean) =>
+      mutar(`/api/admin/documentos/${docId}/publicacion`, 'PUT', { publicado }),
+    [mutar],
+  );
+
   const value = useMemo<ColeccionArbolValue>(
     () => ({
       coleccionId, coleccion, documentos, arbol, cargando, error, refetch,
-      renombrar, cambiarSlug, mover, eliminar,
+      renombrar, cambiarSlug, mover, eliminar, cambiarPublicacion,
     }),
-    [coleccionId, coleccion, documentos, arbol, cargando, error, refetch, renombrar, cambiarSlug, mover, eliminar],
+    [coleccionId, coleccion, documentos, arbol, cargando, error, refetch,
+     renombrar, cambiarSlug, mover, eliminar, cambiarPublicacion],
   );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;

--- a/packages/web/src/types/contenidos.ts
+++ b/packages/web/src/types/contenidos.ts
@@ -32,6 +32,8 @@ export interface DocumentoData {
   orden: number;
   plantilla: DocumentoPlantilla | null;
   publicado: boolean;
+  /** Candado explícito: esconde el nodo y TODO lo que cuelga de él. */
+  oculto: boolean;
   versionId: string | null;
   borradorId: string | null;
   active: boolean;


### PR DESCRIPTION
## Descripción

Hacía falta poder **despublicar** contenido: tener el curso escrito de antemano e irlo
liberando conforme avanza. Cubre **páginas** y **carpetas completas**.

El modelo ya estaba casi todo ahí —`Documento.publicado` existe y `construirArbolVisible`
poda lo no publicado como código de seguridad— pero **nada podía devolver el flag a
`false`**: `/publicar` lo pone en `true` y `updateDocumento` ni siquiera acepta el campo.

**Dónde queda el control:** el ojo en las acciones de cada nodo del árbol (donde uno piensa
"libero esta y esta"), y en las páginas además un botón **Ocultar/Mostrar** en el encabezado
del editor.

**La visibilidad es su propio endpoint** (`PUT /admin/documentos/:docId/publicacion`),
deliberadamente separado de `/publicar`. Fundirlos habría hecho que "mostrar" desde el árbol
publicara de rebote un borrador a medio escribir: `/publicar` congela contenido, esto solo
enciende y apaga el nodo. Ocultar **no toca `version`**, así que volver a mostrar devuelve
exactamente el mismo contenido, sin versión nueva.

## Ocultar una carpeta: por qué un campo nuevo y no `publicado`

Ocultar una carpeta se lleva **todo su subárbol**, incluidas sus páginas publicadas, pero
**no despublica ninguna**: al volver a mostrarla, cada página regresa al estado en el que
estaba. Ocultar la carpeta y despublicar sus páginas una por una **no son lo mismo** — solo
lo primero es reversible sin perder el detalle de qué había dentro publicado y qué no.

La carpeta usa un campo **propio**, `Documento.oculto`, y no `publicado`. El motivo es
concreto: una categoría **no tiene publicación propia**, se muestra si tiene alguna página
publicada debajo. Lo comprobé contra la BD:

```
Documentos vivos: 139
 categoria · publicado=false: 54      ← todas, y aun así se ven
 md · publicado=false: 1
 md · publicado=true: 84
```

Reusar `publicado` como candado de carpeta habría **escondido las 54 categorías** de golpe
en cuanto se desplegara el código, hasta que corriera una migración — y la regla del
proyecto es que las migraciones van *después* del deploy. Con `oculto`, **ausente = visible**:
no hace falta migración ninguna.

En la poda, el candado **gana sobre todo lo demás**, así que una página publicada dentro de
una carpeta oculta tampoco se alcanza **por URL directa** (hay test). En el árbol del admin
esa página se pinta apagada: el punto dice lo que el alumno ve, no lo que el flag dice.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)
- [x] `fix` — corrección de bug (SemVer: PATCH) — ver abajo

### El bug que salió al diseñarlo

`POST /publicar` empezaba con:

```ts
const borrador = documento.getBorrador();
if (!borrador) { 400: 'No hay cambios de borrador que publicar' }
```

Una página **ocultada sin editarle nada** no habría tenido camino de vuelta: no hay
borrador, así que Publicar la rechazaba y quedaba **atrapada en invisible**. Un botón
"Despublicar" a secas habría enviado contenido a un pozo. Ahora, sin borrador pero con
versión y oculta, publicar **la re-expone** con su versión actual.

## ¿Cómo se probó?

- [x] `yarn test` pasa (**88 tests**, +4). Los nuevos, en `contenidos-arbol.test.ts`, fijan
  las decisiones y no el resultado accidental:
  - una categoría oculta se lleva su subárbol **aunque sus páginas sigan publicadas**;
  - quitar el candado devuelve cada página **al estado en que estaba** (ocultar ≠ despublicar);
  - el candado gana sobre `publicado`;
  - **`resolverPath` devuelve `null`** para una página publicada dentro de una carpeta oculta
    — el enlace directo es el que de verdad importa: nadie entra por la puerta de atrás.
- [x] `npx tsc --noEmit` sin errores en `packages/api` y `packages/web`.
- [ ] **Falta la comprobación en pantalla**: no pude conducir el admin autenticado
  (la extensión de Chrome abre otro perfil y cae en `/login`). Checklist para el revisor:
  - [ ] Ojo en una página publicada → confirma → desaparece del árbol del alumno.
  - [ ] Volver a darle al ojo **sin editar nada** → reaparece igual y **sin versión nueva**
        en el Historial (este es el bug de arriba).
  - [ ] Ojo en una carpeta → confirma → desaparecen la carpeta y todo su contenido para el
        alumno; las páginas de dentro conservan su punto (apagado) y su estado.
  - [ ] Quitar el candado a la carpeta → vuelve exactamente como estaba, incluidas las
        páginas que estaban ocultas *dentro* (deben seguir ocultas).
  - [ ] Con la carpeta oculta, entrar por **URL directa** a una página de dentro → 404.

## Checklist

- [x] La rama sigue Conventional Branch (`feature/…`)
- [x] Los commits siguen Conventional Commits
- [x] CHANGELOG.md actualizado
- [x] Sin migración de datos (`oculto` ausente = visible)