### PR TITLE
feat(admin): vista de Administradores en el menú del admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Vista "Administradores"** en el menú del admin: una tabla con los usuarios
+  administradores dados de alta (nombre, correo, último acceso, fecha de alta).
+  Solo lectura por ahora. El endpoint `GET /admin/administradores` filtra por
+  `userType: 'admin'` y solo activos, así que **no incluye alumnos** — el censo
+  de producción son 3 admins frente a 20 alumnos, y la tabla trae solo los 3.
 - **Las páginas y las carpetas del CMS se pueden ocultar y volver a mostrar**, para
   escribir el curso completo de antemano e irlo liberando conforme avanza. El ojo
   aparece en las acciones de cada nodo del árbol, y las páginas además tienen un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Administradores asignables a grupos, de forma bidireccional.** Desde el
+  **grupo** (form de crear/editar, junto a las colecciones) se marcan sus
+  administradores; desde **Administradores** cada fila tiene una acción "Grupos"
+  que abre un modal con los grupos del admin. Ambos lados escriben la misma
+  relación (`Grupo.admins`, array de pointers, como `colecciones`).
+  - Es una **asociación organizativa**: registra quién está a cargo de qué grupo.
+    **No cambia el acceso** — todo admin sigue viendo y gestionando todos los
+    grupos, como hasta ahora.
+  - El campo se ve como columna en las tablas de Grupos y de Administradores.
+  - `GET /admin/administradores` gana un uso más; se agrega
+    `PUT /admin/administradores/:id/grupos` (reconcilia los grupos de un admin
+    sin tocar los que no cambian). El servidor valida que cada id asignado sea un
+    admin activo: un alumno no puede colarse por el payload.
 - **Vista "Administradores"** en el menú del admin: una tabla con los usuarios
   administradores dados de alta (nombre, correo, último acceso, fecha de alta).
   Solo lectura por ahora. El endpoint `GET /admin/administradores` filtra por

--- a/packages/api/src/controllers/admin.controller.ts
+++ b/packages/api/src/controllers/admin.controller.ts
@@ -34,6 +34,73 @@ export async function listAdmins(_req: Request, res: Response): Promise<void> {
   }
 }
 
+/**
+ * PUT /admin/administradores/:id/grupos — { grupoIds: string[] }
+ *
+ * Lado ADMIN de la asignación bidireccional: fija en qué grupos figura este
+ * admin. La relación vive en `Grupo.admins` (array de pointers), así que
+ * reconciliar desde aquí significa añadir/quitar el pointer del admin en cada
+ * grupo afectado — sin tocar los grupos que no cambian.
+ *
+ * Es una asociación organizativa: NO altera el acceso (todo admin ve todo).
+ */
+export async function setGruposDeAdmin(req: Request, res: Response): Promise<void> {
+  const { id } = req.params;
+  const { grupoIds } = req.body ?? {};
+
+  if (!Array.isArray(grupoIds) || grupoIds.some((g) => typeof g !== 'string')) {
+    res.status(400).json({ status: 'error', message: 'grupoIds debe ser un arreglo de ids' });
+    return;
+  }
+
+  try {
+    // El id debe ser un admin vivo: no se asignan grupos a un alumno.
+    const admin = await new Parse.Query<AppUser>('AppUser')
+      .equalTo('exists', true)
+      .equalTo('userType', 'admin')
+      .get(id, { useMasterKey: true })
+      .catch(() => null);
+    if (!admin) {
+      res.status(404).json({ status: 'error', message: 'Administrador no encontrado' });
+      return;
+    }
+    const adminPointer = Parse.Object.extend('AppUser').createWithoutData(id);
+
+    const deseados = new Set([...new Set(grupoIds)]);
+
+    // Grupos válidos entre los deseados (ignora ids muertos en silencio: la
+    // meta es "que el admin quede en estos grupos", no auditar el payload).
+    const grupoQuery = BaseModel.queryActive('Grupo');
+    grupoQuery.include('admins');
+    grupoQuery.limit(1000);
+    const grupos = await grupoQuery.find({ useMasterKey: true });
+
+    const porCambiar: Parse.Object[] = [];
+    for (const grupo of grupos) {
+      const admins = (grupo.get('admins') as Parse.Object[]) ?? [];
+      const estaba = admins.some((a) => a.id === id);
+      const debeEstar = deseados.has(grupo.id);
+      if (estaba === debeEstar) continue;
+
+      grupo.set(
+        'admins',
+        debeEstar
+          ? [...admins, adminPointer]
+          : admins.filter((a) => a.id !== id),
+      );
+      porCambiar.push(grupo);
+    }
+
+    if (porCambiar.length > 0) {
+      await Parse.Object.saveAll(porCambiar, { useMasterKey: true });
+    }
+
+    res.json({ status: 'ok', gruposModificados: porCambiar.length });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al asignar grupos al administrador' });
+  }
+}
+
 export async function changeAdminPassword(req: Request, res: Response): Promise<void> {
   try {
     const { newPassword, confirmPassword } = req.body;

--- a/packages/api/src/controllers/admin.controller.ts
+++ b/packages/api/src/controllers/admin.controller.ts
@@ -1,7 +1,38 @@
 import type { Request, Response } from 'express';
 import Parse from 'parse/node';
 import bcrypt from 'bcryptjs';
+import { BaseModel } from '../models/BaseModel.js';
 import { AppUser } from '../models/AppUser.js';
+
+/**
+ * GET /admin/administradores — lista los usuarios administradores dados de alta.
+ *
+ * Solo `userType: 'admin'` y solo activos (`queryActive`): la vista es el censo
+ * de administradores, no incluye alumnos. Sin matrícula ni grupos, que son del
+ * alumno; sí el último acceso, útil para saber quién sigue entrando.
+ */
+export async function listAdmins(_req: Request, res: Response): Promise<void> {
+  try {
+    const query = BaseModel.queryActive<AppUser>('AppUser');
+    query.equalTo('userType', 'admin');
+    query.ascending('name');
+    query.limit(1000);
+    const admins = await query.find({ useMasterKey: true });
+
+    res.json({
+      status: 'ok',
+      administradores: admins.map((a) => ({
+        id: a.id,
+        name: a.getName(),
+        email: a.getEmail(),
+        lastLogin: a.getLastLogin() ?? null,
+        createdAt: a.createdAt,
+      })),
+    });
+  } catch (error) {
+    res.status(500).json({ status: 'error', message: 'Error al obtener administradores' });
+  }
+}
 
 export async function changeAdminPassword(req: Request, res: Response): Promise<void> {
   try {

--- a/packages/api/src/controllers/grupos.controller.ts
+++ b/packages/api/src/controllers/grupos.controller.ts
@@ -10,6 +10,7 @@ export async function listGrupos(_req: Request, res: Response): Promise<void> {
     const query = new Parse.Query<Grupo>('Grupo');
     query.equalTo('exists' as any, true as any);
     query.include('colecciones' as any);
+    query.include('admins' as any);
     query.descending('createdAt');
     const grupos = await query.find({ useMasterKey: true });
 
@@ -36,6 +37,24 @@ async function resolverColecciones(value: unknown): Promise<Parse.Object[] | 'in
   const encontradas = await q.find({ useMasterKey: true });
   if (encontradas.length !== ids.length) return 'invalido';
   return encontradas;
+}
+
+/**
+ * ids de administradores → pointers VALIDADOS. Igual que resolverColecciones,
+ * pero además exige que cada id sea un AppUser activo con userType='admin': así
+ * un alumno no puede colarse como admin de un grupo por manipular el payload.
+ * null = no-array (se ignora); 'invalido' = algún id no es un admin (400).
+ */
+async function resolverAdmins(value: unknown): Promise<Parse.Object[] | 'invalido' | null> {
+  if (!Array.isArray(value)) return null;
+  const ids = [...new Set(value.filter((s): s is string => typeof s === 'string' && s.trim() !== ''))];
+  if (ids.length === 0) return [];
+  const q = BaseModel.queryActive('AppUser');
+  q.equalTo('userType' as any, 'admin' as any);
+  q.containedIn('objectId' as any, ids as any);
+  const encontrados = await q.find({ useMasterKey: true });
+  if (encontrados.length !== ids.length) return 'invalido';
+  return encontrados;
 }
 
 export async function createGrupo(req: Request, res: Response): Promise<void> {
@@ -66,6 +85,13 @@ export async function createGrupo(req: Request, res: Response): Promise<void> {
     }
     if (coleccionesPtrs) grupo.setColecciones(coleccionesPtrs);
 
+    const adminsPtrs = await resolverAdmins(req.body.admins);
+    if (adminsPtrs === 'invalido') {
+      res.status(400).json({ status: 'error', message: 'Alguno de los administradores indicados no existe o no es admin' });
+      return;
+    }
+    if (adminsPtrs) grupo.setAdmins(adminsPtrs);
+
     await grupo.save(null, { useMasterKey: true });
     if (coleccionesPtrs?.length) invalidateColeccionesPermitidas();
 
@@ -81,9 +107,10 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
 
   try {
     const query = BaseModel.queryActive<Grupo>('Grupo');
-    // colecciones incluidas: toSafeJSON serializa pointers y sin fetch
+    // colecciones/admins incluidos: toSafeJSON serializa pointers y sin fetch
     // respondería nulls (y no podría filtrar soft-deleted).
     query.include('colecciones' as any);
+    query.include('admins' as any);
     const grupo = await query.get(id, { useMasterKey: true });
 
     if (name !== undefined) {
@@ -116,6 +143,14 @@ export async function updateGrupo(req: Request, res: Response): Promise<void> {
       return;
     }
     if (coleccionesPtrs) grupo.setColecciones(coleccionesPtrs);
+
+    // Solo un array válido aplica ([] limpia); no-array (undefined) se ignora.
+    const adminsPtrs = await resolverAdmins(req.body.admins);
+    if (adminsPtrs === 'invalido') {
+      res.status(400).json({ status: 'error', message: 'Alguno de los administradores indicados no existe o no es admin' });
+      return;
+    }
+    if (adminsPtrs) grupo.setAdmins(adminsPtrs);
 
     await grupo.save(null, { useMasterKey: true });
     if (coleccionesPtrs) invalidateColeccionesPermitidas();

--- a/packages/api/src/models/Grupo.ts
+++ b/packages/api/src/models/Grupo.ts
@@ -62,6 +62,19 @@ export class Grupo extends BaseModel {
     this.set('colecciones', colecciones);
   }
 
+  /**
+   * Administradores (AppUser userType='admin') asignados al grupo — array de
+   * pointers, como `colecciones`. Es una asociación ORGANIZATIVA: no cambia el
+   * acceso (todo admin ve todos los grupos), solo registra quién está a cargo.
+   * Se gestiona de forma bidireccional: desde el grupo y desde el admin.
+   */
+  getAdmins(): Parse.Object[] {
+    return this.get('admins') ?? [];
+  }
+  setAdmins(admins: Parse.Object[]): void {
+    this.set('admins', admins);
+  }
+
   toSafeJSON(): Record<string, unknown> {
     return {
       id: this.id,
@@ -78,6 +91,14 @@ export class Grupo extends BaseModel {
           nombre: c.get('nombre') ?? null,
           slug: c.get('slug') ?? null,
           clave: c.get('clave') ?? null,
+        })),
+      // Requiere query.include('admins'); los soft-deleted no se exponen.
+      admins: this.getAdmins()
+        .filter((a) => a && a.get('exists') !== false)
+        .map((a) => ({
+          id: a.id,
+          name: a.get('name') ?? null,
+          email: a.get('email') ?? null,
         })),
       active: this.get('active'),
       createdAt: this.createdAt,

--- a/packages/api/src/routes/admin.routes.ts
+++ b/packages/api/src/routes/admin.routes.ts
@@ -5,7 +5,7 @@ import { reorderActividades } from '../controllers/calendario-reorder.controller
 import { createActividad } from '../controllers/calendario-create.controller.js';
 import { updateActividad, deleteActividad } from '../controllers/calendario-update.controller.js';
 import { createSemana, reorderSemanas, deleteSemana } from '../controllers/semana.controller.js';
-import { changeAdminPassword } from '../controllers/admin.controller.js';
+import { changeAdminPassword, listAdmins } from '../controllers/admin.controller.js';
 import { copyCalendario } from '../controllers/calendario-copy.controller.js';
 
 const router = Router();
@@ -25,5 +25,6 @@ router.put('/admin/calendario/semana/reorder', reorderSemanas);
 router.delete('/admin/calendario/semana/:semanaId', deleteSemana);
 router.post('/admin/calendario/copy', copyCalendario);
 router.put('/admin/cambiar-password', changeAdminPassword);
+router.get('/admin/administradores', listAdmins);
 
 export default router;

--- a/packages/api/src/routes/admin.routes.ts
+++ b/packages/api/src/routes/admin.routes.ts
@@ -5,7 +5,7 @@ import { reorderActividades } from '../controllers/calendario-reorder.controller
 import { createActividad } from '../controllers/calendario-create.controller.js';
 import { updateActividad, deleteActividad } from '../controllers/calendario-update.controller.js';
 import { createSemana, reorderSemanas, deleteSemana } from '../controllers/semana.controller.js';
-import { changeAdminPassword, listAdmins } from '../controllers/admin.controller.js';
+import { changeAdminPassword, listAdmins, setGruposDeAdmin } from '../controllers/admin.controller.js';
 import { copyCalendario } from '../controllers/calendario-copy.controller.js';
 
 const router = Router();
@@ -26,5 +26,6 @@ router.delete('/admin/calendario/semana/:semanaId', deleteSemana);
 router.post('/admin/calendario/copy', copyCalendario);
 router.put('/admin/cambiar-password', changeAdminPassword);
 router.get('/admin/administradores', listAdmins);
+router.put('/admin/administradores/:id/grupos', setGruposDeAdmin);
 
 export default router;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -11,6 +11,7 @@ import AlumnoDashboard from './components/dashboard/pages/AlumnoDashboard/Alumno
 import LoginPage from './components/dashboard/pages/LoginPage/LoginPage';
 import VerifyPage from './components/dashboard/pages/VerifyPage/VerifyPage';
 import GruposPage from './components/dashboard/pages/GruposPage/GruposPage';
+import AdministradoresPage from './components/dashboard/pages/AdministradoresPage/AdministradoresPage';
 import GrupoDetailPage from './components/dashboard/pages/GrupoDetailPage/GrupoDetailPage';
 import AdminCalendarioPage from './components/dashboard/pages/AdminCalendarioPage/AdminCalendarioPage';
 import CompetenciasPage from './components/dashboard/pages/CompetenciasPage/CompetenciasPage';
@@ -78,6 +79,7 @@ export default function App() {
       <Route element={<DashboardLayout role="admin" />}>
         <Route path="admin" element={<AdminDashboard />} />
         <Route path="admin/grupos" element={<GruposPage />} />
+        <Route path="admin/administradores" element={<AdministradoresPage />} />
         <Route path="admin/grupos/:id" element={<GrupoDetailPage />} />
         <Route path="admin/grupos/:id/alumnos/:alumnoId/malla" element={<MallaEvaluacionPage />} />
         <Route path="admin/grupos/:id/actividades-evaluacion" element={<ActividadesGrupoPage />} />

--- a/packages/web/src/components/dashboard/organisms/AdminTable/AdminTable.module.css
+++ b/packages/web/src/components/dashboard/organisms/AdminTable/AdminTable.module.css
@@ -154,6 +154,15 @@
   color: #dc2626;
 }
 
+/* Acción sin icono: botón de texto (ancho automático en vez del cuadro 32px). */
+.actionText {
+  width: auto;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+}
+
 .pagination {
   display: flex;
   align-items: center;

--- a/packages/web/src/components/dashboard/organisms/AdminTable/AdminTable.tsx
+++ b/packages/web/src/components/dashboard/organisms/AdminTable/AdminTable.tsx
@@ -164,12 +164,16 @@ export default function AdminTable<T>({
                 {items.map((action) => (
                   <button
                     key={action.label}
-                    className={`${styles.actionBtn} ${action.variant === 'danger' ? styles.actionDanger : ''}`}
+                    className={`${styles.actionBtn} ${action.icon ? '' : styles.actionText} ${action.variant === 'danger' ? styles.actionDanger : ''}`}
                     onClick={action.onClick}
                     title={action.label}
                   >
-                    {action.icon && (
+                    {action.icon ? (
                       <span className="material-icons" style={{ fontSize: 18 }}>{action.icon}</span>
+                    ) : (
+                      // Sin icono: se muestra el texto del label (si no, el botón
+                      // quedaría vacío e invisible).
+                      action.label
                     )}
                   </button>
                 ))}

--- a/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
+++ b/packages/web/src/components/dashboard/organisms/GrupoForm/GrupoForm.tsx
@@ -4,12 +4,20 @@ import DashButton from '../../atoms/DashButton/DashButton';
 import styles from './GrupoForm.module.css';
 import type { ColeccionRef } from '../../../../types/contenidos';
 
+/** Administrador asignable a un grupo (subconjunto de lo que expone el API). */
+export interface AdminRef {
+  id: string;
+  name: string;
+  email: string;
+}
+
 interface GrupoData {
   id?: string;
   name: string;
   fechaInicio?: string;
   fechaFin?: string;
   colecciones?: ColeccionRef[];
+  admins?: AdminRef[];
   urlAgendaEntrevistas?: string | null;
 }
 
@@ -18,6 +26,7 @@ interface GrupoSavePayload {
   fechaInicio?: string;
   fechaFin?: string;
   colecciones?: string[];
+  admins?: string[];
   urlAgendaEntrevistas?: string;
 }
 
@@ -30,6 +39,8 @@ interface GrupoFormProps {
    * podía contradecir a este campo).
    */
   colecciones?: ColeccionRef[];
+  /** Administradores dados de alta, para asignarlos al grupo (asociación). */
+  admins?: AdminRef[];
   onSave: (data: GrupoSavePayload) => void;
   onCancel: () => void;
   loading?: boolean;
@@ -42,12 +53,15 @@ function toDateString(value?: string | Date): string {
   return d.toISOString().split('T')[0];
 }
 
-export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, loading }: GrupoFormProps) {
+export default function GrupoForm({ grupo, colecciones = [], admins = [], onSave, onCancel, loading }: GrupoFormProps) {
   const [name, setName] = useState(grupo?.name ?? '');
   const [fechaInicio, setFechaInicio] = useState(toDateString(grupo?.fechaInicio));
   const [fechaFin, setFechaFin] = useState(toDateString(grupo?.fechaFin));
   const [coleccionesSel, setColeccionesSel] = useState<string[]>(
     (grupo?.colecciones ?? []).map((c) => c.id),
+  );
+  const [adminsSel, setAdminsSel] = useState<string[]>(
+    (grupo?.admins ?? []).map((a) => a.id),
   );
   const [agendaUrl, setAgendaUrl] = useState(grupo?.urlAgendaEntrevistas ?? '');
   const [error, setError] = useState('');
@@ -57,6 +71,12 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
   function toggleColeccion(id: string) {
     setColeccionesSel((prev) =>
       prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id],
+    );
+  }
+
+  function toggleAdmin(id: string) {
+    setAdminsSel((prev) =>
+      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id],
     );
   }
 
@@ -79,6 +99,7 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
       fechaInicio: fechaInicio || undefined,
       fechaFin: fechaFin || undefined,
       colecciones: coleccionesSel,
+      admins: adminsSel,
       // Cadena vacía = quitar el enlace del grupo.
       urlAgendaEntrevistas: url,
     });
@@ -115,6 +136,28 @@ export default function GrupoForm({ grupo, colecciones = [], onSave, onCancel, l
                   type="checkbox"
                   checked={coleccionesSel.includes(c.id)}
                   onChange={() => toggleColeccion(c.id)}
+                  disabled={loading}
+                />
+                <span className={styles.checkboxLabel} title={label}>{label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+      <div className={styles.field}>
+        <label className={styles.label}>Administradores del grupo</label>
+        <div className={styles.checkboxList}>
+          {admins.length === 0 && (
+            <span className={styles.hint}>No hay administradores dados de alta.</span>
+          )}
+          {admins.map((a) => {
+            const label = a.name ? `${a.name} (${a.email})` : a.email;
+            return (
+              <label key={a.id} className={styles.checkboxItem}>
+                <input
+                  type="checkbox"
+                  checked={adminsSel.includes(a.id)}
+                  onChange={() => toggleAdmin(a.id)}
                   disabled={loading}
                 />
                 <span className={styles.checkboxLabel} title={label}>{label}</span>

--- a/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
+++ b/packages/web/src/components/dashboard/organisms/Sidebar/sidebarConfig.ts
@@ -18,6 +18,7 @@ export function getSidebarItems(
     return [
       { label: 'Dashboard', icon: 'dashboard', path: '/admin' },
       { label: 'Grupos', icon: 'groups', path: '/admin/grupos' },
+      { label: 'Administradores', icon: 'admin_panel_settings', path: '/admin/administradores' },
       // "Páginas", "Competencias" y "Actividades" ya no son entradas propias: se
       // llega a ellas desde Contenidos, que es donde viven (las tres pertenecen a
       // una Coleccion). Cada colección tiene su acción, que las abre ya filtradas,

--- a/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.module.css
+++ b/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.module.css
@@ -18,3 +18,54 @@
   border-radius: 8px;
   font-size: 14px;
 }
+
+/* Lista de grupos en el modal de asignación. */
+.checkboxList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.checkboxItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.checkboxItem:hover {
+  background: var(--bg-page);
+}
+.checkboxItem input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+.checkboxLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  color: var(--text-primary);
+}
+
+.hint {
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 20px;
+}

--- a/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.module.css
+++ b/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.module.css
@@ -1,0 +1,20 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.pageTitle {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.error {
+  padding: 12px 16px;
+  background: #fdecea;
+  color: var(--dash-danger);
+  border-radius: 8px;
+  font-size: 14px;
+}

--- a/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.tsx
+++ b/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.tsx
@@ -2,6 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
+import Modal from '../../atoms/Modal/Modal';
+import DashButton from '../../atoms/DashButton/DashButton';
+import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
 import styles from './AdministradoresPage.module.css';
 
 interface AdminData {
@@ -12,46 +15,102 @@ interface AdminData {
   createdAt: string;
 }
 
+interface GrupoConAdmins {
+  id: string;
+  name: string;
+  admins?: { id: string }[];
+}
+
 const API_BASE = '/api';
 
 /**
- * Censo de administradores dados de alta (solo lectura). No incluye alumnos: el
- * API filtra por `userType: 'admin'`.
+ * Censo de administradores dados de alta. No incluye alumnos: el API filtra por
+ * `userType: 'admin'`. Desde cada fila se asignan sus grupos (asociación
+ * organizativa bidireccional; no cambia accesos).
  */
 export default function AdministradoresPage() {
   const { sessionToken } = useAuth();
   const [admins, setAdmins] = useState<AdminData[]>([]);
+  const [grupos, setGrupos] = useState<GrupoConAdmins[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
-  const fetchAdmins = useCallback(async () => {
+  // Modal "Grupos del administrador".
+  const [modalAdmin, setModalAdmin] = useState<AdminData | null>(null);
+  const [seleccion, setSeleccion] = useState<string[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const headers = { 'x-session-token': sessionToken ?? '' };
+
+  const fetchAll = useCallback(async () => {
     try {
       setLoading(true);
-      const res = await fetch(`${API_BASE}/admin/administradores`, {
-        headers: { 'x-session-token': sessionToken ?? '' },
-      });
-      if (!res.ok) throw new Error('Error al cargar administradores');
-      const data = await res.json();
-      setAdmins(data.administradores ?? []);
+      const [resAdmins, resGrupos] = await Promise.all([
+        fetch(`${API_BASE}/admin/administradores`, { headers }),
+        fetch(`${API_BASE}/admin/grupos`, { headers }),
+      ]);
+      if (!resAdmins.ok) throw new Error('Error al cargar administradores');
+      if (!resGrupos.ok) throw new Error('Error al cargar grupos');
+      const dataAdmins = await resAdmins.json();
+      const dataGrupos = await resGrupos.json();
+      setAdmins(dataAdmins.administradores ?? []);
+      setGrupos(dataGrupos.grupos ?? []);
     } catch (err: any) {
       setError(err.message);
     } finally {
       setLoading(false);
     }
+    // headers depende solo de sessionToken; se recrea en cada render pero no importa.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionToken]);
 
   useEffect(() => {
-    fetchAdmins();
-  }, [fetchAdmins]);
+    fetchAll();
+  }, [fetchAll]);
+
+  /** Grupos donde figura este admin (derivado de la lista de grupos). */
+  const gruposDe = useCallback(
+    (adminId: string) => grupos.filter((g) => (g.admins ?? []).some((a) => a.id === adminId)),
+    [grupos],
+  );
+
+  function openGruposModal(admin: AdminData) {
+    setModalAdmin(admin);
+    setSeleccion(gruposDe(admin.id).map((g) => g.id));
+    setError('');
+  }
+
+  function toggleGrupo(id: string) {
+    setSeleccion((prev) => (prev.includes(id) ? prev.filter((g) => g !== id) : [...prev, id]));
+  }
+
+  async function guardarGrupos() {
+    if (!modalAdmin) return;
+    setSaving(true);
+    setError('');
+    try {
+      const res = await fetch(`${API_BASE}/admin/administradores/${modalAdmin.id}/grupos`, {
+        method: 'PUT',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ grupoIds: seleccion }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.message || 'Error al asignar grupos');
+      }
+      setModalAdmin(null);
+      await fetchAll();
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
 
   function formatDateTime(value: string | null): string {
     if (!value) return 'Nunca';
     return new Date(value).toLocaleString('es-MX', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
     });
   }
 
@@ -64,6 +123,11 @@ export default function AdministradoresPage() {
   const columns = [
     columnHelper.accessor('name', { header: 'Nombre', cell: (info) => info.getValue() || '—' }),
     columnHelper.accessor('email', { header: 'Correo' }),
+    columnHelper.accessor((row) => gruposDe(row.id).map((g) => g.name).join(', '), {
+      id: 'grupos',
+      header: 'Grupos',
+      cell: (info) => info.getValue() || '—',
+    }),
     columnHelper.accessor('lastLogin', {
       header: 'Último acceso',
       cell: (info) => formatDateTime(info.getValue()),
@@ -74,11 +138,15 @@ export default function AdministradoresPage() {
     }),
   ];
 
+  const getActions = (admin: AdminData): ActionItem[] => [
+    { label: 'Grupos', onClick: () => openGruposModal(admin) },
+  ];
+
   return (
     <div className={styles.page}>
       <h1 className={styles.pageTitle}>Administradores</h1>
 
-      {error && <div className={styles.error}>{error}</div>}
+      {error && !modalAdmin && <div className={styles.error}>{error}</div>}
 
       {loading ? (
         <p>Cargando...</p>
@@ -87,10 +155,41 @@ export default function AdministradoresPage() {
           title="Administradores dados de alta"
           columns={columns}
           data={admins}
+          actions={getActions}
           emptyMessage="No hay administradores registrados"
           searchPlaceholder="Buscar administrador..."
         />
       )}
+
+      <Modal
+        isOpen={modalAdmin !== null}
+        onClose={() => setModalAdmin(null)}
+        title={modalAdmin ? `Grupos de ${modalAdmin.name || modalAdmin.email}` : 'Grupos'}
+      >
+        {error && modalAdmin && <div className={styles.error}>{error}</div>}
+        <div className={styles.checkboxList}>
+          {grupos.length === 0 && <span className={styles.hint}>No hay grupos disponibles.</span>}
+          {grupos.map((g) => (
+            <label key={g.id} className={styles.checkboxItem}>
+              <input
+                type="checkbox"
+                checked={seleccion.includes(g.id)}
+                onChange={() => toggleGrupo(g.id)}
+                disabled={saving}
+              />
+              <span className={styles.checkboxLabel} title={g.name}>{g.name}</span>
+            </label>
+          ))}
+        </div>
+        <div className={styles.actions}>
+          <DashButton variant="outline" onClick={() => setModalAdmin(null)} disabled={saving}>
+            Cancelar
+          </DashButton>
+          <DashButton onClick={guardarGrupos} disabled={saving}>
+            {saving ? 'Guardando...' : 'Guardar'}
+          </DashButton>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.tsx
+++ b/packages/web/src/components/dashboard/pages/AdministradoresPage/AdministradoresPage.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createColumnHelper } from '@tanstack/react-table';
+import { useAuth } from '../../../../context/AuthContext';
+import AdminTable from '../../organisms/AdminTable/AdminTable';
+import styles from './AdministradoresPage.module.css';
+
+interface AdminData {
+  id: string;
+  name: string;
+  email: string;
+  lastLogin: string | null;
+  createdAt: string;
+}
+
+const API_BASE = '/api';
+
+/**
+ * Censo de administradores dados de alta (solo lectura). No incluye alumnos: el
+ * API filtra por `userType: 'admin'`.
+ */
+export default function AdministradoresPage() {
+  const { sessionToken } = useAuth();
+  const [admins, setAdmins] = useState<AdminData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const fetchAdmins = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(`${API_BASE}/admin/administradores`, {
+        headers: { 'x-session-token': sessionToken ?? '' },
+      });
+      if (!res.ok) throw new Error('Error al cargar administradores');
+      const data = await res.json();
+      setAdmins(data.administradores ?? []);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionToken]);
+
+  useEffect(() => {
+    fetchAdmins();
+  }, [fetchAdmins]);
+
+  function formatDateTime(value: string | null): string {
+    if (!value) return 'Nunca';
+    return new Date(value).toLocaleString('es-MX', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function formatDate(value: string): string {
+    return new Date(value).toLocaleDateString('es-MX', { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  const columnHelper = createColumnHelper<AdminData>();
+
+  const columns = [
+    columnHelper.accessor('name', { header: 'Nombre', cell: (info) => info.getValue() || '—' }),
+    columnHelper.accessor('email', { header: 'Correo' }),
+    columnHelper.accessor('lastLogin', {
+      header: 'Último acceso',
+      cell: (info) => formatDateTime(info.getValue()),
+    }),
+    columnHelper.accessor('createdAt', {
+      header: 'Alta',
+      cell: (info) => formatDate(info.getValue()),
+    }),
+  ];
+
+  return (
+    <div className={styles.page}>
+      <h1 className={styles.pageTitle}>Administradores</h1>
+
+      {error && <div className={styles.error}>{error}</div>}
+
+      {loading ? (
+        <p>Cargando...</p>
+      ) : (
+        <AdminTable
+          title="Administradores dados de alta"
+          columns={columns}
+          data={admins}
+          emptyMessage="No hay administradores registrados"
+          searchPlaceholder="Buscar administrador..."
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
+++ b/packages/web/src/components/dashboard/pages/GruposPage/GruposPage.tsx
@@ -5,7 +5,7 @@ import { createColumnHelper } from '@tanstack/react-table';
 import { useAuth } from '../../../../context/AuthContext';
 import AdminTable from '../../organisms/AdminTable/AdminTable';
 import Modal from '../../atoms/Modal/Modal';
-import GrupoForm from '../../organisms/GrupoForm/GrupoForm';
+import GrupoForm, { type AdminRef } from '../../organisms/GrupoForm/GrupoForm';
 import type { ActionItem } from '../../organisms/AdminTable/AdminTable';
 import type { ColeccionRef } from '../../../../types/contenidos';
 import styles from './GruposPage.module.css';
@@ -17,6 +17,7 @@ interface GrupoData {
   fechaFin?: string;
   active: boolean;
   colecciones?: ColeccionRef[];
+  admins?: AdminRef[];
   urlAgendaEntrevistas?: string | null;
 }
 
@@ -27,6 +28,7 @@ export default function GruposPage() {
   const navigate = useNavigate();
   const [grupos, setGrupos] = useState<GrupoData[]>([]);
   const [colecciones, setColecciones] = useState<ColeccionRef[]>([]);
+  const [admins, setAdmins] = useState<AdminRef[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -63,10 +65,22 @@ export default function GruposPage() {
     }
   }, [sessionToken]);
 
+  const fetchAdmins = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/admin/administradores`, { headers: { 'x-session-token': sessionToken ?? '' } });
+      if (!res.ok) return;
+      const data = await res.json();
+      setAdmins(data.administradores ?? []);
+    } catch {
+      // opcional en el form; ignorar error de carga
+    }
+  }, [sessionToken]);
+
   useEffect(() => {
     fetchGrupos();
     fetchColecciones();
-  }, [fetchGrupos, fetchColecciones]);
+    fetchAdmins();
+  }, [fetchGrupos, fetchColecciones, fetchAdmins]);
 
   function openCreate() {
     setEditGrupo(undefined);
@@ -83,7 +97,7 @@ export default function GruposPage() {
     setEditGrupo(undefined);
   }
 
-  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; colecciones?: string[]; urlAgendaEntrevistas?: string }) {
+  async function handleSave(data: { name: string; fechaInicio?: string; fechaFin?: string; colecciones?: string[]; admins?: string[]; urlAgendaEntrevistas?: string }) {
     setSaving(true);
     setError('');
     try {
@@ -143,6 +157,11 @@ export default function GruposPage() {
       header: 'Colecciones',
       cell: (info) => info.getValue() || '—',
     }),
+    columnHelper.accessor((row) => (row.admins ?? []).map((a) => a.name || a.email).join(', '), {
+      id: 'admins',
+      header: 'Administradores',
+      cell: (info) => info.getValue() || '—',
+    }),
     columnHelper.accessor('fechaInicio', {
       header: 'Fecha Inicio',
       cell: (info) => formatDate(info.getValue()),
@@ -197,6 +216,7 @@ export default function GruposPage() {
         <GrupoForm
           grupo={editGrupo}
           colecciones={colecciones}
+          admins={admins}
           onSave={handleSave}
           onCancel={closeModal}
           loading={saving}


### PR DESCRIPTION
## Descripción

Nueva entrada **Administradores** en el menú del admin y su vista: una tabla, en el mismo
patrón que Grupos y Alumnos (`AdminTable`), con los usuarios administradores **dados de
alta**. Por ahora es **solo lectura** — lista, no crea ni edita.

Columnas: **Nombre, Correo, Último acceso, Alta**. Sin matrícula ni grupos (son del
alumno); el último acceso ayuda a ver quién sigue entrando.

**No incluye alumnos.** El endpoint `GET /admin/administradores` filtra por
`userType: 'admin'` y solo activos (`queryActive`).

Sin iconos en la tabla ni en la vista, según lo pedido.

## Tipo de cambio

- [x] `feat` — nueva funcionalidad (SemVer: MINOR)

## ¿Cómo se probó?

- [x] **Query validada contra la BD de producción** (script temporal que replica el
  controlador): el universo activo es **3 admins y 20 alumnos**; el endpoint devuelve los
  **3 admins y 0 alumnos colados**.
- [x] **Endpoint montado y protegido**: `GET /api/admin/administradores` responde **401 sin
  token**, igual que `/api/admin/grupos` (pasa por `identifyUser` + `requireAdmin`).
- [x] `npx tsc --noEmit` sin errores en `packages/api` y `packages/web`; `yarn test` pasa (88).
- [ ] **Falta la comprobación en pantalla**: no puedo conducir el admin autenticado (la
  extensión de Chrome abre otro perfil y cae en `/login`). Checklist para el revisor:
  - [ ] "Administradores" aparece en el menú, entre Grupos y Contenidos, y abre la tabla.
  - [ ] La tabla lista solo los 3 admins; el buscador filtra por nombre/correo.
  - [ ] Ningún alumno aparece.

## Nota

Dejé la vista de **solo lectura** porque el pedido era "cargar una tabla que disponga
cuáles son los administradores". Crear/editar/dar de baja admins se puede añadir después
con el mismo `AdminTable` (acciones + form), como en Grupos — dígame si lo quieres ya.

## Checklist

- [x] La rama sigue Conventional Branch (`feature/…`)
- [x] Los commits siguen Conventional Commits
- [x] CHANGELOG.md actualizado